### PR TITLE
Tweak packages to include typings

### DIFF
--- a/packages/amplify-ui-codegen-schema/package.json
+++ b/packages/amplify-ui-codegen-schema/package.json
@@ -7,12 +7,8 @@
   "license": "ISC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "directories": {
-    "lib": "lib",
-    "test": "__tests__"
-  },
   "files": [
-    "lib"
+    "dist/**"
   ],
   "repository": {
     "type": "git",
@@ -27,7 +23,5 @@
     "rollup": "^2.47.0",
     "source-map-support": "^0.5.19",
     "typescript": "^4.2.4"
-  },
-  "dependencies": {
   }
 }

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/button.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/button.ts
@@ -1,4 +1,4 @@
-import { ButtonProps } from "@amzn/amplify-ui-react-types";
+import { ButtonProps } from "@aws-amplify/ui-react-types";
 
 import {
   StudioComponent,

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/text.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/text.ts
@@ -1,4 +1,4 @@
-import { TextProps } from '@amzn/amplify-ui-react-types';
+import { TextProps } from '@aws-amplify/ui-react-types';
 
 import { StudioComponent, StudioComponentProperties } from '@amzn/amplify-ui-codegen-schema';
 

--- a/packages/studio-ui-codegen-react/package.json
+++ b/packages/studio-ui-codegen-react/package.json
@@ -6,13 +6,9 @@
   "homepage": "https://code.amazon.com/packages/AmplifyUICodegen/packages/studio-ui-codegen-react",
   "license": "ISC",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "directories": {
-    "lib": "lib",
-    "test": "__tests__"
-  },
+  "types": "dist/index.d.ts",  
   "files": [
-    "lib"
+    "dist/**"
   ],
   "repository": {
     "type": "git",
@@ -29,7 +25,7 @@
     "source-map-support": "^0.5.19"
   },
   "dependencies": {
-    "@amzn/amplify-ui-react-types": "^0.0.1",
+    "@aws-amplify/ui-react-types": "^0.0.1",
     "@amzn/studio-ui-codegen": "^0.0.1",
     "@amzn/amplify-ui-codegen-schema": "^0.0.1",
     "@emotion/react": "^11",

--- a/packages/studio-ui-codegen/package.json
+++ b/packages/studio-ui-codegen/package.json
@@ -7,12 +7,8 @@
   "license": "ISC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "directories": {
-    "lib": "lib",
-    "test": "__tests__"
-  },
   "files": [
-    "lib"
+    "dist/**"
   ],
   "repository": {
     "type": "git",

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -10,6 +10,7 @@
     "lib": "lib",
     "test": "__tests__"
   },
+  "private": true,
   "files": [
     "lib"
   ],

--- a/packages/ui-react-types/package.json
+++ b/packages/ui-react-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amzn/amplify-ui-react-types",
+  "name": "@aws-amplify/ui-react-types",
   "version": "0.0.1",
   "description": "Amplify UI React types package mirror. Includes type definitions for React UI components",
   "main": "dist/index.js",
@@ -9,7 +9,7 @@
   },
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist/**"
   ],
   "devDependencies": {
     "rimraf": "^3.0.2",


### PR DESCRIPTION
This PR tweaks the package.json files so that they include the typings and compiled JS when packaged. It also reverts the package name change for the primitive types.