### PR TITLE
Generate prop type declaration from top level bindingProperties

### DIFF
--- a/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
@@ -6,8 +6,21 @@ export function getFixedComponentPropValueExpression(prop: FixedStudioComponentP
   return factory.createStringLiteral(prop.value.toString(), true);
 }
 
+export function getComponentPropName(componentName?: string): string {
+  if (componentName !== undefined) {
+    return componentName + 'Props';
+  }
+  return 'ComponentWithoutName' + 'Props';
+}
+
 export function isFixedPropertyWithValue(
   prop: FixedStudioComponentProperty | BoundStudioComponentProperty,
 ): prop is FixedStudioComponentProperty {
   return 'value' in prop;
+}
+
+export function isBoundProperty(
+  prop: FixedStudioComponentProperty | BoundStudioComponentProperty,
+): prop is BoundStudioComponentProperty {
+  return 'bindingProperties' in prop || 'defaultValue' in prop;
 }

--- a/packages/studio-ui-codegen/lib/renderer-helper.ts
+++ b/packages/studio-ui-codegen/lib/renderer-helper.ts
@@ -1,4 +1,70 @@
+import {
+  FixedStudioComponentProperty,
+  StudioComponent,
+  StudioComponentChild,
+  StudioComponentProperties,
+  WrappedComponentProperties,
+  StudioComponentDataPropertyBinding,
+  StudioComponentAuthPropertyBinding,
+  StudioComponentStoragePropertyBinding,
+  StudioComponentSimplePropertyBinding,
+  StudioComponentPropertyType,
+} from '@amzn/amplify-ui-codegen-schema';
 
 export const StudioRendererConstants = {
-    unknownName: "unknown_component_name"
+  unknownName: 'unknown_component_name',
+};
+
+export function isStudioComponentWithBinding(
+  component: StudioComponent | StudioComponentChild,
+): component is StudioComponent {
+  return 'bindingProperties' in component;
+}
+
+export function isDataPropertyBinding(
+  prop:
+    | StudioComponentDataPropertyBinding
+    | StudioComponentAuthPropertyBinding
+    | StudioComponentStoragePropertyBinding
+    | StudioComponentSimplePropertyBinding,
+): prop is StudioComponentDataPropertyBinding {
+  return 'type' in prop && prop.type === 'Data';
+}
+
+export function isAuthPropertyBinding(
+  prop:
+    | StudioComponentDataPropertyBinding
+    | StudioComponentAuthPropertyBinding
+    | StudioComponentStoragePropertyBinding
+    | StudioComponentSimplePropertyBinding,
+): prop is StudioComponentAuthPropertyBinding {
+  return 'type' in prop && prop.type === 'Authentication';
+}
+
+export function isStoragePropertyBinding(
+  prop:
+    | StudioComponentDataPropertyBinding
+    | StudioComponentAuthPropertyBinding
+    | StudioComponentStoragePropertyBinding
+    | StudioComponentSimplePropertyBinding,
+): prop is StudioComponentStoragePropertyBinding {
+  return 'type' in prop && prop.type === 'Storage';
+}
+
+export function isSimplePropertyBinding(
+  prop:
+    | StudioComponentDataPropertyBinding
+    | StudioComponentAuthPropertyBinding
+    | StudioComponentStoragePropertyBinding
+    | StudioComponentSimplePropertyBinding,
+): prop is StudioComponentSimplePropertyBinding {
+  return (
+    'type' in prop &&
+    [
+      StudioComponentPropertyType.Boolean.toString(),
+      StudioComponentPropertyType.Number.toString(),
+      StudioComponentPropertyType.String.toString(),
+      StudioComponentPropertyType.Date.toString(),
+    ].includes(prop.type)
+  );
 }

--- a/packages/test-generator/index.ts
+++ b/packages/test-generator/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@amzn/studio-ui-codegen";
 import { AmplifyRenderer } from "@amzn/studio-ui-codegen-react";
 
-import * as schema from "./lib/sampleCodeSnippet.json";
+import * as schema from "./lib/dataBindingWithDataStore.json";
 
 Error.stackTraceLimit = Infinity;
 

--- a/packages/test-generator/lib/dataBindingWithDataStore.json
+++ b/packages/test-generator/lib/dataBindingWithDataStore.json
@@ -1,0 +1,40 @@
+{
+  "componentId": "1234-5678-9010",
+  "componentType": "Button",
+  "name": "CustomButton",
+  "bindingProperties": {
+    "width": {
+      "type": "Number"
+    },
+    "buttonUser": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "User"
+      },
+      "defaultValue": {
+        "predicates": {
+          "eq": {
+            "ID": "1234"
+          }
+        }
+      }
+    },
+    "buttonColor": {
+      "type": "String"
+    }
+  },
+  "properties": {
+    "label": {
+      "bindingProperties": {
+        "property": "buttonUser",
+        "field": "username"
+      },
+      "defaultValue": "hspain@gmail.com"
+    },
+    "labelWidth": {
+      "bindingProperties": {
+        "property": "width"
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:*

Render Component Prop type declarations for Simple and Data bidingProperty types on top component. 

This is an example of prop declaration generated:

```
export type CustomButtonProps = {
  buttonUser?: User;
  width: Number;
} & CommonProps;

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
