### PR TITLE
Generate child component Jsx attributes with bindingProperties

### DIFF
--- a/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
@@ -1,8 +1,8 @@
 import { FixedStudioComponentProperty, BoundStudioComponentProperty } from '@amzn/amplify-ui-codegen-schema';
 
-import { factory, Expression } from 'typescript';
+import { factory, JsxAttribute, JsxExpression, StringLiteral, SyntaxKind } from 'typescript';
 
-export function getFixedComponentPropValueExpression(prop: FixedStudioComponentProperty): Expression {
+export function getFixedComponentPropValueExpression(prop: FixedStudioComponentProperty): StringLiteral {
   return factory.createStringLiteral(prop.value.toString(), true);
 }
 
@@ -23,4 +23,77 @@ export function isBoundProperty(
   prop: FixedStudioComponentProperty | BoundStudioComponentProperty,
 ): prop is BoundStudioComponentProperty {
   return 'bindingProperties' in prop || 'defaultValue' in prop;
+}
+
+export function buildBindingAttr(prop: BoundStudioComponentProperty, propName: string): JsxAttribute {
+  const expr =
+    prop.bindingProperties.field === undefined
+      ? factory.createIdentifier(prop.bindingProperties.property)
+      : factory.createPropertyAccessExpression(
+          factory.createIdentifier(prop.bindingProperties.property),
+          prop.bindingProperties.field,
+        );
+
+  const attr = factory.createJsxAttribute(
+    factory.createIdentifier(propName),
+    factory.createJsxExpression(undefined, expr),
+  );
+  return attr;
+}
+
+export function buildBindingAttrWithDefault(
+  prop: BoundStudioComponentProperty,
+  propName: string,
+  defaultValue: string,
+): JsxAttribute {
+  const rightExpr = factory.createStringLiteral(defaultValue);
+  const leftExpr =
+    prop.bindingProperties.field === undefined
+      ? factory.createIdentifier(prop.bindingProperties.property)
+      : factory.createPropertyAccessExpression(
+          factory.createIdentifier(prop.bindingProperties.property),
+          prop.bindingProperties.field,
+        );
+
+  const binaryExpr = factory.createBinaryExpression(leftExpr, factory.createToken(SyntaxKind.BarBarToken), rightExpr);
+  const attr = factory.createJsxAttribute(
+    factory.createIdentifier(propName),
+    factory.createJsxExpression(undefined, binaryExpr),
+  );
+  return attr;
+}
+
+export function buildFixedAttr(prop: FixedStudioComponentProperty, propName: string): JsxAttribute {
+  const currentPropValue = prop.value;
+  var propValueExpr: StringLiteral | JsxExpression = factory.createStringLiteral(currentPropValue.toString());
+  switch (typeof currentPropValue) {
+    case 'number':
+      propValueExpr = factory.createJsxExpression(undefined, factory.createNumericLiteral(currentPropValue, undefined));
+      break;
+    case 'boolean':
+      propValueExpr = factory.createJsxExpression(
+        undefined,
+        currentPropValue ? factory.createTrue() : factory.createFalse(),
+      );
+      break;
+    default:
+      break;
+  }
+  return factory.createJsxAttribute(factory.createIdentifier(propName), propValueExpr);
+}
+
+export function buildOpeningElementAttributes(
+  prop: FixedStudioComponentProperty | BoundStudioComponentProperty,
+  propName: string,
+): JsxAttribute {
+  if (isFixedPropertyWithValue(prop)) {
+    return buildFixedAttr(prop, propName);
+  } else if (isBoundProperty(prop)) {
+    const attr =
+      prop.defaultValue === undefined
+        ? buildBindingAttr(prop, propName)
+        : buildBindingAttrWithDefault(prop, propName, prop.defaultValue);
+    return attr;
+  }
+  return factory.createJsxAttribute(factory.createIdentifier(propName), undefined);
 }

--- a/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
@@ -2,43 +2,27 @@ import {
   StudioComponent,
   StudioComponentChild,
   StudioComponentProperties,
-  FixedStudioComponentProperty,
-} from "@amzn/amplify-ui-codegen-schema";
-import { ComponentRendererBase } from "@amzn/studio-ui-codegen";
-import { factory, JsxAttribute, JsxAttributeLike, JsxElement, JsxOpeningElement, NodeFactory, SyntaxKind, Expression } from "typescript";
+} from '@amzn/amplify-ui-codegen-schema';
+import { ComponentRendererBase } from '@amzn/studio-ui-codegen';
+import { JsxAttribute, JsxAttributeLike, JsxElement, JsxOpeningElement, NodeFactory } from 'typescript';
 
-import { ImportCollection } from "./import-collection";
-import { getFixedComponentPropValueExpression, isFixedPropertyWithValue } from "./react-component-render-helper";
+import { ImportCollection } from './import-collection';
+import { buildOpeningElementAttributes } from './react-component-render-helper';
 
-export abstract class ReactComponentRenderer<
-  TPropIn
-> extends ComponentRendererBase<TPropIn, JsxElement> {
-  constructor(
-    component: StudioComponent | StudioComponentChild,
-    protected importCollection: ImportCollection
-  ) {
+export abstract class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<TPropIn, JsxElement> {
+  constructor(component: StudioComponent | StudioComponentChild, protected importCollection: ImportCollection) {
     super(component);
   }
 
   protected renderOpeningElement(
     factory: NodeFactory,
     props: StudioComponentProperties,
-    tagName: string
+    tagName: string,
   ): JsxOpeningElement {
     const propsArray: JsxAttribute[] = [];
     for (let propKey of Object.keys(props)) {
       const currentProp = props[propKey];
-      if (isFixedPropertyWithValue(currentProp)) {
-        const propName = propKey;
-        const propValue = getFixedComponentPropValueExpression(currentProp);
-        const attr = factory.createJsxAttribute(
-          factory.createIdentifier(propKey),
-          factory.createJsxExpression(undefined, propValue)
-        );
-        propsArray.push(attr);
-      }
-      //TODO:  handle BoundStudioComponentProperty
-      
+      propsArray.push(buildOpeningElementAttributes(currentProp, propKey));
     }
 
     this.addPropsSpreadAttributes(factory, propsArray, tagName);
@@ -46,29 +30,22 @@ export abstract class ReactComponentRenderer<
     return factory.createJsxOpeningElement(
       factory.createIdentifier(tagName),
       undefined,
-      factory.createJsxAttributes(propsArray)
+      factory.createJsxAttributes(propsArray),
     );
   }
 
-  private addPropsSpreadAttributes(
-    factory: NodeFactory,
-    attributes: JsxAttributeLike[],
-    tagName: string
-  ) {
-    const propsAttr = factory.createJsxSpreadAttribute(factory.createIdentifier("props"));
+  private addPropsSpreadAttributes(factory: NodeFactory, attributes: JsxAttributeLike[], tagName: string) {
+    const propsAttr = factory.createJsxSpreadAttribute(factory.createIdentifier('props'));
     attributes.push(propsAttr);
 
     const overrideAttr = factory.createJsxSpreadAttribute(
-      factory.createCallExpression(
-        factory.createIdentifier("getOverrideProps"), 
-        undefined, 
-        [factory.createPropertyAccessExpression(
-          factory.createIdentifier("props"), 
-          factory.createIdentifier("overrides")
-          ), 
-          factory.createStringLiteral(tagName)
-        ]
-      )
+      factory.createCallExpression(factory.createIdentifier('getOverrideProps'), undefined, [
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('props'),
+          factory.createIdentifier('overrides'),
+        ),
+        factory.createStringLiteral(tagName),
+      ]),
     );
     attributes.push(overrideAttr);
   }

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -1,58 +1,37 @@
-import {
-  ComponentWithChildrenRendererBase,
-} from "@amzn/studio-ui-codegen";
-import {
-  FixedStudioComponentProperty,
-  StudioComponent,
-  StudioComponentChild,
-  StudioComponentProperties,
-} from "@amzn/amplify-ui-codegen-schema";
+import { ComponentWithChildrenRendererBase } from '@amzn/studio-ui-codegen';
+import { StudioComponent, StudioComponentChild, StudioComponentProperties } from '@amzn/amplify-ui-codegen-schema';
 
-import { factory, JsxAttribute, JsxAttributeLike, JsxElement, JsxChild, JsxOpeningElement, NodeFactory, SyntaxKind, Expression } from "typescript";
-import { ImportCollection } from "./import-collection";
-import { getFixedComponentPropValueExpression, isFixedPropertyWithValue } from "./react-component-render-helper";
+import {
+  JsxAttribute,
+  JsxAttributeLike,
+  JsxElement,
+  JsxChild,
+  JsxOpeningElement,
+  NodeFactory,
+  SyntaxKind,
+  Expression,
+} from 'typescript';
+import { ImportCollection } from './import-collection';
+import { buildOpeningElementAttributes } from './react-component-render-helper';
 
-export abstract class ReactComponentWithChildrenRenderer<
-  TPropIn
-> extends ComponentWithChildrenRendererBase<
+export abstract class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithChildrenRendererBase<
   TPropIn,
   JsxElement,
   JsxChild
 > {
-  constructor(
-    component: StudioComponent | StudioComponentChild,
-    protected importCollection: ImportCollection
-  ) {
+  constructor(component: StudioComponent | StudioComponentChild, protected importCollection: ImportCollection) {
     super(component);
   }
 
   protected renderCustomCompOpeningElement(
     factory: NodeFactory,
     props: StudioComponentProperties,
-    tagName: string
+    tagName: string,
   ): JsxOpeningElement {
     const propsArray: JsxAttribute[] = [];
     for (let propKey of Object.keys(props)) {
       const currentProp = props[propKey];
-      if (isFixedPropertyWithValue(currentProp)) {
-        const currentPropValue = currentProp.value;
-        const propName = propKey;
-        if (typeof currentPropValue == "string") {
-          const attr = factory.createJsxAttribute(
-            factory.createIdentifier(propKey),
-            factory.createStringLiteral(currentPropValue),
-          );
-          propsArray.push(attr);
-        } else {
-          const propValueExpr = getFixedComponentPropValueExpression(currentProp);
-          const attr = factory.createJsxAttribute(
-            factory.createIdentifier(propKey),
-            factory.createJsxExpression(undefined, propValueExpr)
-          );
-          propsArray.push(attr);
-        }
-        
-      }
+      propsArray.push(buildOpeningElementAttributes(currentProp, propKey));
     }
 
     this.addFindChildOverrideAttribute(factory, propsArray, tagName);
@@ -60,30 +39,19 @@ export abstract class ReactComponentWithChildrenRenderer<
     return factory.createJsxOpeningElement(
       factory.createIdentifier(tagName),
       undefined,
-      factory.createJsxAttributes(propsArray)
+      factory.createJsxAttributes(propsArray),
     );
   }
 
   protected renderOpeningElement(
     factory: NodeFactory,
     props: StudioComponentProperties,
-    tagName: string
+    tagName: string,
   ): JsxOpeningElement {
     const propsArray: JsxAttribute[] = [];
     for (let propKey of Object.keys(props)) {
       const currentProp = props[propKey];
-
-      if (isFixedPropertyWithValue(currentProp)) {
-        const propName = propKey;
-        const propValue = getFixedComponentPropValueExpression(currentProp);
-        const attr = factory.createJsxAttribute(
-          factory.createIdentifier(propKey),
-          factory.createJsxExpression(undefined, propValue)
-        );
-        propsArray.push(attr);
-      }
-
-      //TODO:  handle BoundStudioComponentProperty
+      propsArray.push(buildOpeningElementAttributes(currentProp, propKey));
     }
 
     this.addPropsSpreadAttributes(factory, propsArray, tagName);
@@ -91,50 +59,35 @@ export abstract class ReactComponentWithChildrenRenderer<
     return factory.createJsxOpeningElement(
       factory.createIdentifier(tagName),
       undefined,
-      factory.createJsxAttributes(propsArray)
+      factory.createJsxAttributes(propsArray),
     );
   }
 
-  private addPropsSpreadAttributes(
-    factory: NodeFactory,
-    attributes: JsxAttributeLike[],
-    tagName: string
-  ) {
-    const propsAttr = factory.createJsxSpreadAttribute(factory.createIdentifier("props"));
+  private addPropsSpreadAttributes(factory: NodeFactory, attributes: JsxAttributeLike[], tagName: string) {
+    const propsAttr = factory.createJsxSpreadAttribute(factory.createIdentifier('props'));
     attributes.push(propsAttr);
 
     const overrideAttr = factory.createJsxSpreadAttribute(
-      factory.createCallExpression(
-        factory.createIdentifier("getOverrideProps"), 
-        undefined, 
-        [factory.createPropertyAccessExpression(
-          factory.createIdentifier("props"), 
-          factory.createIdentifier("overrides")
-          ), 
-          factory.createStringLiteral(tagName)
-        ]
-      )
+      factory.createCallExpression(factory.createIdentifier('getOverrideProps'), undefined, [
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('props'),
+          factory.createIdentifier('overrides'),
+        ),
+        factory.createStringLiteral(tagName),
+      ]),
     );
     attributes.push(overrideAttr);
   }
 
-  private addFindChildOverrideAttribute(
-    factory: NodeFactory,
-    attributes: JsxAttributeLike[],
-    tagName: string
-  ) {
-
+  private addFindChildOverrideAttribute(factory: NodeFactory, attributes: JsxAttributeLike[], tagName: string) {
     const findChildOverrideAttr = factory.createJsxSpreadAttribute(
-      factory.createCallExpression(
-        factory.createIdentifier("findChildOverrides"), 
-        undefined, 
-        [factory.createPropertyAccessExpression(
-          factory.createIdentifier("props"), 
-          factory.createIdentifier("overrides")
-          ), 
-          factory.createStringLiteral(tagName)
-        ]
-      )
+      factory.createCallExpression(factory.createIdentifier('findChildOverrides'), undefined, [
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('props'),
+          factory.createIdentifier('overrides'),
+        ),
+        factory.createStringLiteral(tagName),
+      ]),
     );
     attributes.push(findChildOverrideAttr);
   }
@@ -144,23 +97,20 @@ export abstract class ReactComponentWithChildrenRenderer<
     attributes: JsxAttributeLike[],
     propKey: string,
     propName: string,
-    propValue: Expression  
+    propValue: Expression,
   ) {
     const attr = factory.createJsxAttribute(
       factory.createIdentifier(propKey),
       factory.createJsxExpression(
         undefined,
         factory.createBinaryExpression(
-          factory.createPropertyAccessExpression(
-            factory.createIdentifier("props"),
-            propName
-          ),
+          factory.createPropertyAccessExpression(factory.createIdentifier('props'), propName),
           SyntaxKind.QuestionQuestionToken,
           propValue,
-        )
-      )
+        ),
+      ),
     );
 
-    attributes.push(attr);  
+    attributes.push(attr);
   }
 }

--- a/packages/studio-ui-codegen/lib/common-component-renderer.ts
+++ b/packages/studio-ui-codegen/lib/common-component-renderer.ts
@@ -11,7 +11,6 @@ import {
  * Mostly contains helper functions for mapping the Studio schema to actual props.
  */
 export abstract class CommonComponentRenderer<TPropIn> {
-  //inputProps: TPropIn;
   protected inputProps: WrappedComponentProperties<TPropIn>;
 
   constructor(protected component: StudioComponent | StudioComponentChild) {

--- a/packages/studio-ui-codegen/lib/renderer-helper.ts
+++ b/packages/studio-ui-codegen/lib/renderer-helper.ts
@@ -1,9 +1,6 @@
 import {
-  FixedStudioComponentProperty,
   StudioComponent,
   StudioComponentChild,
-  StudioComponentProperties,
-  WrappedComponentProperties,
   StudioComponentDataPropertyBinding,
   StudioComponentAuthPropertyBinding,
   StudioComponentStoragePropertyBinding,

--- a/packages/test-generator/lib/dataBindingWithDataStore.json
+++ b/packages/test-generator/lib/dataBindingWithDataStore.json
@@ -24,6 +24,12 @@
     }
   },
   "properties": {
+    "color": {
+      "value": "#ff0000"
+    },
+    "width": {
+      "value": 20
+    },
     "label": {
       "bindingProperties": {
         "property": "buttonUser",
@@ -34,7 +40,8 @@
     "labelWidth": {
       "bindingProperties": {
         "property": "width"
-      }
+      },
+      "defaultValue": "50px"
     }
   }
 }


### PR DESCRIPTION

*Description of changes:*
Data binding related Jsx attributes for components and child components are rendered using the information contained in bindingProperties.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
