### PR TITLE
chore: resolve some ansi-regex security risks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,6 @@
         "eslint-plugin-prettier": "^3.4.0",
         "husky": ">=6",
         "jest": "^27.0.6",
-        "jest-circus": "^27.0.6",
-        "jest-junit": "^12.2.0",
         "lerna": "^4.0.0",
         "prettier": "2.3.2",
         "rimraf": "^3.0.2",
@@ -7952,51 +7950,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/jest-junit": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.2.0.tgz",
-      "integrity": "sha512-ecGzF3KEQwLbMP5xMO7wqmgmyZlY/5yWDvgE/vFa+/uIT0KsU5nluf0D2fjIlOKB+tb6DiuSSpZuGpsmwbf7Fw==",
-      "dev": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "strip-ansi": "^5.2.0",
-        "uuid": "^8.3.2",
-        "xml": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/jest-junit/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jest-junit/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jest-junit/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "27.1.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
@@ -13057,12 +13010,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
-      "dev": true
     },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
@@ -19317,41 +19264,6 @@
         }
       }
     },
-    "jest-junit": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.2.0.tgz",
-      "integrity": "sha512-ecGzF3KEQwLbMP5xMO7wqmgmyZlY/5yWDvgE/vFa+/uIT0KsU5nluf0D2fjIlOKB+tb6DiuSSpZuGpsmwbf7Fw==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^1.0.4",
-        "strip-ansi": "^5.2.0",
-        "uuid": "^8.3.2",
-        "xml": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
-        }
-      }
-    },
     "jest-leak-detector": {
       "version": "27.1.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
@@ -23277,12 +23189,6 @@
       "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
       "dev": true,
       "requires": {}
-    },
-    "xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
-      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "eslint-plugin-prettier": "^3.4.0",
     "husky": ">=6",
     "jest": "^27.0.6",
-    "jest-circus": "^27.0.6",
-    "jest-junit": "^12.2.0",
     "lerna": "^4.0.0",
     "prettier": "2.3.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Resolves some risks from CVE-2021-3807.

The advisory is out of date. ansi-regex@5.0.1 has resolved the security risk. I am looking into how to report the advisory as inaccurate.

- upgrade to ansi-regex@5.0.1
- remove jest-junit and jest-circus
  - These packages are not used

Lerna is still pulling in ansi-regex@2.1.1 and ansi-regex@3.0.0. I have not found a way to upgrade these. We may need to wait for Lerna to upgrade, but I will look further.
