### PR TITLE
fix: add data binding model imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,13 @@
       "version": "0.1.0",
       "license": "UNLICENSED",
       "devDependencies": {
+        "@commitlint/cli": "^13.1.0",
+        "@commitlint/config-conventional": "^13.1.0",
+        "@commitlint/config-lerna-scopes": "^13.1.0",
         "@types/jest": "^26.0.24",
         "@types/node": "^15.14.0",
         "eslint-config-prettier": "^8.3.0",
+        "husky": ">=6",
         "jest": "^27.0.6",
         "jest-circus": "^27.0.6",
         "jest-junit": "^12.2.0",
@@ -668,6 +672,367 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-13.1.0.tgz",
+      "integrity": "sha512-xN/uNYWtGTva5OMSd+xA6e6/c2jk8av7MUbdd6w2cw89u6z3fAWoyiH87X0ewdSMNYmW/6B3L/2dIVGHRDID5w==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/format": "^13.1.0",
+        "@commitlint/lint": "^13.1.0",
+        "@commitlint/load": "^13.1.0",
+        "@commitlint/read": "^13.1.0",
+        "@commitlint/types": "^13.1.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "5.0.0",
+        "resolve-global": "1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-13.1.0.tgz",
+      "integrity": "sha512-zukJXqdr6jtMiVRy3tTHmwgKcUMGfqKDEskRigc5W3k2aYF4gBAtCEjMAJGZgSQE4DMcHeok0pEV2ANmTpb0cw==",
+      "dev": true,
+      "dependencies": {
+        "conventional-changelog-conventionalcommits": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/config-lerna-scopes": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-13.1.0.tgz",
+      "integrity": "sha512-/OTFM75GYHFRm5m1TKOpHsLvAUuGL6GYnA5xJDT4fe2vPIGqgBYVL9hEolKYTJfDtviBq4fEkEWZQjQF5e4KgA==",
+      "dev": true,
+      "dependencies": {
+        "globby": "^11.0.1",
+        "import-from": "4.0.0",
+        "resolve-pkg": "2.0.0",
+        "semver": "7.3.5"
+      },
+      "engines": {
+        "node": ">=v12"
+      },
+      "peerDependencies": {
+        "lerna": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "lerna": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-13.1.0.tgz",
+      "integrity": "sha512-NRGyjOdZQnlYwm9it//BZJ2Vm+4x7G9rEnHpLCvNKYY0c6RA8Qf7hamLAB8dWO12RLuFt06JaOpHZoTt/gHutA==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^13.1.0",
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-13.0.0.tgz",
+      "integrity": "sha512-lBz2bJhNAgkkU/rFMAw3XBNujbxhxlaFHY3lfKB/MxpAa+pIfmWB3ig9i1VKe0wCvujk02O0WiMleNaRn2KJqw==",
+      "dev": true,
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-13.1.0.tgz",
+      "integrity": "sha512-n46rYvzf+6Sm99TJjTLjJBkjm6JVcklt31lDO5Q+pCIV0NnJ4qIUcwa6wIL9a9Vqb1XzlMgtp27E0zyYArkvSg==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^13.1.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-13.1.0.tgz",
+      "integrity": "sha512-P6zenLE5Tn3FTNjRzmL9+/KooTXEI0khA2TmUbuei9KiycemeO4q7Xk7w7aXwFPNAbN0O9oI7z3z7cFpzKJWmQ==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^13.1.0",
+        "semver": "7.3.5"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-13.1.0.tgz",
+      "integrity": "sha512-qH9AYSQDDTaSWSdtOvB3G1RdPpcYSgddAdFYqpFewlKQ1GJj/L+sM7vwqCG7/ip6AiM04Sry1sgmFzaEoFREUA==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/is-ignored": "^13.1.0",
+        "@commitlint/parse": "^13.1.0",
+        "@commitlint/rules": "^13.1.0",
+        "@commitlint/types": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-13.1.0.tgz",
+      "integrity": "sha512-zlZbjJCWnWmBOSwTXis8H7I6pYk6JbDwOCuARA6B9Y/qt2PD+NCo0E/7EuaaFoxjHl+o56QR5QttuMBrf+BJzg==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/execute-rule": "^13.0.0",
+        "@commitlint/resolve-extends": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "chalk": "^4.0.0",
+        "cosmiconfig": "^7.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-13.0.0.tgz",
+      "integrity": "sha512-W/pxhesVEk8747BEWJ+VGQ9ILHmCV27/pEwJ0hGny1wqVquUR8SxvScRCbUjHCB1YtWX4dEnOPXOS9CLH/CX7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-13.1.0.tgz",
+      "integrity": "sha512-xFybZcqBiKVjt6vTStvQkySWEUYPI0AcO4QQELyy29o8EzYZqWkhUfrb7K61fWiHsplWL1iL6F3qCLoxSgTcrg==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/types": "^13.1.0",
+        "conventional-changelog-angular": "^5.0.11",
+        "conventional-commits-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-13.1.0.tgz",
+      "integrity": "sha512-NrVe23GMKyL6i1yDJD8IpqCBzhzoS3wtLfDj8QBzc01Ov1cYBmDojzvBklypGb+MLJM1NbzmRM4PR5pNX0U/NQ==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/top-level": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "fs-extra": "^10.0.0",
+        "git-raw-commits": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-13.0.0.tgz",
+      "integrity": "sha512-1SyaE+UOsYTkQlTPUOoj4NwxQhGFtYildVS/d0TJuK8a9uAJLw7bhCLH2PEeH5cC2D1do4Eqhx/3bLDrSLH3hg==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-13.1.0.tgz",
+      "integrity": "sha512-b6F+vBqEXsHVghrhomG0Y6YJimHZqkzZ0n5QEpk03dpBXH2OnsezpTw5e+GvbyYCc7PutGbYVQkytuv+7xCxYA==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/ensure": "^13.1.0",
+        "@commitlint/message": "^13.0.0",
+        "@commitlint/to-lines": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-13.0.0.tgz",
+      "integrity": "sha512-mzxWwCio1M4/kG9/69TTYqrraQ66LmtJCYTzAZdZ2eJX3I5w52pSjyP/DJzAUVmmJCYf2Kw3s+RtNVShtnZ+Rw==",
+      "dev": true,
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-13.0.0.tgz",
+      "integrity": "sha512-baBy3MZBF28sR93yFezd4a5TdHsbXaakeladfHK9dOcGdXo9oQe3GS5hP3BmlN680D6AiQSN7QPgEJgrNUWUCg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/top-level/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+      "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=v12"
+      }
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -3575,6 +3940,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz",
+      "integrity": "sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/conventional-changelog-core": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.2.tgz",
@@ -5468,6 +5847,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/globals": {
       "version": "13.9.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
@@ -5710,6 +6101,21 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/husky": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
+      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5752,6 +6158,18 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9977,6 +10395,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
+      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -11637,6 +12088,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -12134,6 +12597,276 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@commitlint/cli": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-13.1.0.tgz",
+      "integrity": "sha512-xN/uNYWtGTva5OMSd+xA6e6/c2jk8av7MUbdd6w2cw89u6z3fAWoyiH87X0ewdSMNYmW/6B3L/2dIVGHRDID5w==",
+      "dev": true,
+      "requires": {
+        "@commitlint/format": "^13.1.0",
+        "@commitlint/lint": "^13.1.0",
+        "@commitlint/load": "^13.1.0",
+        "@commitlint/read": "^13.1.0",
+        "@commitlint/types": "^13.1.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "5.0.0",
+        "resolve-global": "1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+          "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        }
+      }
+    },
+    "@commitlint/config-conventional": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-13.1.0.tgz",
+      "integrity": "sha512-zukJXqdr6jtMiVRy3tTHmwgKcUMGfqKDEskRigc5W3k2aYF4gBAtCEjMAJGZgSQE4DMcHeok0pEV2ANmTpb0cw==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-conventionalcommits": "^4.3.1"
+      }
+    },
+    "@commitlint/config-lerna-scopes": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-13.1.0.tgz",
+      "integrity": "sha512-/OTFM75GYHFRm5m1TKOpHsLvAUuGL6GYnA5xJDT4fe2vPIGqgBYVL9hEolKYTJfDtviBq4fEkEWZQjQF5e4KgA==",
+      "dev": true,
+      "requires": {
+        "globby": "^11.0.1",
+        "import-from": "4.0.0",
+        "resolve-pkg": "2.0.0",
+        "semver": "7.3.5"
+      }
+    },
+    "@commitlint/ensure": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-13.1.0.tgz",
+      "integrity": "sha512-NRGyjOdZQnlYwm9it//BZJ2Vm+4x7G9rEnHpLCvNKYY0c6RA8Qf7hamLAB8dWO12RLuFt06JaOpHZoTt/gHutA==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^13.1.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@commitlint/execute-rule": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-13.0.0.tgz",
+      "integrity": "sha512-lBz2bJhNAgkkU/rFMAw3XBNujbxhxlaFHY3lfKB/MxpAa+pIfmWB3ig9i1VKe0wCvujk02O0WiMleNaRn2KJqw==",
+      "dev": true
+    },
+    "@commitlint/format": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-13.1.0.tgz",
+      "integrity": "sha512-n46rYvzf+6Sm99TJjTLjJBkjm6JVcklt31lDO5Q+pCIV0NnJ4qIUcwa6wIL9a9Vqb1XzlMgtp27E0zyYArkvSg==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^13.1.0",
+        "chalk": "^4.0.0"
+      }
+    },
+    "@commitlint/is-ignored": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-13.1.0.tgz",
+      "integrity": "sha512-P6zenLE5Tn3FTNjRzmL9+/KooTXEI0khA2TmUbuei9KiycemeO4q7Xk7w7aXwFPNAbN0O9oI7z3z7cFpzKJWmQ==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^13.1.0",
+        "semver": "7.3.5"
+      }
+    },
+    "@commitlint/lint": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-13.1.0.tgz",
+      "integrity": "sha512-qH9AYSQDDTaSWSdtOvB3G1RdPpcYSgddAdFYqpFewlKQ1GJj/L+sM7vwqCG7/ip6AiM04Sry1sgmFzaEoFREUA==",
+      "dev": true,
+      "requires": {
+        "@commitlint/is-ignored": "^13.1.0",
+        "@commitlint/parse": "^13.1.0",
+        "@commitlint/rules": "^13.1.0",
+        "@commitlint/types": "^13.1.0"
+      }
+    },
+    "@commitlint/load": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-13.1.0.tgz",
+      "integrity": "sha512-zlZbjJCWnWmBOSwTXis8H7I6pYk6JbDwOCuARA6B9Y/qt2PD+NCo0E/7EuaaFoxjHl+o56QR5QttuMBrf+BJzg==",
+      "dev": true,
+      "requires": {
+        "@commitlint/execute-rule": "^13.0.0",
+        "@commitlint/resolve-extends": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "chalk": "^4.0.0",
+        "cosmiconfig": "^7.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@commitlint/message": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-13.0.0.tgz",
+      "integrity": "sha512-W/pxhesVEk8747BEWJ+VGQ9ILHmCV27/pEwJ0hGny1wqVquUR8SxvScRCbUjHCB1YtWX4dEnOPXOS9CLH/CX7A==",
+      "dev": true
+    },
+    "@commitlint/parse": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-13.1.0.tgz",
+      "integrity": "sha512-xFybZcqBiKVjt6vTStvQkySWEUYPI0AcO4QQELyy29o8EzYZqWkhUfrb7K61fWiHsplWL1iL6F3qCLoxSgTcrg==",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^13.1.0",
+        "conventional-changelog-angular": "^5.0.11",
+        "conventional-commits-parser": "^3.0.0"
+      }
+    },
+    "@commitlint/read": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-13.1.0.tgz",
+      "integrity": "sha512-NrVe23GMKyL6i1yDJD8IpqCBzhzoS3wtLfDj8QBzc01Ov1cYBmDojzvBklypGb+MLJM1NbzmRM4PR5pNX0U/NQ==",
+      "dev": true,
+      "requires": {
+        "@commitlint/top-level": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "fs-extra": "^10.0.0",
+        "git-raw-commits": "^2.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@commitlint/resolve-extends": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-13.0.0.tgz",
+      "integrity": "sha512-1SyaE+UOsYTkQlTPUOoj4NwxQhGFtYildVS/d0TJuK8a9uAJLw7bhCLH2PEeH5cC2D1do4Eqhx/3bLDrSLH3hg==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^3.0.0",
+        "lodash": "^4.17.19",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@commitlint/rules": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-13.1.0.tgz",
+      "integrity": "sha512-b6F+vBqEXsHVghrhomG0Y6YJimHZqkzZ0n5QEpk03dpBXH2OnsezpTw5e+GvbyYCc7PutGbYVQkytuv+7xCxYA==",
+      "dev": true,
+      "requires": {
+        "@commitlint/ensure": "^13.1.0",
+        "@commitlint/message": "^13.0.0",
+        "@commitlint/to-lines": "^13.0.0",
+        "@commitlint/types": "^13.1.0",
+        "execa": "^5.0.0"
+      }
+    },
+    "@commitlint/to-lines": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-13.0.0.tgz",
+      "integrity": "sha512-mzxWwCio1M4/kG9/69TTYqrraQ66LmtJCYTzAZdZ2eJX3I5w52pSjyP/DJzAUVmmJCYf2Kw3s+RtNVShtnZ+Rw==",
+      "dev": true
+    },
+    "@commitlint/top-level": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-13.0.0.tgz",
+      "integrity": "sha512-baBy3MZBF28sR93yFezd4a5TdHsbXaakeladfHK9dOcGdXo9oQe3GS5hP3BmlN680D6AiQSN7QPgEJgrNUWUCg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
+      }
+    },
+    "@commitlint/types": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-13.1.0.tgz",
+      "integrity": "sha512-zcVjuT+OfKt8h91vhBxt05RMcTGEx6DM7Q9QZeuMbXFk6xgbsSEDMMapbJPA1bCZ81fa/1OQBijSYPrKvtt06g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0"
+      }
     },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -14514,6 +15247,17 @@
         "q": "^1.5.1"
       }
     },
+    "conventional-changelog-conventionalcommits": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz",
+      "integrity": "sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      }
+    },
     "conventional-changelog-core": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.2.tgz",
@@ -15997,6 +16741,15 @@
         "is-glob": "^4.0.1"
       }
     },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
     "globals": {
       "version": "13.9.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
@@ -16177,6 +16930,12 @@
         "ms": "^2.0.0"
       }
     },
+    "husky": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
+      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -16211,6 +16970,12 @@
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       }
+    },
+    "import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true
     },
     "import-local": {
       "version": "3.0.2",
@@ -19476,6 +20241,32 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.1"
+      }
+    },
+    "resolve-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
+      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
     "restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -20726,6 +21517,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -78,6 +78,25 @@ export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
 }"
 `;
 
+exports[`amplify render tests component with data binding should add model imports 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import { User } from \\"../models\\";
+import { Button, EscapeHatchProps, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+
+export type ComponentWithDataBindingProps = {
+    width: Number;
+    isDisabled: Boolean;
+    buttonUser?: User;
+    buttonColor: String;
+} & {
+    overrides?: EscapeHatchProps | undefined | null;
+};
+export default function ComponentWithDataBinding(props: ComponentWithDataBindingProps): JSX.Element {
+    return (<Button label={buttonUser.username || \\"hspain@gmail.com\\"} labelWidth={width} disabled={isDisabled} {...props} {...getOverrideProps(props.overrides, \\"Button\\")}></Button>);
+}"
+`;
+
 exports[`amplify render tests sample code snippet tests should generate a sample code snippet for components 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -74,4 +74,11 @@ describe('amplify render tests', () => {
       expect(generatedCode).toMatchSnapshot();
     });
   });
+
+  describe('component with data binding', () => {
+    it('should add model imports', () => {
+      const generatedCode = generateWithAmplifyRenderer('componentWithDataBinding');
+      expect(generatedCode).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/componentWithDataBinding.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/componentWithDataBinding.json
@@ -1,0 +1,41 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Button",
+  "name": "ComponentWithDataBinding",
+  "bindingProperties": {
+    "width": {
+      "type": "Number"
+    },
+    "isDisabled": {
+      "type": "Boolean"
+    },
+    "buttonUser": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "User"
+      }
+    },
+    "buttonColor": {
+      "type": "String"
+    }
+  },
+  "properties": {
+    "label": {
+      "bindingProperties": {
+        "property": "buttonUser",
+        "field": "username"
+      },
+      "defaultValue": "hspain@gmail.com"
+    },
+    "labelWidth": {
+      "bindingProperties": {
+        "property": "width"
+      }
+    },
+    "disabled": {
+      "bindingProperties": {
+        "property": "isDisabled"
+      }
+    }
+  }
+}

--- a/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-render-helper.ts
@@ -4,9 +4,13 @@ import {
   CollectionStudioComponentProperty,
   WorkflowStudioComponentProperty,
   FormStudioComponentProperty,
+  StudioComponent,
+  StudioComponentChild,
 } from '@amzn/amplify-ui-codegen-schema';
 
 import { factory, JsxAttribute, JsxExpression, StringLiteral, SyntaxKind } from 'typescript';
+
+import { ImportCollection } from './import-collection';
 
 export function getFixedComponentPropValueExpression(prop: FixedStudioComponentProperty): StringLiteral {
   return factory.createStringLiteral(prop.value.toString(), true);
@@ -182,4 +186,17 @@ export function buildCollectionBindingAttrWithDefault(
     factory.createJsxExpression(undefined, binaryExpr),
   );
   return attr;
+}
+
+export function addBindingPropertiesImports(
+  component: StudioComponent | StudioComponentChild,
+  importCollection: ImportCollection,
+) {
+  if ('bindingProperties' in component) {
+    Object.entries(component.bindingProperties).forEach(([property, binding]) => {
+      if ('bindingProperties' in binding && 'model' in binding.bindingProperties) {
+        importCollection.addImport('../models', binding.bindingProperties.model);
+      }
+    });
+  }
 }

--- a/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
@@ -2,12 +2,13 @@ import { StudioComponent, StudioComponentChild, StudioComponentProperties } from
 import { ComponentRendererBase } from '@amzn/studio-ui-codegen';
 import { JsxAttribute, JsxAttributeLike, JsxElement, JsxOpeningElement, NodeFactory } from 'typescript';
 
+import { addBindingPropertiesImports, buildOpeningElementAttributes } from './react-component-render-helper';
 import { ImportCollection } from './import-collection';
-import { buildOpeningElementAttributes } from './react-component-render-helper';
 
 export abstract class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<TPropIn, JsxElement> {
   constructor(component: StudioComponent | StudioComponentChild, protected importCollection: ImportCollection) {
     super(component);
+    addBindingPropertiesImports(component, importCollection);
   }
 
   protected renderOpeningElement(

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -12,7 +12,7 @@ import {
   Expression,
 } from 'typescript';
 import { ImportCollection } from './import-collection';
-import { buildOpeningElementAttributes } from './react-component-render-helper';
+import { addBindingPropertiesImports, buildOpeningElementAttributes } from './react-component-render-helper';
 
 export abstract class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithChildrenRendererBase<
   TPropIn,
@@ -21,6 +21,7 @@ export abstract class ReactComponentWithChildrenRenderer<TPropIn> extends Compon
 > {
   constructor(component: StudioComponent | StudioComponentChild, protected importCollection: ImportCollection) {
     super(component);
+    addBindingPropertiesImports(component, importCollection);
   }
 
   protected renderCustomCompOpeningElement(

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -243,22 +243,21 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       return factory.createTypeLiteralNode([]);
     }
     for (let bindingProp of Object.entries(component.bindingProperties)) {
-      const propName = bindingProp[0];
-      const typeName = bindingProp[1].type.toString();
-      if (isSimplePropertyBinding(bindingProp[1])) {
+      const [propName, binding] = bindingProp;
+      if (isSimplePropertyBinding(binding)) {
         const propSignature = factory.createPropertySignature(
           undefined,
           propName,
           undefined,
-          factory.createTypeReferenceNode(typeName, undefined),
+          factory.createTypeReferenceNode(binding.type, undefined),
         );
         propSignatures.push(propSignature);
-      } else if (isDataPropertyBinding(bindingProp[1])) {
+      } else if (isDataPropertyBinding(binding)) {
         const propSignature = factory.createPropertySignature(
           undefined,
           propName,
           factory.createToken(SyntaxKind.QuestionToken),
-          factory.createTypeReferenceNode(typeName, undefined),
+          factory.createTypeReferenceNode(binding.bindingProperties.model, undefined),
         );
         propSignatures.push(propSignature);
       }

--- a/packages/test-generator/lib/componentWithDataBinding.json
+++ b/packages/test-generator/lib/componentWithDataBinding.json
@@ -1,0 +1,41 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Button",
+  "name": "ComponentWithDataBinding",
+  "bindingProperties": {
+    "width": {
+      "type": "Number"
+    },
+    "isDisabled": {
+      "type": "Boolean"
+    },
+    "buttonUser": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "User"
+      }
+    },
+    "buttonColor": {
+      "type": "String"
+    }
+  },
+  "properties": {
+    "label": {
+      "bindingProperties": {
+        "property": "buttonUser",
+        "field": "username"
+      },
+      "defaultValue": "hspain@gmail.com"
+    },
+    "labelWidth": {
+      "bindingProperties": {
+        "property": "width"
+      }
+    },
+    "disabled": {
+      "bindingProperties": {
+        "property": "isDisabled"
+      }
+    }
+  }
+}

--- a/packages/test-generator/lib/index.ts
+++ b/packages/test-generator/lib/index.ts
@@ -8,3 +8,4 @@ export { default as HeaderWithAction } from './headerWithAction.json';
 export { default as SampleCodeSnippet } from './sampleCodeSnippet.json';
 export { default as TextGolden } from './textGolden.json';
 export { default as CollectionWithBinding } from './collectionWithBinding.json';
+export { default as ComponentWithDataBinding } from './componentWithDataBinding.json';


### PR DESCRIPTION
The model imports for data bindings are missing.

Example import:
```
import { User } from '../models';
```

* add model imports when needed with data bindings.
* set correct data type for props on data bindings.
  * previously the type was set to `Data` rather than the correct model.

Old:
```
export type CustomButtonProps = { buttonUser?: Data }
```

New:
```
export type CustomButtonProps = { buttonUser?: User }
```

Testing:
Add new unit test based on golden file for component with data binding.
