### PR TITLE
Added exposedAs property handling

### DIFF
--- a/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
@@ -56,6 +56,7 @@ export abstract class ReactComponentRenderer<
       const currentProp = props[propKey];
 
       if (currentProp.value) {
+        const propName = currentProp.exposedAs ?? propKey;
         const attr = factory.createJsxAttribute(
           factory.createIdentifier(propKey),
           factory.createJsxExpression(
@@ -63,7 +64,7 @@ export abstract class ReactComponentRenderer<
             factory.createBinaryExpression(
               factory.createPropertyAccessExpression(
                 factory.createIdentifier("props"),
-                propKey
+                propName
               ),
               SyntaxKind.QuestionQuestionToken,
               factory.createStringLiteral(currentProp.value, true),

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -65,6 +65,7 @@ export abstract class ReactComponentWithChildrenRenderer<
       const currentProp = props[propKey];
 
       if (currentProp.value) {
+        const propName = currentProp.exposedAs ?? propKey;
         const attr = factory.createJsxAttribute(
           factory.createIdentifier(propKey),
           factory.createJsxExpression(
@@ -72,7 +73,7 @@ export abstract class ReactComponentWithChildrenRenderer<
             factory.createBinaryExpression(
               factory.createPropertyAccessExpression(
                 factory.createIdentifier("props"),
-                propKey
+                propName
               ),
               SyntaxKind.QuestionQuestionToken,
               factory.createStringLiteral(currentProp.value, true),

--- a/packages/test-generator/lib/exposedAsTest.json
+++ b/packages/test-generator/lib/exposedAsTest.json
@@ -1,0 +1,21 @@
+{
+  "componentId": "1234-5678-9010",
+  "componentType": "Box",
+  "name": "BoxWithButton",
+  "properties": {},
+  "children": [
+    {
+      "componentId": "0987-6543-3211",
+      "componentType": "Button",
+      "properties": {
+        "color": {
+          "exposedAs": "buttonColor",
+          "value": "#ff0000"
+        },
+        "width": {
+          "value": "20px"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
*Description of changes:*
Added exposedAs handling so that a child's property can be specified from the top container.


```
"properties": {
   "color": {
     "exposedAs": "buttonColor",
     "value": "#ff0000"
    }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
