### PR TITLE
ci: fix commitlint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm run lint
       - name: Commit message
         run: |
-          echo ${{ github.event.head_commit.message }} > commit-message-tmp
+          echo "${{ github.event.head_commit.message }}" > commit-message-tmp
           ./.husky/commit-msg commit-message-tmp
           rm commit-message-tmp
 


### PR DESCRIPTION
Omitting quotes around the commit message caused the `echo` command to fail.
