### PR TITLE
build: remove __tests__ from dist

### DIFF
--- a/packages/studio-ui-codegen-react/package.json
+++ b/packages/studio-ui-codegen-react/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "build:watch": "npm run build -- --watch"
   },
   "devDependencies": {

--- a/packages/studio-ui-codegen-react/tsconfig.build.json
+++ b/packages/studio-ui-codegen-react/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "lib/__tests__/*"
+  ]
+}

--- a/packages/studio-ui-codegen/package.json
+++ b/packages/studio-ui-codegen/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "build:watch": "npm run build -- --watch"
   },
   "devDependencies": {

--- a/packages/studio-ui-codegen/tsconfig.build.json
+++ b/packages/studio-ui-codegen/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "lib/__tests__/*"
+  ]
+}

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -7,7 +7,7 @@
   "license": "ISC",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "build:watch": "npm run build -- --watch",
     "test": "echo \"No tests\""
   },

--- a/packages/test-generator/tsconfig.build.json
+++ b/packages/test-generator/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "lib/__tests__/*"
+  ]
+}


### PR DESCRIPTION
Prevent test files from being transpiled when building the package.

Based on suggestions here: https://stackoverflow.com/questions/35470511/setting-up-tsconfig-with-spec-test-folder

Testing
```
npm run build
```
Check `dist` directories. There should be no `__tests__` directories.
