### PR TITLE
Generate sample App code snippet

### DIFF
--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -21,7 +21,7 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
     super(component);
   }
 
-  renderJsx(component: StudioComponent): JsxElement | JsxFragment {
+  renderJsx(component: StudioComponent | FirstOrderStudioComponent): JsxElement | JsxFragment {
     switch (component.componentType) {
       case "Badge":
         return new BadgeRenderer(component, this.importCollection).renderElement(

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/sampleCodeRenderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/sampleCodeRenderer.ts
@@ -1,0 +1,84 @@
+import { BaseComponentProps } from '@amzn/amplify-ui-react-types';
+import { ReactComponentRenderer } from '../react-component-renderer';
+
+import { factory, JsxAttribute, JsxAttributeLike, JsxElement, JsxOpeningElement, NodeFactory } from 'typescript';
+import {
+  StudioComponent,
+  FirstOrderStudioComponent,
+  StudioComponentProperty,
+} from '../../../amplify-ui-codegen-schema/dist';
+
+export default class SampleCodeRenderer extends ReactComponentRenderer<BaseComponentProps, BaseComponentProps> {
+  renderElement(): JsxElement {
+    const tagName = (<FirstOrderStudioComponent>this.component).name;
+    var exposedProps = new Map<string, StudioComponentProperty>();
+    this.collectExposedProps(this.component, exposedProps);
+
+    const element = factory.createJsxElement(
+      this.renderSampleCodeOpeningElement(factory, exposedProps, tagName),
+      [],
+      factory.createJsxClosingElement(factory.createIdentifier(tagName)),
+    );
+
+    return element;
+  }
+
+  private collectExposedProps(component: StudioComponent, collected: Map<string, StudioComponentProperty>) {
+    const moreItems = Object.entries(component.properties).filter((m) => !(m[1].exposedAs == null));
+    moreItems?.forEach((value, index) => {
+      if (!collected.has(value[0])) {
+        collected.set(value[0], value[1]);
+      }
+    });
+
+    component.children?.forEach((child) => {
+      this.collectExposedProps(child, collected);
+    });
+  }
+
+  private renderSampleCodeOpeningElement(
+    factory: NodeFactory,
+    props: Map<string, StudioComponentProperty>,
+    tagName: string,
+  ): JsxOpeningElement {
+    const defaultValue = 'defaultValue';
+    const defaultValueExpr = factory.createJsxExpression(undefined, factory.createIdentifier(defaultValue));
+    const propsArray: JsxAttribute[] = [];
+    props?.forEach((value, key) => {
+      if (value.exposedAs) {
+        const displayExpr = value.value ? factory.createStringLiteral(value.value) : defaultValueExpr;
+        const attr = factory.createJsxAttribute(
+          factory.createIdentifier(key),
+          displayExpr,
+        );
+        propsArray.push(attr);
+      }
+    });
+
+    return factory.createJsxOpeningElement(
+      factory.createIdentifier(tagName),
+      undefined,
+      factory.createJsxAttributes(propsArray),
+    );
+  }
+
+  private addExposedPropAttributes(factory: NodeFactory, attributes: JsxAttributeLike[], tagName: string) {
+    const propsAttr = factory.createJsxSpreadAttribute(factory.createIdentifier('props'));
+    attributes.push(propsAttr);
+
+    const overrideAttr = factory.createJsxSpreadAttribute(
+      factory.createCallExpression(factory.createIdentifier('getOverrideProps'), undefined, [
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('props'),
+          factory.createIdentifier('overrides'),
+        ),
+        factory.createStringLiteral(tagName),
+      ]),
+    );
+    attributes.push(overrideAttr);
+  }
+
+  mapProps(props: BaseComponentProps): BaseComponentProps {
+    return props;
+  }
+}

--- a/packages/studio-ui-codegen-react/lib/import-collection.ts
+++ b/packages/studio-ui-codegen-react/lib/import-collection.ts
@@ -26,6 +26,27 @@ export class ImportCollection {
     }
   }
 
+  buildSampleSnippetImports(topComponentName: string): ImportDeclaration[] {
+    const importDeclarations: ImportDeclaration[] = [];
+    const sampleStudioPath = "./studio-ui";
+    const namedImports = factory.createNamedImports([
+      factory.createImportSpecifier(undefined, factory.createIdentifier(topComponentName))
+    ]);
+
+    importDeclarations.push(
+      createImportDeclaration(
+        undefined,
+        undefined,
+        factory.createImportClause(
+          undefined,
+          namedImports
+        ),
+        factory.createStringLiteral(sampleStudioPath)
+      )
+    );
+    return importDeclarations;
+  }
+
   buildImportStatements(): ImportDeclaration[] {
     const importDeclarations: ImportDeclaration[] = [];
 

--- a/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
@@ -1,5 +1,6 @@
 import {
   StudioComponent,
+  FirstOrderStudioComponent,
   StudioComponentProperties,
 } from "@amzn/amplify-ui-codegen-schema";
 import { ComponentRendererBase } from "@amzn/studio-ui-codegen";
@@ -12,7 +13,7 @@ export abstract class ReactComponentRenderer<
   TPropOut
 > extends ComponentRendererBase<TPropIn, TPropOut, JsxElement> {
   constructor(
-    component: StudioComponent,
+    component: StudioComponent | FirstOrderStudioComponent,
     protected importCollection: ImportCollection
   ) {
     super(component);

--- a/packages/test-generator/index.ts
+++ b/packages/test-generator/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@amzn/studio-ui-codegen";
 import { AmplifyRenderer } from "@amzn/studio-ui-codegen-react";
 
-import * as schema from "./lib/customChild.json";
+import * as schema from "./lib/sampleCodeSnippet.json";
 
 Error.stackTraceLimit = Infinity;
 
@@ -27,3 +27,10 @@ console.log("componentText ");
 console.log(compOnly.compText);
 console.log("componentImports ");
 console.log(compOnly.importsText);
+
+const compOnlyAppSample = rendererFactory.buildRenderer(schema as any).renderSampleCodeSnippet();
+console.log("Code Snippet Output");
+console.log("componentText ");
+console.log(compOnlyAppSample.compText);
+console.log("componentImports ");
+console.log(compOnlyAppSample.importsText);

--- a/packages/test-generator/lib/sampleCodeSnippet.json
+++ b/packages/test-generator/lib/sampleCodeSnippet.json
@@ -1,0 +1,28 @@
+{
+  "componentId": "1234-5678-9010",
+  "componentType": "Box",
+  "name": "BoxWithButton",
+  "properties": {
+    "padding-left": {
+      "exposedAs": "paddingLeft"
+    }
+  },
+  "children": [
+    {
+      "componentId": "0987-6543-3211",
+      "componentType": "CustomButton",
+      "properties": {
+        "color": {
+          "value": "#ff0000"
+        },
+        "width": {
+          "value": "20px"
+        },
+        "buttonText": {
+          "exposedAs": "buttonText",
+          "value": "Click Me"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION

*Description of changes:*

Added a function *renderSampleCodeSnippet* in code generator to generate sample App code.  It will return code text and import statement.
 
The generated code will have a format as follows:
```
export const App = () => {
    return (<BoxWithButton padding-left={defaultValue} buttonText="Click Me"></BoxWithButton>);
};
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
