### PR TITLE
Provided function to handle JSON without StudioApp schema

### DIFF
--- a/packages/studio-ui-codegen/lib/template-renderer.ts
+++ b/packages/studio-ui-codegen/lib/template-renderer.ts
@@ -1,7 +1,7 @@
 import { FrameworkOutputManager } from "./framework-output-manager";
 import { StudioTemplateRenderer } from "./studio-template-renderer";
 import { StudioTemplateRendererFactory } from "./template-renderer-factory";
-import { StudioApp } from "@amzn/amplify-ui-codegen-schema";
+import { StudioApp, FirstOrderStudioComponent } from "@amzn/amplify-ui-codegen-schema";
 
 var fs = require("fs");
 var path = require("path");
@@ -32,6 +32,14 @@ export class StudioTemplateRendererManager<
     if (!fs.existsSync(renderPath)) {
       fs.mkdirSync(renderPath);
     }
+  }
+
+  renderSchemaToTemplate(component: FirstOrderStudioComponent | undefined) {
+    if (!component) {
+      throw new Error("Please ensure you have passed in a valid component schema");
+    }
+    console.log("Rendering a component ", component.componentType);
+    this.renderer.buildRenderer(component).renderComponent();
   }
 
   renderSchemaToTemplates(jsonSchema: StudioApp | undefined) {

--- a/packages/test-generator/index.ts
+++ b/packages/test-generator/index.ts
@@ -20,4 +20,4 @@ const rendererManager = new StudioTemplateRendererManager(rendererFactory, '.');
 
 console.log(rendererManager);
 
-rendererManager.renderSchemaToTemplates(schema as any);
+rendererManager.renderSchemaToTemplate(schema as any);

--- a/packages/test-generator/lib/buttonGolden.json
+++ b/packages/test-generator/lib/buttonGolden.json
@@ -1,15 +1,6 @@
 {
-    "versionId": "ctX1rE1SroAk0eJUQeyxZggXq_SRzRgO",
-    "shareableId": "93a4b069-4b7c-4d38-b0bb-e8f672f876fd",
-    "studioConfig": {
-        "name": "My Amplify Studio Project",
-        "components": [
-            {
-                "componentId": "1234-5678-9010",
-                "componentType": "Icon",
-                "name": "CustomButton",
-                "props": {}
-            }
-        ]
-    }
+    "componentId": "1234-5678-9010",
+    "componentType": "Icon",
+    "name": "CustomButton",
+    "props": {}
 }


### PR DESCRIPTION

*Description of changes:*
Since StudioApp and StudioConfig types in Json schema may not be used, introduced render function to take in Component directly.  Updated the test as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
