### PR TITLE
feat: remove console log

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     // TODO: enable rules below and fix issues
     'import/no-cycle': 'off',
-    'no-console': 'off',
     '@typescript-eslint/no-shadow': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/no-var-requires': 'off',

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -22,7 +22,6 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
   }
 
   renderJsx(component: StudioComponent | StudioComponentChild, parent?: StudioNode): JsxElement | JsxFragment {
-    console.log(parent);
     const node = new StudioNode(component, parent);
     switch (component.componentType) {
       case 'Collection':
@@ -66,8 +65,6 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
       case 'Text':
         return new TextRenderer(component, this.importCollection, parent).renderElement();
     }
-
-    console.warn(`${component.componentType} is not one of the primitives - assuming CustomComponent`);
 
     return new CustomComponentRenderer(component, this.importCollection).renderElement((children) =>
       children.map((child) => this.renderJsx(child, node)),

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/string.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/string.ts
@@ -8,7 +8,6 @@ export default function renderString(component: StudioComponentChild): JsxFragme
     if ('value' in component.properties.value) {
       const stringProp = component.properties.value;
       const { value } = stringProp;
-      console.log(value);
 
       const element = factory.createJsxFragment(
         factory.createJsxOpeningFragment(),

--- a/packages/studio-ui-codegen-react/lib/react-output-manager.ts
+++ b/packages/studio-ui-codegen-react/lib/react-output-manager.ts
@@ -4,8 +4,6 @@ import path from 'path';
 
 export class ReactOutputManager extends FrameworkOutputManager<string> {
   async writeComponent(input: string, outputPath: string, componentName: string): Promise<void> {
-    console.log('Writing file ', outputPath);
-
     const { dir } = path.parse(outputPath);
 
     if (!existsSync(dir)) {

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -103,8 +103,6 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     const { printer, file } = this.createPrinter();
 
-    console.log('JSX rendered');
-
     const imports = this.importCollection.buildImportStatements();
 
     let importsText = '';
@@ -134,8 +132,6 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     const jsx = this.renderJsx(this.component);
 
-    console.log('JSX rendered');
-
     const wrappedFunction = this.renderFunctionWrapper(
       this.component.name ?? StudioRendererConstants.unknownName,
       jsx,
@@ -163,8 +159,6 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     componentText += result;
 
     const transpiledComponentText = this.transpile(componentText);
-
-    console.log(transpiledComponentText);
 
     return {
       componentText: transpiledComponentText,

--- a/packages/studio-ui-codegen/lib/template-renderer.ts
+++ b/packages/studio-ui-codegen/lib/template-renderer.ts
@@ -34,7 +34,6 @@ export class StudioTemplateRendererManager<
     if (!component) {
       throw new Error('Please ensure you have passed in a valid component schema');
     }
-    console.log('Rendering a component ', component.componentType);
     const componentRenderer = this.renderer.buildRenderer(component);
     const result = componentRenderer.renderComponent();
     result.renderComponentToFilesystem(this.outputConfig.outputPathDir);
@@ -45,8 +44,6 @@ export class StudioTemplateRendererManager<
     if (!jsonSchema) {
       throw new Error('Please ensure you have passed in a valid schema');
     }
-
-    console.log('Rendering multiple components ', jsonSchema.length);
 
     for (const component of jsonSchema) {
       const componentPath = path.join(

--- a/packages/test-generator/index.ts
+++ b/packages/test-generator/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { StudioComponent } from '@amzn/amplify-ui-codegen-schema';
 import { StudioTemplateRendererManager, StudioTemplateRendererFactory } from '@amzn/studio-ui-codegen';
 import { AmplifyRenderer, ReactOutputConfig, ReactRenderConfig, ScriptKind } from '@amzn/studio-ui-codegen-react';


### PR DESCRIPTION
The current logs are not useful and are causing friction on the CLI integration. John said he would prefer that the codegen library refrains from logging and the CLI integration can log if needed. We can add a logger later to add levels of logging, but for now it is easiest to just remove all `console.log`.
