### PR TITLE
fix: react render config

### DIFF
--- a/packages/studio-ui-codegen-react/index.ts
+++ b/packages/studio-ui-codegen-react/index.ts
@@ -1,2 +1,1 @@
-export * from './lib/amplify-ui-renderers/amplify-renderer';
 export * from './lib/index';

--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -3,109 +3,313 @@
 exports[`amplify render tests basic component tests should generate a simple box component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { EscapeHatchProps, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  EscapeHatchProps,
+  View,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type TestProps = {} & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
 export default function Test(props: TestProps): JSX.Element {
-    return (<View fontFamily=\\"Times New Roman\\" fontSize=\\"20px\\" {...props} {...getOverrideProps(props.overrides, \\"View\\")}></View>);
-}"
+  return (
+    <View
+      fontFamily=\\"Times New Roman\\"
+      fontSize=\\"20px\\"
+      {...props}
+      {...getOverrideProps(props.overrides, \\"View\\")}
+    ></View>
+  );
+}
+"
 `;
 
 exports[`amplify render tests basic component tests should generate a simple button component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { Button, EscapeHatchProps, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type CustomButtonProps = {} & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
 export default function CustomButton(props: CustomButtonProps): JSX.Element {
-    return (<Button color=\\"#ff0000\\" width=\\"20\\" {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button>);
-}"
+  return (
+    <Button
+      color=\\"#ff0000\\"
+      width=\\"20\\"
+      {...props}
+      {...getOverrideProps(props.overrides, \\"Button\\")}
+    ></Button>
+  );
+}
+"
 `;
 
 exports[`amplify render tests basic component tests should generate a simple text component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { EscapeHatchProps, Text, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  EscapeHatchProps,
+  Text,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type CustomTextProps = {} & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
 export default function CustomText(props: CustomTextProps): JSX.Element {
-    return (<Text color=\\"#ff0000\\" width=\\"20px\\" value=\\"Text Value\\" {...props} {...getOverrideProps(props.overrides, \\"Text\\")}>Text Value</Text>);
-}"
+  return (
+    <Text
+      color=\\"#ff0000\\"
+      width=\\"20px\\"
+      value=\\"Text Value\\"
+      {...props}
+      {...getOverrideProps(props.overrides, \\"Text\\")}
+    >
+      Text Value
+    </Text>
+  );
+}
+"
 `;
 
 exports[`amplify render tests complex component tests should generate a button within a box component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { Button, EscapeHatchProps, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  EscapeHatchProps,
+  View,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type BoxWithButtonProps = {} & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
-    return (<View {...props} {...getOverrideProps(props.overrides, \\"View\\")}><Button color=\\"#ff0000\\" width=\\"20px\\" {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button></View>);
-}"
+  return (
+    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+      <Button
+        color=\\"#ff0000\\"
+        width=\\"20px\\"
+        {...props}
+        {...getOverrideProps(props.overrides, \\"Button\\")}
+      ></Button>
+    </View>
+  );
+}
+"
 `;
 
 exports[`amplify render tests complex component tests should generate a component with custom child 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { CustomButton, EscapeHatchProps, View, findChildOverrides, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  CustomButton,
+  EscapeHatchProps,
+  View,
+  findChildOverrides,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type BoxWithCustomButtonProps = {} & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
-export default function BoxWithCustomButton(props: BoxWithCustomButtonProps): JSX.Element {
-    return (<View {...props} {...getOverrideProps(props.overrides, \\"View\\")}><CustomButton color=\\"#ff0000\\" width=\\"20px\\" {...findChildOverrides(props.overrides, \\"CustomButton\\")}></CustomButton></View>);
-}"
+export default function BoxWithCustomButton(
+  props: BoxWithCustomButtonProps
+): JSX.Element {
+  return (
+    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+      <CustomButton
+        color=\\"#ff0000\\"
+        width=\\"20px\\"
+        {...findChildOverrides(props.overrides, \\"CustomButton\\")}
+      ></CustomButton>
+    </View>
+  );
+}
+"
 `;
 
 exports[`amplify render tests complex component tests should generate a component with exposeAs prop 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { Button, EscapeHatchProps, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  EscapeHatchProps,
+  View,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type BoxWithButtonProps = {} & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
-    return (<View {...props} {...getOverrideProps(props.overrides, \\"View\\")}><Button color=\\"#ff0000\\" width=\\"20px\\" {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button></View>);
-}"
+  return (
+    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+      <Button
+        color=\\"#ff0000\\"
+        width=\\"20px\\"
+        {...props}
+        {...getOverrideProps(props.overrides, \\"Button\\")}
+      ></Button>
+    </View>
+  );
+}
+"
 `;
 
 exports[`amplify render tests component with data binding should add model imports 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
 import { User } from \\"../models\\";
-import { Button, EscapeHatchProps, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type ComponentWithDataBindingProps = {
-    width: Number;
-    isDisabled: Boolean;
-    buttonUser?: User;
-    buttonColor: String;
+  width: Number,
+  isDisabled: Boolean,
+  buttonUser?: User,
+  buttonColor: String,
 } & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
-export default function ComponentWithDataBinding(props: ComponentWithDataBindingProps): JSX.Element {
-    return (<Button label={buttonUser.username || \\"hspain@gmail.com\\"} labelWidth={width} disabled={isDisabled} {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button>);
-}"
+export default function ComponentWithDataBinding(
+  props: ComponentWithDataBindingProps
+): JSX.Element {
+  return (
+    <Button
+      label={buttonUser.username || \\"hspain@gmail.com\\"}
+      labelWidth={width}
+      disabled={isDisabled}
+      {...props}
+      {...getOverrideProps(props.overrides, \\"Button\\")}
+    ></Button>
+  );
+}
+"
+`;
+
+exports[`amplify render tests custom render config should render ES5 1`] = `
+"var __assign =
+  (this && this.__assign) ||
+  function () {
+    __assign =
+      Object.assign ||
+      function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s)
+            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+      };
+    return __assign.apply(this, arguments);
+  };
+/* eslint-disable */
+import React from \\"react\\";
+import { Button, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+export default function BoxWithButton(props) {
+  return React.createElement(
+    View,
+    __assign({}, props, getOverrideProps(props.overrides, \\"View\\")),
+    React.createElement(
+      Button,
+      __assign(
+        { color: \\"#ff0000\\", width: \\"20px\\" },
+        props,
+        getOverrideProps(props.overrides, \\"Button\\")
+      )
+    )
+  );
+}
+"
+`;
+
+exports[`amplify render tests custom render config should render JSX 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import { Button, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+export default function BoxWithButton(props) {
+  return (
+    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+      <Button
+        color=\\"#ff0000\\"
+        width=\\"20px\\"
+        {...props}
+        {...getOverrideProps(props.overrides, \\"Button\\")}
+      ></Button>
+    </View>
+  );
+}
+"
+`;
+
+exports[`amplify render tests custom render config should render common JS 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+/* eslint-disable */
+const react_1 = require(\\"react\\");
+const ui_react_1 = require(\\"@aws-amplify/ui-react\\");
+function BoxWithButton(props) {
+  return react_1.default.createElement(
+    ui_react_1.View,
+    Object.assign(
+      {},
+      props,
+      ui_react_1.getOverrideProps(props.overrides, \\"View\\")
+    ),
+    react_1.default.createElement(
+      ui_react_1.Button,
+      Object.assign(
+        { color: \\"#ff0000\\", width: \\"20px\\" },
+        props,
+        ui_react_1.getOverrideProps(props.overrides, \\"Button\\")
+      )
+    )
+  );
+}
+exports.default = BoxWithButton;
+"
 `;
 
 exports[`amplify render tests sample code snippet tests should generate a sample code snippet for components 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { CustomButton, EscapeHatchProps, View, findChildOverrides, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import {
+  CustomButton,
+  EscapeHatchProps,
+  View,
+  findChildOverrides,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
 
 export type BoxWithButtonProps = {} & {
-    overrides?: EscapeHatchProps | undefined | null;
+  overrides?: EscapeHatchProps | undefined | null,
 };
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
-    return (<View padding-left {...props} {...getOverrideProps(props.overrides, \\"View\\")}><CustomButton color=\\"#ff0000\\" width=\\"20px\\" buttonText=\\"Click Me\\" {...findChildOverrides(props.overrides, \\"CustomButton\\")}></CustomButton></View>);
-}"
+  return (
+    <View
+      padding-left
+      {...props}
+      {...getOverrideProps(props.overrides, \\"View\\")}
+    >
+      <CustomButton
+        color=\\"#ff0000\\"
+        width=\\"20px\\"
+        buttonText=\\"Click Me\\"
+        {...findChildOverrides(props.overrides, \\"CustomButton\\")}
+      ></CustomButton>
+    </View>
+  );
+}
+"
 `;

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -1,8 +1,9 @@
 import { StudioComponent } from '@amzn/amplify-ui-codegen-schema';
 import { StudioTemplateRendererFactory } from '@amzn/studio-ui-codegen';
-import { AmplifyRenderer } from '../amplify-ui-renderers/amplify-renderer';
+import { ModuleKind, ScriptTarget, ScriptKind, ReactRenderConfig } from '../';
 import fs from 'fs';
 import { join } from 'path';
+import { AmplifyRenderer } from '../amplify-ui-renderers/amplify-renderer';
 
 function loadSchemaFromJSONFile(jsonSchemaFile: string): StudioComponent {
   return JSON.parse(
@@ -10,10 +11,14 @@ function loadSchemaFromJSONFile(jsonSchemaFile: string): StudioComponent {
   ) as StudioComponent;
 }
 
-function generateWithAmplifyRenderer(jsonSchemaFile: string, isSampleCodeSnippet: boolean = false): string {
+function generateWithAmplifyRenderer(
+  jsonSchemaFile: string,
+  renderConfig: ReactRenderConfig = {},
+  isSampleCodeSnippet: boolean = false,
+): string {
   const schema = loadSchemaFromJSONFile(jsonSchemaFile);
   const rendererFactory = new StudioTemplateRendererFactory(
-    (component: StudioComponent) => new AmplifyRenderer(component),
+    (component: StudioComponent) => new AmplifyRenderer(component, renderConfig),
   );
   if (isSampleCodeSnippet) {
     return rendererFactory.buildRenderer(schema).renderSampleCodeSnippet().compText;
@@ -79,6 +84,24 @@ describe('amplify render tests', () => {
     it('should add model imports', () => {
       const generatedCode = generateWithAmplifyRenderer('componentWithDataBinding');
       expect(generatedCode).toMatchSnapshot();
+    });
+  });
+
+  describe('custom render config', () => {
+    it('should render ES5', () => {
+      expect(
+        generateWithAmplifyRenderer('boxGolden', { target: ScriptTarget.ES5, script: ScriptKind.JS }),
+      ).toMatchSnapshot();
+    });
+
+    it('should render JSX', () => {
+      expect(generateWithAmplifyRenderer('boxGolden', { script: ScriptKind.JSX })).toMatchSnapshot();
+    });
+
+    it('should render common JS', () => {
+      expect(
+        generateWithAmplifyRenderer('boxGolden', { module: ModuleKind.CommonJS, script: ScriptKind.JS }),
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -1,6 +1,7 @@
 import { StudioComponent, StudioComponentChild } from '@amzn/amplify-ui-codegen-schema';
 import { factory, JsxElement, JsxFragment } from 'typescript';
 import { ReactStudioTemplateRenderer } from '../react-studio-template-renderer';
+import { ReactRenderConfig } from '../react-render-config';
 
 import BadgeRenderer from './badge';
 import ButtonRenderer from './button';
@@ -15,8 +16,8 @@ import CustomComponentRenderer from './customComponent';
 import CollectionRenderer from './collection';
 
 export class AmplifyRenderer extends ReactStudioTemplateRenderer {
-  constructor(component: StudioComponent) {
-    super(component);
+  constructor(component: StudioComponent, renderConfig: ReactRenderConfig) {
+    super(component, renderConfig);
   }
 
   renderJsx(component: StudioComponent | StudioComponentChild): JsxElement | JsxFragment {

--- a/packages/studio-ui-codegen-react/lib/index.ts
+++ b/packages/studio-ui-codegen-react/lib/index.ts
@@ -8,29 +8,6 @@ export * from './react-component-renderer';
 export { ImportCollection } from './import-collection';
 export * from './react-studio-template-renderer';
 export * from './react-output-config';
-
-export class ReactOutputManager extends FrameworkOutputManager<string> {
-  async writeComponent(input: string, outputPath: string, componentName: string): Promise<void> {
-    console.log('Writing file ', outputPath);
-
-    const componentFileName = `${componentName}.tsx`;
-
-    if (!existsSync(outputPath)) {
-      mkdirSync(outputPath);
-    }
-
-    const pathWithComponent = path.join(outputPath, componentName);
-
-    if (!existsSync(pathWithComponent)) {
-      mkdirSync(pathWithComponent);
-    }
-
-    if (!input) {
-      throw new Error('You must call renderComponent before you can save the file.');
-    }
-
-    const finalFileOutputPath = path.join(outputPath, componentFileName);
-    await fs.writeFile(finalFileOutputPath, '/* eslint-disable */');
-    await fs.writeFile(finalFileOutputPath, input);
-  }
-}
+export * from './react-render-config';
+export * from './react-output-manager';
+export * from './amplify-ui-renderers/amplify-renderer';

--- a/packages/studio-ui-codegen-react/lib/react-output-config.ts
+++ b/packages/studio-ui-codegen-react/lib/react-output-config.ts
@@ -1,31 +1,3 @@
 import { FrameworkOutputConfig } from '@amzn/studio-ui-codegen';
 
-export type ReactOutputConfig = FrameworkOutputConfig & {
-  /**
-   * @name outputFormat
-   * @type string
-   * @description required, the format of react ui codegen.
-   * @values 'ts' | 'tsx' | 'js' | 'jsx'
-   * @default jsx
-   */
-  outputFormat: JSOutputFormatEnum;
-  // ES5,ES6
-  compileTarget: CompileTargetEnum;
-  // CommonJS, ESModule
-  module: JSModuleEnum;
-};
-
-export enum JSOutputFormatEnum {
-  ts = 'ts',
-  tsx = 'tsx',
-  js = 'js',
-  jsx = 'jsx',
-}
-export enum CompileTargetEnum {
-  ES5 = 'ES5',
-  ES6 = 'ES6',
-}
-export enum JSModuleEnum {
-  CommonJS = 'CommonJS',
-  ESModule = 'ESModule',
-}
+export type ReactOutputConfig = FrameworkOutputConfig & {};

--- a/packages/studio-ui-codegen-react/lib/react-output-manager.ts
+++ b/packages/studio-ui-codegen-react/lib/react-output-manager.ts
@@ -7,24 +7,17 @@ export default class ReactOutputManager extends FrameworkOutputManager<string> {
   async writeComponent(input: string, outputPath: string, componentName: string): Promise<void> {
     console.log('Writing file ', outputPath);
 
-    const componentFileName = `${componentName}.tsx`;
+    const dir = path.parse(outputPath).base;
 
-    if (!existsSync(outputPath)) {
-      mkdirSync(outputPath);
-    }
-
-    const pathWithComponent = path.join(outputPath, componentName);
-
-    if (!existsSync(pathWithComponent)) {
-      mkdirSync(pathWithComponent);
+    if (!existsSync(dir)) {
+      mkdirSync(dir);
     }
 
     if (!input) {
       throw new Error('You must call renderComponent before you can save the file.');
     }
 
-    const finalFileOutputPath = path.join(outputPath, componentFileName);
-    await fs.writeFile(finalFileOutputPath, '/* eslint-disable */');
-    await fs.writeFile(finalFileOutputPath, input);
+    await fs.writeFile(outputPath, '/* eslint-disable */');
+    await fs.writeFile(outputPath, input);
   }
 }

--- a/packages/studio-ui-codegen-react/lib/react-render-config.ts
+++ b/packages/studio-ui-codegen-react/lib/react-render-config.ts
@@ -1,0 +1,25 @@
+import { FrameworkRenderConfig } from '@amzn/studio-ui-codegen';
+import { ScriptKind, ScriptTarget, ModuleKind } from 'typescript';
+
+export { ScriptKind, ScriptTarget, ModuleKind } from 'typescript';
+
+export type ReactRenderConfig = FrameworkRenderConfig & {
+  script?: ScriptKind;
+  target?: ScriptTarget;
+  module?: ModuleKind;
+};
+
+export function scriptKindToFileExtension(scriptKind: ScriptKind): string {
+  switch (scriptKind) {
+    case ScriptKind.TS:
+      return 'ts';
+    case ScriptKind.TSX:
+      return 'tsx';
+    case ScriptKind.JS:
+      return 'js';
+    case ScriptKind.JSX:
+      return 'jsx';
+    default:
+      return 'tsx';
+  }
+}

--- a/packages/studio-ui-codegen/index.ts
+++ b/packages/studio-ui-codegen/index.ts
@@ -10,3 +10,4 @@ export * from './lib/template-renderer-factory';
 export * from './lib/mapper/mapper-base';
 export * from './lib/renderer-helper';
 export * from './lib/framework-output-config';
+export * from './lib/framework-render-config';

--- a/packages/studio-ui-codegen/lib/framework-render-config.ts
+++ b/packages/studio-ui-codegen/lib/framework-render-config.ts
@@ -1,0 +1,2 @@
+//The basic type for studio ui codegen render configuration
+export type FrameworkRenderConfig = {};

--- a/packages/studio-ui-codegen/lib/studio-template-renderer.ts
+++ b/packages/studio-ui-codegen/lib/studio-template-renderer.ts
@@ -1,7 +1,9 @@
 import { FrameworkOutputManager } from './framework-output-manager';
+import { FrameworkRenderConfig } from './framework-render-config';
 import { StudioComponent } from '@amzn/amplify-ui-codegen-schema';
 import { StudioRendererConstants } from './renderer-helper';
 import { RenderTextComponentResponse } from './render-component-response';
+import path from 'path';
 
 export abstract class StudioTemplateRenderer<
   TSource,
@@ -12,7 +14,11 @@ export abstract class StudioTemplateRenderer<
    *
    * @param component The first order component to be rendered.
    */
-  constructor(protected component: StudioComponent, protected outputManager: TOutputManager) {}
+  constructor(
+    protected component: StudioComponent,
+    protected outputManager: TOutputManager,
+    protected renderConfig: FrameworkRenderConfig,
+  ) {}
 
   /**
    * Renders the entire first order component. It returns the
@@ -21,10 +27,10 @@ export abstract class StudioTemplateRenderer<
   abstract renderComponent(): TRenderOutput;
 
   renderComponentToFilesystem(componentContent: TSource) {
-    return (outputPath: string) =>
+    return (fileName: string) => (outputPath: string) =>
       this.outputManager.writeComponent(
         componentContent,
-        outputPath,
+        path.join(outputPath, fileName),
         this.component.name ?? StudioRendererConstants.unknownName,
       );
   }

--- a/packages/studio-ui-codegen/lib/template-renderer.ts
+++ b/packages/studio-ui-codegen/lib/template-renderer.ts
@@ -36,8 +36,8 @@ export class StudioTemplateRendererManager<
     }
     console.log('Rendering a component ', component.componentType);
     const componentRenderer = this.renderer.buildRenderer(component);
-    let result = componentRenderer.renderComponent();
-    componentRenderer.renderComponentToFilesystem(result.componentText as any)(this.outputConfig.outputPathDir);
+    const result = componentRenderer.renderComponent();
+    result.renderComponentToFilesystem(this.outputConfig.outputPathDir);
     return result;
   }
 

--- a/packages/test-generator/index.ts
+++ b/packages/test-generator/index.ts
@@ -1,28 +1,26 @@
 import { StudioComponent } from '@amzn/amplify-ui-codegen-schema';
 import { StudioTemplateRendererManager, StudioTemplateRendererFactory } from '@amzn/studio-ui-codegen';
-import {
-  AmplifyRenderer,
-  ReactOutputConfig,
-  JSModuleEnum,
-  CompileTargetEnum,
-  JSOutputFormatEnum,
-} from '@amzn/studio-ui-codegen-react';
+import { AmplifyRenderer, ReactOutputConfig, ReactRenderConfig, ScriptKind } from '@amzn/studio-ui-codegen-react';
+import { ModuleKind, ScriptTarget } from 'typescript';
 import path from 'path';
 
 import * as schemas from './lib';
 
 Error.stackTraceLimit = Infinity;
 
+const renderConfig: ReactRenderConfig = {
+  module: ModuleKind.CommonJS,
+  target: ScriptTarget.ES2015,
+  script: ScriptKind.JS,
+};
+
 const rendererFactory = new StudioTemplateRendererFactory(
-  (component: StudioComponent) => new AmplifyRenderer(component),
+  (component: StudioComponent) => new AmplifyRenderer(component, renderConfig),
 );
 
 const outputPathDir = path.resolve(path.join(__dirname, '..', 'ui-components'));
 const outputConfig: ReactOutputConfig = {
   outputPathDir,
-  module: JSModuleEnum.CommonJS,
-  compileTarget: CompileTargetEnum.ES6,
-  outputFormat: JSOutputFormatEnum.tsx,
 };
 const rendererManager = new StudioTemplateRendererManager(rendererFactory, outputConfig);
 Object.entries(schemas).forEach(([name, schema]) => {


### PR DESCRIPTION
The major changes:
* Made a `FrameworkRenderConfig` and `ReactRenderConfig` because we needed to pass these configurations into the renderer and not the output manager
* Use the `transpileModule` from typescript to set certain targets and modules
  * I haven’t found a way to use the `transpileModule` and keep typescript. 
    * For TSX I set it to not pass through `transpileModule` to preserve the syntax
    * For TS I have not found a was to transpile the React code, but still preserve the TS syntax. I think we should push this to another change.
 
Example:
amplify component:
```
{
  "componentId": "1234-5678-9010",
  "componentType": "Text",
  "name": "CustomText",
  "properties": {
    "color": {
      "value": "#ff0000"
    },
    "width": {
      "value": "20px"
    },
    "value": {
      "value": "Text Value"
    }
  }
}
```
With config:
```
const renderConfig: ReactRenderConfig = {
  module: ModuleEnum.CommonJS,
  script: ScriptEnum.js,
}
```
Will produce:
```
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
/* eslint-disable */
const react_1 = require("react");
const ui_react_1 = require("@aws-amplify/ui-react");
function CustomButton(props) {
  return react_1.default.createElement(
    ui_react_1.Button,
    Object.assign(
      {
        color: "#ff0000",
        width: 20,
        label: buttonUser.username || "hspain@gmail.com",
        labelWidth: width || "50px",
      },
      props,
      getOverrideProps(props.overrides, "Button")
    )
  );
}
exports.default = CustomButton;
```

TODO in future change:
* Figure out `TS` script kind
* Raise warnings on invalid render config combinations. i.e. CommonJS + JSX