### PR TITLE
Added props and override spread attributes

### DIFF
--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/icon.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/icon.ts
@@ -34,30 +34,4 @@ export default class IconRenderer extends ReactComponentRenderer<
       color: props.color,
     };
   }
-
-  private renderOpeningElement(
-    factory: ts.NodeFactory,
-    props: StudioComponentProperties,
-    tagName: string
-  ): ts.JsxOpeningElement {
-    const propsArray: ts.JsxAttribute[] = [];
-    for (let propKey of Object.keys(props)) {
-      const currentProp = props[propKey];
-
-      if (currentProp.value) {
-        const attr = factory.createJsxAttribute(
-          factory.createIdentifier(propKey),
-          factory.createStringLiteral(currentProp.value)
-        );
-
-        propsArray.push(attr);
-      }
-    }
-
-    return factory.createJsxOpeningElement(
-      factory.createIdentifier(tagName),
-      undefined,
-      factory.createJsxAttributes(propsArray)
-    );
-  }
 }

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/image.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/image.ts
@@ -14,8 +14,9 @@ export default class ImageRenderer extends ReactComponentRenderer<
   AmplifyImageProps
 > {
   renderElement(): ts.JsxElement {
+    const tagName = "Image";
     const element = factory.createJsxElement(
-      this.renderOpeningElement(factory, this.component.props),
+      this.renderOpeningElement(factory, this.component.props, tagName),
       [],
       factory.createJsxClosingElement(factory.createIdentifier("Image"))
     );
@@ -31,16 +32,5 @@ export default class ImageRenderer extends ReactComponentRenderer<
       source: props.source,
       alt: props.alt,
     };
-  }
-
-  private renderOpeningElement(
-    factory: ts.NodeFactory,
-    props: StudioComponentProperties
-  ): ts.JsxOpeningElement {
-    return factory.createJsxOpeningElement(
-      factory.createIdentifier("Image"),
-      undefined,
-      factory.createJsxAttributes(this.convertPropsToJsxAttributes(props))
-    );
   }
 }


### PR DESCRIPTION
*Description of changes:*
Generated code needs to contain props and override props spread attributes.  
For example,
<Icon {...props} {...getOverrideProps(overrides, "Icon")}></Icon>)

Added code to add those and also moved common operations like "renderOpenElement" to the common base class so that those can be shared by children classes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
