### PR TITLE
Handle custom component rendering

### DIFF
--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -14,6 +14,7 @@ import FlexRenderer from "./flex";
 import ImageRenderer from "./image";
 import TextRenderer from "./text";
 import renderString from "./string";
+import CustomComponentRenderer from "./customComponent";
 
 export class AmplifyRenderer extends ReactStudioTemplateRenderer {
   constructor(component: FirstOrderStudioComponent) {
@@ -69,17 +70,13 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
         ).renderElement();
     }
 
-    console.warn(`${component.componentType} is not mapped!`);
-    const element = factory.createJsxElement(
-      factory.createJsxOpeningElement(
-        factory.createIdentifier("div"),
-        undefined,
-        factory.createJsxAttributes([])
-      ),
-      [],
-      factory.createJsxClosingElement(factory.createIdentifier("div"))
-    );
+    console.warn(`${component.componentType} is not one of the primitives - assuming CustomComponent`);
 
-    return element;
+    return new CustomComponentRenderer(
+      component,
+      this.importCollection
+    ).renderElement(
+      (children) => children.map((child) => this.renderJsx(child))
+    );
   }
 }

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/customComponent.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/customComponent.ts
@@ -1,0 +1,31 @@
+import { ViewProps as CustomComponentProps } from '@amzn/amplify-ui-react-types';
+
+import { StudioComponent, StudioComponentProperties } from '@amzn/amplify-ui-codegen-schema';
+
+import { ReactComponentWithChildrenRenderer } from '../react-component-with-children-renderer';
+
+import { factory, JsxChild, JsxElement } from 'typescript';
+
+export default class CustomComponentRenderer extends ReactComponentWithChildrenRenderer<
+  CustomComponentProps,
+  CustomComponentProps
+> {
+  renderElement(renderChildren: (children: StudioComponent[]) => JsxChild[]): JsxElement {
+    const tagName = this.component.componentType;
+
+    const childrenJsx = this.component.children ? renderChildren(this.component.children) : [];
+    const element = factory.createJsxElement(
+      this.renderCustomCompOpeningElement(factory, this.component.properties, tagName),
+      childrenJsx,
+      factory.createJsxClosingElement(factory.createIdentifier(tagName)),
+    );
+
+    this.importCollection.addImport('@aws-amplify/ui-react', tagName);
+
+    return element;
+  }
+
+  mapProps(props: CustomComponentProps): CustomComponentProps {
+    return props;
+  }
+}

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -55,6 +55,35 @@ export abstract class ReactComponentWithChildrenRenderer<
     return propsArray;
   }
 
+  protected renderCustomCompOpeningElement(
+    factory: NodeFactory,
+    props: StudioComponentProperties,
+    tagName: string
+  ): JsxOpeningElement {
+    const propsArray: JsxAttribute[] = [];
+    for (let propKey of Object.keys(props)) {
+      const currentProp = props[propKey];
+
+      if (currentProp.value) {
+        const propName = currentProp.exposedAs ?? propKey;
+        const attr = factory.createJsxAttribute(
+          factory.createIdentifier(propKey),
+          factory.createStringLiteral(currentProp.value, true)
+        );
+
+        propsArray.push(attr);
+      }
+    }
+
+    this.addFindChildOverrideAttribute(factory, propsArray, tagName);
+
+    return factory.createJsxOpeningElement(
+      factory.createIdentifier(tagName),
+      undefined,
+      factory.createJsxAttributes(propsArray)
+    );
+  }
+
   protected renderOpeningElement(
     factory: NodeFactory,
     props: StudioComponentProperties,
@@ -115,5 +144,26 @@ export abstract class ReactComponentWithChildrenRenderer<
       )
     );
     attributes.push(overrideAttr);
+  }
+
+  private addFindChildOverrideAttribute(
+    factory: NodeFactory,
+    attributes: JsxAttributeLike[],
+    tagName: string
+  ) {
+
+    const findChildOverrideAttr = factory.createJsxSpreadAttribute(
+      factory.createCallExpression(
+        factory.createIdentifier("findChildOverrides"), 
+        undefined, 
+        [factory.createPropertyAccessExpression(
+          factory.createIdentifier("props"), 
+          factory.createIdentifier("overrides")
+          ), 
+          factory.createStringLiteral(tagName)
+        ]
+      )
+    );
+    attributes.push(findChildOverrideAttr);
   }
 }

--- a/packages/test-generator/index.ts
+++ b/packages/test-generator/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@amzn/studio-ui-codegen";
 import { AmplifyRenderer } from "@amzn/studio-ui-codegen-react";
 
-import * as schema from "./lib/boxTest.json";
+import * as schema from "./lib/customChild.json";
 
 Error.stackTraceLimit = Infinity;
 

--- a/packages/test-generator/lib/customChild.json
+++ b/packages/test-generator/lib/customChild.json
@@ -1,0 +1,20 @@
+{
+  "componentId": "1234-5678-9010",
+  "componentType": "Box",
+  "name": "BoxWithCustomButton",
+  "properties": {},
+  "children": [
+    {
+      "componentId": "0987-6543-3211",
+      "componentType": "CustomButton",
+      "properties": {
+        "color": {
+          "value": "#ff0000"
+        },
+        "width": {
+          "value": "20px"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
*Description of changes:*

Added code to handle rendering of Custom components (i.e. component that is not one of the primitives).

Now we can handle JSON input such as this:
```


{
  "componentId": "1234-5678-9010",
  "componentType": "Box",
  "name": "BoxWithButton",
  "properties": {},
  "children": [
  {
  "componentId": "0987-6543-3211",
  "componentType": "CustomButton",
  "properties": {
    "color": {  "value": "#ff0000" },
    "width": { "value": "20px" }
   }
 }]}


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
