### PR TITLE
chore: ignore styles on ui-react-types and amplify-ui-codegen-schema

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,14 @@
 module.exports = {
-  ignorePatterns: ['build', 'dist', 'node_modules', 'jest.config.js', '.eslintrc.js', 'commitlint.config.js'],
+  ignorePatterns: [
+    'build',
+    'dist',
+    'node_modules',
+    'jest.config.js',
+    '.eslintrc.js',
+    'commitlint.config.js',
+    'packages/ui-react-types',
+    'packages/amplify-ui-codegen-schema',
+  ],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'airbnb-typescript/base',

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 .husky
+packages/ui-react-types
+packages/amplify-ui-codegen-schema


### PR DESCRIPTION
Ignore eslint and prettier on ui-react-types and amplify-ui-codegen-schema. 

Packages are copied from another source and should not be modified.

Testing:
```
echo " " >> packages/amplify-ui-codegen-schema/lib/types/primitives.ts
git diff # see extra newline and whitespace
npm run format
git diff # still see extra newline and whitespace
npm run lint:fix
git diff # still see extra newline and whitespace
```
