### PR TITLE
fix: only pass props to top level

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -18,7 +18,7 @@ export default function Test(props: TestProps): JSX.Element {
       fontFamily=\\"Times New Roman\\"
       fontSize=\\"20px\\"
       {...props}
-      {...getOverrideProps(props.overrides, \\"View\\")}
+      {...getOverrideProps(props.overrides, \\"Box\\")}
     ></View>
   );
 }
@@ -93,12 +93,11 @@ export type BoxWithButtonProps = {} & {
 };
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
   return (
-    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+    <View {...props} {...getOverrideProps(props.overrides, \\"Box\\")}>
       <Button
         color=\\"#ff0000\\"
         width=\\"20px\\"
-        {...props}
-        {...getOverrideProps(props.overrides, \\"Button\\")}
+        {...getOverrideProps(props.overrides, \\"Box.Button\\")}
       ></Button>
     </View>
   );
@@ -124,7 +123,7 @@ export default function BoxWithCustomButton(
   props: BoxWithCustomButtonProps
 ): JSX.Element {
   return (
-    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+    <View {...props} {...getOverrideProps(props.overrides, \\"Box\\")}>
       <CustomButton
         color=\\"#ff0000\\"
         width=\\"20px\\"
@@ -151,12 +150,11 @@ export type BoxWithButtonProps = {} & {
 };
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
   return (
-    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+    <View {...props} {...getOverrideProps(props.overrides, \\"Box\\")}>
       <Button
         color=\\"#ff0000\\"
         width=\\"20px\\"
-        {...props}
-        {...getOverrideProps(props.overrides, \\"Button\\")}
+        {...getOverrideProps(props.overrides, \\"Box.Button\\")}
       ></Button>
     </View>
   );
@@ -175,16 +173,17 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 
 export type ComponentWithDataBindingProps = {
-  width: Number,
-  isDisabled: Boolean,
+  width?: Number,
+  isDisabled?: Boolean,
   buttonUser?: User,
-  buttonColor: String,
+  buttonColor?: String,
 } & {
   overrides?: EscapeHatchProps | undefined | null,
 };
 export default function ComponentWithDataBinding(
   props: ComponentWithDataBindingProps
 ): JSX.Element {
+  const { width, isDisabled, buttonUser, buttonColor } = props;
   return (
     <Button
       label={buttonUser.username || \\"hspain@gmail.com\\"}
@@ -220,13 +219,12 @@ import { Button, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
 export default function BoxWithButton(props) {
   return React.createElement(
     View,
-    __assign({}, props, getOverrideProps(props.overrides, \\"View\\")),
+    __assign({}, props, getOverrideProps(props.overrides, \\"Box\\")),
     React.createElement(
       Button,
       __assign(
         { color: \\"#ff0000\\", width: \\"20px\\" },
-        props,
-        getOverrideProps(props.overrides, \\"Button\\")
+        getOverrideProps(props.overrides, \\"Box.Button\\")
       )
     )
   );
@@ -240,12 +238,11 @@ import React from \\"react\\";
 import { Button, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
 export default function BoxWithButton(props) {
   return (
-    <View {...props} {...getOverrideProps(props.overrides, \\"View\\")}>
+    <View {...props} {...getOverrideProps(props.overrides, \\"Box\\")}>
       <Button
         color=\\"#ff0000\\"
         width=\\"20px\\"
-        {...props}
-        {...getOverrideProps(props.overrides, \\"Button\\")}
+        {...getOverrideProps(props.overrides, \\"Box.Button\\")}
       ></Button>
     </View>
   );
@@ -265,14 +262,13 @@ function BoxWithButton(props) {
     Object.assign(
       {},
       props,
-      ui_react_1.getOverrideProps(props.overrides, \\"View\\")
+      ui_react_1.getOverrideProps(props.overrides, \\"Box\\")
     ),
     react_1.default.createElement(
       ui_react_1.Button,
       Object.assign(
         { color: \\"#ff0000\\", width: \\"20px\\" },
-        props,
-        ui_react_1.getOverrideProps(props.overrides, \\"Button\\")
+        ui_react_1.getOverrideProps(props.overrides, \\"Box.Button\\")
       )
     )
   );
@@ -297,11 +293,7 @@ export type BoxWithButtonProps = {} & {
 };
 export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
   return (
-    <View
-      padding-left
-      {...props}
-      {...getOverrideProps(props.overrides, \\"View\\")}
-    >
+    <View padding-left {...props} {...getOverrideProps(props.overrides, \\"Box\\")}>
       <CustomButton
         color=\\"#ff0000\\"
         width=\\"20px\\"

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -1,4 +1,5 @@
 import { StudioComponent, StudioComponentChild } from '@amzn/amplify-ui-codegen-schema';
+import { StudioNode } from '@amzn/studio-ui-codegen';
 import { factory, JsxElement, JsxFragment } from 'typescript';
 import { ReactStudioTemplateRenderer } from '../react-studio-template-renderer';
 import { ReactRenderConfig } from '../react-render-config';
@@ -20,54 +21,56 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
     super(component, renderConfig);
   }
 
-  renderJsx(component: StudioComponent | StudioComponentChild): JsxElement | JsxFragment {
+  renderJsx(component: StudioComponent | StudioComponentChild, parent?: StudioNode): JsxElement | JsxFragment {
+    console.log(parent);
+    const node = new StudioNode(component, parent);
     switch (component.componentType) {
       case 'Collection':
-        return new CollectionRenderer(component, this.importCollection).renderElement((children) =>
-          children.map((child) => this.renderJsx(child)),
+        return new CollectionRenderer(component, this.importCollection, parent).renderElement((children) =>
+          children.map((child) => this.renderJsx(child, node)),
         );
       case 'Badge':
-        return new BadgeRenderer(component, this.importCollection).renderElement((children) =>
-          children.map((child) => this.renderJsx(child)),
+        return new BadgeRenderer(component, this.importCollection, parent).renderElement((children) =>
+          children.map((child) => this.renderJsx(child, node)),
         );
 
       case 'Button':
-        return new ButtonRenderer(component, this.importCollection).renderElement((children) =>
-          children.map((child) => this.renderJsx(child)),
+        return new ButtonRenderer(component, this.importCollection, parent).renderElement((children) =>
+          children.map((child) => this.renderJsx(child, node)),
         );
 
       case 'Box':
-        return new BoxRenderer(component, this.importCollection).renderElement((children) =>
-          children.map((child) => this.renderJsx(child)),
+        return new BoxRenderer(component, this.importCollection, parent).renderElement((children) =>
+          children.map((child) => this.renderJsx(child, node)),
         );
 
       case 'Card':
-        return new CardRenderer(component, this.importCollection).renderElement((children) =>
-          children.map((child) => this.renderJsx(child)),
+        return new CardRenderer(component, this.importCollection, parent).renderElement((children) =>
+          children.map((child) => this.renderJsx(child, node)),
         );
 
       case 'Divider':
-        return new DividerRenderer(component, this.importCollection).renderElement();
+        return new DividerRenderer(component, this.importCollection, parent).renderElement();
 
       case 'Flex':
-        return new FlexRenderer(component, this.importCollection).renderElement((children) =>
-          children.map((child) => this.renderJsx(child)),
+        return new FlexRenderer(component, this.importCollection, parent).renderElement((children) =>
+          children.map((child) => this.renderJsx(child, node)),
         );
 
       case 'Image':
-        return new ImageRenderer(component, this.importCollection).renderElement();
+        return new ImageRenderer(component, this.importCollection, parent).renderElement();
 
       case 'String':
         return renderString(component);
 
       case 'Text':
-        return new TextRenderer(component, this.importCollection).renderElement();
+        return new TextRenderer(component, this.importCollection, parent).renderElement();
     }
 
     console.warn(`${component.componentType} is not one of the primitives - assuming CustomComponent`);
 
     return new CustomComponentRenderer(component, this.importCollection).renderElement((children) =>
-      children.map((child) => this.renderJsx(child)),
+      children.map((child) => this.renderJsx(child, node)),
     );
   }
 }

--- a/packages/studio-ui-codegen/index.ts
+++ b/packages/studio-ui-codegen/index.ts
@@ -11,3 +11,4 @@ export * from './lib/mapper/mapper-base';
 export * from './lib/renderer-helper';
 export * from './lib/framework-output-config';
 export * from './lib/framework-render-config';
+export * from './lib/studio-node';

--- a/packages/studio-ui-codegen/lib/common-component-renderer.ts
+++ b/packages/studio-ui-codegen/lib/common-component-renderer.ts
@@ -6,6 +6,8 @@ import {
   WrappedComponentProperties,
 } from '@amzn/amplify-ui-codegen-schema';
 
+import { StudioNode } from './studio-node';
+
 /**
  * Shared class for rendering components.
  * Mostly contains helper functions for mapping the Studio schema to actual props.
@@ -13,10 +15,13 @@ import {
 export abstract class CommonComponentRenderer<TPropIn> {
   protected inputProps: WrappedComponentProperties<TPropIn>;
 
-  constructor(protected component: StudioComponent | StudioComponentChild) {
+  protected node: StudioNode;
+
+  constructor(protected component: StudioComponent | StudioComponentChild, protected parent?: StudioNode) {
     const flattenedProps = Object.entries(component.properties).map((prop) => {
       return [prop[0], prop[1]];
     });
     this.inputProps = Object.fromEntries(flattenedProps);
+    this.node = new StudioNode(component, parent);
   }
 }

--- a/packages/studio-ui-codegen/lib/studio-node.ts
+++ b/packages/studio-ui-codegen/lib/studio-node.ts
@@ -1,0 +1,23 @@
+import { StudioComponent, StudioComponentChild } from '@amzn/amplify-ui-codegen-schema';
+
+export class StudioNode {
+  component: StudioComponent | StudioComponentChild;
+
+  parent?: StudioNode;
+
+  constructor(component: StudioComponent | StudioComponentChild, parent?: StudioNode) {
+    this.component = component;
+    this.parent = parent;
+  }
+
+  isRoot(): boolean {
+    return this.parent === undefined;
+  }
+
+  getComponentPathToRoot(): (StudioComponent | StudioComponentChild)[] {
+    if (this.parent !== undefined) {
+      return [this.component].concat(this.parent.getComponentPathToRoot());
+    }
+    return [this.component];
+  }
+}


### PR DESCRIPTION
* only apply props spread to top level 

This was done by adding a `StudioNode` object that contain the current component as well as a reference to the parent node.

Example props not spread:
```
export default function CollectionOfCustomButtons(props) {
  const { width, backgroundColor, buttonColor } = props;
  const filterCriteriabuttonUser = [];
  const { buttonUser } = useDataStoreBinding({
    type: "collection",
    model: User,
    criteria: filterCriteriabuttonUser,
  });
  return (
    <Collection
      type="list"
      gap="1.5rem"
      backgroundColor={backgroundColor}
      items={buttonUser}
      {...props}
      {...getOverrideProps(props.overrides, "Collection")}
    >
      {(item, index) => (
        <Flex {...getOverrideProps(props.overrides, "Collection.Flex")}>
          <Button
            label={item.username || "hspain@gmail.com"}
            labelWidth={width}
            backgroundColor={buttonColor.favoriteColor}
            disabled={isDisabled}
            {...getOverrideProps(props.overrides, "Collection.Flex.Button")}
          ></Button>
        </Flex>
      )}
    </Collection>
  );
}
```