### PR TITLE
Rename props to properties and add missing param

### DIFF
--- a/packages/amplify-ui-codegen-schema/lib/types/studio-component.ts
+++ b/packages/amplify-ui-codegen-schema/lib/types/studio-component.ts
@@ -24,7 +24,7 @@ export type StudioComponent = {
   /**
    * These are the customized properties
    */
-  props: StudioComponentProperties;
+  properties: StudioComponentProperties;
 };
 
 export type StudioComponentProperties = {

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/badge.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/badge.ts
@@ -16,7 +16,7 @@ export default class BadgeRenderer extends ReactComponentWithChildrenRenderer<
     renderChildren: (children: StudioComponent[]) => JsxChild[]
   ): ts.JsxElement {
     const element = factory.createJsxElement(
-      this.renderOpeningElement(factory, this.component.props),
+      this.renderOpeningElement(factory, this.component.properties),
       renderChildren(this.component.children),
       factory.createJsxClosingElement(factory.createIdentifier("Badge"))
     );

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/box.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/box.ts
@@ -18,7 +18,7 @@ export default class BoxRenderer extends ReactComponentWithChildrenRenderer<
     renderChildren: (children: StudioComponent[]) => JsxChild[]
   ): JsxElement {
     const element = factory.createJsxElement(
-      this.renderOpeningElement(factory, this.component.props),
+      this.renderOpeningElement(factory, this.component.properties),
       renderChildren(this.component.children),
       factory.createJsxClosingElement(factory.createIdentifier("Box"))
     );

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/icon.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/icon.ts
@@ -18,12 +18,12 @@ export default class IconRenderer extends ReactComponentRenderer<
     const tagName = "Icon";
 
     const element = factory.createJsxElement(
-      this.renderOpeningElement(factory, this.component.props, tagName),
+      this.renderOpeningElement(factory, this.component.properties, tagName),
       [],
       factory.createJsxClosingElement(factory.createIdentifier(tagName))
     );
 
-    this.importCollection.addImport("@amzn/amplify-ui", tagName);
+    this.importCollection.addImport("@amzn-amplify/amplify-ui", tagName);
     return element;
   }
 

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/image.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/image.ts
@@ -16,7 +16,7 @@ export default class ImageRenderer extends ReactComponentRenderer<
   renderElement(): ts.JsxElement {
     const tagName = "Image";
     const element = factory.createJsxElement(
-      this.renderOpeningElement(factory, this.component.props, tagName),
+      this.renderOpeningElement(factory, this.component.properties, tagName),
       [],
       factory.createJsxClosingElement(factory.createIdentifier("Image"))
     );

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/string.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/string.ts
@@ -4,7 +4,7 @@ import ts, { JsxFragment } from "typescript";
 export default function renderString(component: StudioComponent): JsxFragment {
   const factory = ts.factory;
 
-  const value = component.props["value"].value;
+  const value = component.properties["value"].value;
   console.log(value);
   const element = factory.createJsxFragment(
     factory.createJsxOpeningFragment(),

--- a/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
@@ -86,7 +86,12 @@ export abstract class ReactComponentRenderer<
       factory.createCallExpression(
         factory.createIdentifier("getOverrideProps"), 
         undefined, 
-        [factory.createIdentifier("overrides"), factory.createStringLiteral(tagName)]
+        [factory.createPropertyAccessExpression(
+          factory.createIdentifier("props"), 
+          factory.createIdentifier("overrides")
+          ), 
+          factory.createStringLiteral(tagName)
+        ]
       )
     );
     attributes.push(overrideAttr);

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -1,12 +1,7 @@
-import {
-  FirstOrderStudioComponent,
-  StudioComponent,
-} from "@amzn/amplify-ui-codegen-schema"
-import {
-  StudioTemplateRenderer,
-} from "@amzn/studio-ui-codegen";
+import { FirstOrderStudioComponent, StudioComponent } from '@amzn/amplify-ui-codegen-schema';
+import { StudioTemplateRenderer } from '@amzn/studio-ui-codegen';
 
-import { EOL } from "os";
+import { EOL } from 'os';
 import ts, {
   createPrinter,
   createSourceFile,
@@ -20,9 +15,9 @@ import ts, {
   ScriptTarget,
   SyntaxKind,
   transpileModule,
-} from "typescript";
-import { ImportCollection } from "./import-collection";
-import ReactOutputManager from "./react-output-manager";
+} from 'typescript';
+import { ImportCollection } from './import-collection';
+import ReactOutputManager from './react-output-manager';
 
 export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer<
   string,
@@ -45,18 +40,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     const { printer, file } = this.createPrinter();
 
-    console.log("JSX rendered");
+    console.log('JSX rendered');
 
-    const wrappedFunction = this.renderFunctionWrapper(
-      this.component.name,
-      jsx
-    );
+    const wrappedFunction = this.renderFunctionWrapper(this.component.name, jsx);
 
-    const result = printer.printNode(
-      EmitHint.Unspecified,
-      wrappedFunction,
-      file
-    );
+    const result = printer.printNode(EmitHint.Unspecified, wrappedFunction, file);
 
     let compiled = transpileModule(result, {
       compilerOptions: {
@@ -66,7 +54,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       },
     });
 
-    return compiled.outputText.replace("export default ", "");
+    return compiled.outputText.replace('export default ', '');
   }
 
   renderComponent() {
@@ -76,52 +64,34 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     const jsx = this.renderJsx(this.component);
 
-    console.log("JSX rendered");
+    console.log('JSX rendered');
 
-    const wrappedFunction = this.renderFunctionWrapper(
-      this.component.name,
-      jsx
-    );
+    const wrappedFunction = this.renderFunctionWrapper(this.component.name, jsx);
 
     const imports = this.importCollection.buildImportStatements();
 
-    let componentText = "/* eslint-disable */" + EOL;
+    let componentText = '/* eslint-disable */' + EOL;
 
     for (let importStatement of imports) {
-      const result = printer.printNode(
-        EmitHint.Unspecified,
-        importStatement,
-        file
-      );
+      const result = printer.printNode(EmitHint.Unspecified, importStatement, file);
       componentText += result + EOL;
     }
 
     componentText += EOL;
 
-    const result = printer.printNode(
-      EmitHint.Unspecified,
-      wrappedFunction,
-      file
-    );
+    const result = printer.printNode(EmitHint.Unspecified, wrappedFunction, file);
     componentText += result;
 
     console.log(componentText);
 
     return {
       componentText,
-      renderComponentToFilesystem:
-        this.renderComponentToFilesystem(componentText),
+      renderComponentToFilesystem: this.renderComponentToFilesystem(componentText),
     };
   }
 
   private createPrinter() {
-    const file = createSourceFile(
-      this.componentPath,
-      "",
-      ScriptTarget.ESNext,
-      false,
-      ScriptKind.TSX
-    );
+    const file = createSourceFile(this.componentPath, '', ScriptTarget.ESNext, false, ScriptKind.TSX);
 
     const printer = createPrinter({
       newLine: NewLineKind.LineFeed,
@@ -129,35 +99,31 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     return { printer, file };
   }
 
-  renderFunctionWrapper(
-    componentName: string,
-    jsx: JsxElement | JsxFragment
-  ): FunctionDeclaration {
+  renderFunctionWrapper(componentName: string, jsx: JsxElement | JsxFragment): FunctionDeclaration {
+    const componentPropType = componentName + 'Props';
+
     return factory.createFunctionDeclaration(
       undefined,
-      [
-        factory.createModifier(SyntaxKind.ExportKeyword),
-        factory.createModifier(SyntaxKind.DefaultKeyword),
-      ],
+      [factory.createModifier(SyntaxKind.ExportKeyword), factory.createModifier(SyntaxKind.DefaultKeyword)],
       undefined,
       factory.createIdentifier(componentName),
       undefined,
-      [],
-      factory.createTypeReferenceNode(
-        factory.createQualifiedName(
-          factory.createIdentifier("JSX"),
-          factory.createIdentifier("Element")
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          undefined,
+          'props',
+          undefined,
+          factory.createTypeReferenceNode(componentPropType, undefined),
+          undefined,
         ),
-        undefined
+      ],
+      factory.createTypeReferenceNode(
+        factory.createQualifiedName(factory.createIdentifier('JSX'), factory.createIdentifier('Element')),
+        undefined,
       ),
-      factory.createBlock(
-        [
-          factory.createReturnStatement(
-            factory.createParenthesizedExpression(jsx)
-          ),
-        ],
-        true
-      )
+      factory.createBlock([factory.createReturnStatement(factory.createParenthesizedExpression(jsx))], true),
     );
   }
 

--- a/packages/studio-ui-codegen/lib/common-component-renderer.ts
+++ b/packages/studio-ui-codegen/lib/common-component-renderer.ts
@@ -13,7 +13,7 @@ export abstract class CommonComponentRenderer<TPropIn, TPropOut> {
   abstract mapProps(props: TPropIn): TPropOut;
 
   constructor(protected component: StudioComponent) {
-    const flattenedProps = Object.entries(component.props).map((prop) => {
+    const flattenedProps = Object.entries(component.properties).map((prop) => {
       return [prop[0], prop[1]?.value];
     });
 

--- a/packages/test-generator/lib/buttonGolden.json
+++ b/packages/test-generator/lib/buttonGolden.json
@@ -2,5 +2,5 @@
     "componentId": "1234-5678-9010",
     "componentType": "Icon",
     "name": "CustomButton",
-    "props": {}
+    "properties": {}
 }


### PR DESCRIPTION
*Description of changes:*

- Code change to reflect the recent change of schema from 'props' to 'properties'
- Added missing 'props' param in generated codes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
