### PR TITLE
fix: remove extra component directories

### DIFF
--- a/packages/studio-ui-codegen-react/lib/react-output-manager.ts
+++ b/packages/studio-ui-codegen-react/lib/react-output-manager.ts
@@ -6,7 +6,7 @@ export class ReactOutputManager extends FrameworkOutputManager<string> {
   async writeComponent(input: string, outputPath: string, componentName: string): Promise<void> {
     console.log('Writing file ', outputPath);
 
-    const dir = path.parse(outputPath).base;
+    const { dir } = path.parse(outputPath);
 
     if (!existsSync(dir)) {
       mkdirSync(dir);


### PR DESCRIPTION
Resolves #65

`dir` not `base` should be used to get the directory.

`base` was using the filename of the component to create a directory in the current working directory resulting in a directory for each component.
