### PR TITLE
fix: enable esModuleInterop

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -358,9 +358,14 @@ export default function BoxWithButton(props) {
 
 exports[`amplify render tests custom render config should render common JS 1`] = `
 "\\"use strict\\";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
 Object.defineProperty(exports, \\"__esModule\\", { value: true });
 /* eslint-disable */
-const react_1 = require(\\"react\\");
+const react_1 = __importDefault(require(\\"react\\"));
 const ui_react_1 = require(\\"@aws-amplify/ui-react\\");
 function BoxWithButton(props) {
   return react_1.default.createElement(

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -180,6 +180,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
           target,
           module,
           jsx: script === ScriptKind.JS ? ts.JsxEmit.React : ts.JsxEmit.Preserve,
+          esModuleInterop: true,
         },
       }).outputText;
 


### PR DESCRIPTION
Resolves #77

Enable `esModuleInterop` to fix issue:

```
TypeError: Cannot read properties of undefined (reading 'createElement')

  11 | const ui_react_1 = require("@aws-amplify/ui-react");
  12 | function Frame1(props) {
  13 |   const {} = props;
> 14 |   return react_1.default.createElement(
  15 |     ui_react_1.View,
  16 |     Object.assign(
  17 |       {
```

See [typescript docs](https://www.typescriptlang.org/tsconfig#esModuleInterop)
for details.


The main difference this will add to generated components is the `__importDefault` shim.

```
var __importDefault =
  (this && this.__importDefault) ||
  function (mod) {
    return mod && mod.__esModule ? mod : { default: mod };
  };
const react_1 = __importDefault(require("react"));
```

With this shim `react_1.default` will not be `undefined`.
