### PR TITLE
chore: upgrade to trim-off-newlines@1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12307,9 +12307,9 @@
       }
     },
     "node_modules/trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.2.tgz",
+      "integrity": "sha512-DAnbtY4lNoOTLw05HLuvPoBFAGV4zOKQ9d1Q45JB+bcDwYIEkCr0xNgwKtygtKFBbRlFA/8ytkAM1V09QGWksg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -22708,9 +22708,9 @@
       "dev": true
     },
     "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.2.tgz",
+      "integrity": "sha512-DAnbtY4lNoOTLw05HLuvPoBFAGV4zOKQ9d1Q45JB+bcDwYIEkCr0xNgwKtygtKFBbRlFA/8ytkAM1V09QGWksg==",
       "dev": true
     },
     "ts-jest": {


### PR DESCRIPTION
Resolves #74

A new version of `trim-off-newlines` has been released that resolves the security risk.

https://github.com/stevemao/trim-off-newlines/pull/3
