### PR TITLE
fix: changes for matching golden file

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`amplify render tests basic component tests should generate a simple box component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { View } from \\"@aws-amplify/ui-react\\";
+import { Box } from \\"@aws-amplify/ui-react\\";
 
 export default function Test(props: TestProps): JSX.Element {
-    return (<View fontFamily={props.fontFamily ?? 'Times New Roman'} fontSize={props.fontSize ?? '20px'} {...props} {...getOverrideProps(props.overrides, \\"View\\")}></View>);
+    return (<Box fontFamily={props.fontFamily ?? 'Times New Roman'} fontSize={props.fontSize ?? '20px'} {...props} {...getOverrideProps(props.overrides, \\"Box\\")}></Box>);
 }"
 `;
 
@@ -33,39 +33,45 @@ export default function CustomText(props: CustomTextProps): JSX.Element {
 exports[`amplify render tests complex component tests should generate a button within a box component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { Button, View } from \\"@aws-amplify/ui-react\\";
+import { Button, Box } from \\"@aws-amplify/ui-react\\";
 
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
-    return (<View {...props} {...getOverrideProps(props.overrides, \\"View\\")}><Button color={props.color ?? '#ff0000'} width={props.width ?? '20px'} {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button></View>);
+    return (<Box {...props} {...getOverrideProps(props.overrides, \\"Box\\")}><Button color={props.color ?? '#ff0000'} width={props.width ?? '20px'} {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button></Box>);
 }"
 `;
 
 exports[`amplify render tests complex component tests should generate a component with custom child 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { CustomButton, View } from \\"@aws-amplify/ui-react\\";
+import { CustomButton, Box } from \\"@aws-amplify/ui-react\\";
 
 export default function BoxWithCustomButton(props: BoxWithCustomButtonProps): JSX.Element {
-    return (<View {...props} {...getOverrideProps(props.overrides, \\"View\\")}><CustomButton color='#ff0000' width='20px' {...findChildOverrides(props.overrides, \\"CustomButton\\")}></CustomButton></View>);
+    return (<Box {...props} {...getOverrideProps(props.overrides, \\"Box\\")}><CustomButton color='#ff0000' width='20px' {...findChildOverrides(props.overrides, \\"CustomButton\\")}></CustomButton></Box>);
 }"
 `;
 
 exports[`amplify render tests complex component tests should generate a component with exposeAs prop 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { Button, View } from \\"@aws-amplify/ui-react\\";
+import { Button, Box } from \\"@aws-amplify/ui-react\\";
 
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
-    return (<View {...props} {...getOverrideProps(props.overrides, \\"View\\")}><Button color={props.buttonColor ?? '#ff0000'} width={props.width ?? '20px'} {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button></View>);
+    return (<Box {...props} {...getOverrideProps(props.overrides, \\"Box\\")}><Button color={props.buttonColor ?? '#ff0000'} width={props.width ?? '20px'} {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button></Box>);
 }"
 `;
 
 exports[`amplify render tests sample code snippet tests should generate a sample code snippet for components 1`] = `
+"export const App = () => {
+    return (<BoxWithButton padding-left={defaultValue} buttonText=\\"Click Me\\"></BoxWithButton>);
+};"
+`;
+
+exports[`amplify render tests typed property tests should generate a property of number type 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { CustomButton, View } from \\"@aws-amplify/ui-react\\";
+import { Button } from \\"@aws-amplify/ui-react\\";
 
-export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
-    return (<View {...props} {...getOverrideProps(props.overrides, \\"View\\")}><CustomButton color='#ff0000' width='20px' buttonText='Click Me' {...findChildOverrides(props.overrides, \\"CustomButton\\")}></CustomButton></View>);
+export default function typedPropTest(props: typedPropTestProps): JSX.Element {
+    return (<Button width={props.width ?? 20} value={props.value ?? 'Header'} {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button>);
 }"
 `;

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -76,8 +76,15 @@ describe('amplify render tests', () => {
 
   describe('sample code snippet tests', () => {
     it('should generate a sample code snippet for components', () => {
-      const generatedCode = generateWithAmplifyRenderer('sampleCodeSnippet')
+      const generatedCode = generateWithAmplifyRenderer('sampleCodeSnippet', true)
       expect(generatedCode).toMatchSnapshot();
     });
   })
+
+  describe('typed property tests', () => {
+    it('should generate a property of number type', () => {
+      const generatedCode = generateWithAmplifyRenderer('typedProp')
+      expect(generatedCode).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/typedProp.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/typedProp.json
@@ -1,0 +1,13 @@
+{
+  "name": "typedPropTest",
+  "componentType": "Button",
+  "componentId": "1234-5678-9010",
+  "properties": {
+    "width": {
+      "value": 20
+    },
+    "value": {
+      "value": "Header"
+    }
+  }
+}

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/box.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/box.ts
@@ -13,7 +13,7 @@ export default class BoxRenderer extends ReactComponentWithChildrenRenderer<BoxP
   renderElement(
     renderChildren: (children: StudioComponent[]) => JsxChild[]
   ): JsxElement {
-    const tagName = "View";
+    const tagName = "Box";
 
     const childrenJsx = this.component.children ? renderChildren(this.component.children) : [];
     const element = factory.createJsxElement(

--- a/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
@@ -3,12 +3,8 @@ import { StudioComponentProperty, StudioComponentPropertyType } from '@amzn/ampl
 import { factory, Expression } from 'typescript';
 
 export function getComponentPropValueExpression(prop: StudioComponentProperty): Expression {
-  if (prop.type) {
-    switch (prop.type) {
-      case StudioComponentPropertyType.Number:
-        return factory.createNumericLiteral(prop.value);
-    }
+  if (prop.value && typeof prop.value === 'number') {
+    return factory.createNumericLiteral(prop.value);
   }
-
   return factory.createStringLiteral(prop.value.toString(), true);
 }

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -66,11 +66,12 @@ export abstract class ReactComponentWithChildrenRenderer<
     for (let propKey of Object.keys(props)) {
       const currentProp = props[propKey];
       if (currentProp.value !== undefined) {
-        const currentPropValue = getComponentPropValueExpression(currentProp);
+        //convert all types to string because of the jsx attribute regulation
+        const currentPropValue = factory.createStringLiteral(currentProp.value.toString(), true);;
         const propName = currentProp.exposedAs ?? propKey;
         const attr = factory.createJsxAttribute(
-          factory.createIdentifier(propKey),
-          factory.createJsxExpression(undefined, currentPropValue),
+          factory.createIdentifier(propName),
+          currentPropValue,
         );
 
         propsArray.push(attr);


### PR DESCRIPTION
*Issue #, if available:*
fix #29
fix #30 

*Description of changes:*

- Add type check for json schema since `prop.type` does not exist
- Remove the curly bracket for the  jsx attribute of string format
- Use the right tag name for `Box` component

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
