### PR TITLE
fix(studio-ui-codegen-react): collection items props takes precedent

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -77,6 +77,120 @@ export default function CustomText(props: CustomTextProps): JSX.Element {
 "
 `;
 
+exports[`amplify render tests collection should render collection with data binding 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import { User, UserPreferences } from \\"../models\\";
+import {
+  Button,
+  Collection,
+  EscapeHatchProps,
+  Flex,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type CollectionOfCustomButtonsProps = {
+  width?: Number,
+  backgroundColor?: String,
+  buttonColor?: UserPreferences,
+  items?: any[],
+} & {
+  overrides?: EscapeHatchProps | undefined | null,
+};
+export default function CollectionOfCustomButtons(
+  props: CollectionOfCustomButtonsProps
+): JSX.Element {
+  const { width, backgroundColor, buttonColor, items } = props;
+  const buttonUserFilter = {
+    and: [
+      { field: \\"age\\", operand: \\"10\\", operator: \\"gt\\" },
+      { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
+    ],
+  };
+  const displayedItems =
+    items !== undefined
+      ? items
+      : useDataStoreBinding({
+          type: \\"collection\\",
+          model: User,
+          criteria: buttonUserFilter,
+        }).buttonUser;
+  const buttonColorFilter = {
+    field: \\"userID\\",
+    operand: \\"user@email.com\\",
+    operator: \\"eq\\",
+  };
+  const { buttonColor } = useDataStoreBinding({
+    type: \\"record\\",
+    model: UserPreferences,
+    criteria: buttonColorFilter,
+  });
+  return (
+    <Collection
+      type=\\"list\\"
+      isPaginated={true}
+      gap=\\"1.5rem\\"
+      backgroundColor={backgroundColor}
+      items={displayedItems}
+      {...props}
+      {...getOverrideProps(props.overrides, \\"Collection\\")}
+    >
+      {(item, index) => (
+        <Flex {...getOverrideProps(props.overrides, \\"Collection.Flex\\")}>
+          <Button
+            label={item.username || \\"hspain@gmail.com\\"}
+            labelWidth={width}
+            backgroundColor={buttonColor.favoriteColor}
+            disabled={isDisabled}
+            {...getOverrideProps(props.overrides, \\"Collection.Flex.Button\\")}
+          ></Button>
+        </Flex>
+      )}
+    </Collection>
+  );
+}
+"
+`;
+
+exports[`amplify render tests collection should render collection without data binding 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import {
+  Collection,
+  EscapeHatchProps,
+  ListingCard,
+  findChildOverrides,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type ListingCardCollectionProps = {
+  items?: any[],
+} & {
+  overrides?: EscapeHatchProps | undefined | null,
+};
+export default function ListingCardCollection(
+  props: ListingCardCollectionProps
+): JSX.Element {
+  const { items } = props;
+  return (
+    <Collection
+      type=\\"list\\"
+      isPaginated=\\"true\\"
+      items={items}
+      {...props}
+      {...getOverrideProps(props.overrides, \\"Collection\\")}
+    >
+      {(item, index) => (
+        <ListingCard
+          {...findChildOverrides(props.overrides, \\"ListingCard\\")}
+        ></ListingCard>
+      )}
+    </Collection>
+  );
+}
+"
+`;
+
 exports[`amplify render tests complex component tests should generate a button within a box component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
@@ -284,77 +398,6 @@ export default function SectionHeading(
         subtitle
       </Text>
     </Flex>
-  );
-}
-"
-`;
-
-exports[`amplify render tests component with data binding should render collection data binding 1`] = `
-"/* eslint-disable */
-import React from \\"react\\";
-import { User, UserPreferences } from \\"../models\\";
-import {
-  Button,
-  Collection,
-  EscapeHatchProps,
-  Flex,
-  getOverrideProps,
-} from \\"@aws-amplify/ui-react\\";
-
-export type CollectionOfCustomButtonsProps = {
-  width?: Number,
-  backgroundColor?: String,
-  buttonColor?: UserPreferences,
-} & {
-  overrides?: EscapeHatchProps | undefined | null,
-};
-export default function CollectionOfCustomButtons(
-  props: CollectionOfCustomButtonsProps
-): JSX.Element {
-  const { width, backgroundColor, buttonColor } = props;
-  const buttonUserFilter = {
-    and: [
-      { field: \\"age\\", operand: \\"10\\", operator: \\"gt\\" },
-      { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
-    ],
-  };
-  const { buttonUser } = useDataStoreBinding({
-    type: \\"collection\\",
-    model: User,
-    criteria: buttonUserFilter,
-  });
-  const buttonColorFilter = {
-    field: \\"userID\\",
-    operand: \\"user@email.com\\",
-    operator: \\"eq\\",
-  };
-  const { buttonColor } = useDataStoreBinding({
-    type: \\"record\\",
-    model: UserPreferences,
-    criteria: buttonColorFilter,
-  });
-  return (
-    <Collection
-      type=\\"list\\"
-      isPaginated={true}
-      gap=\\"1.5rem\\"
-      backgroundColor={backgroundColor}
-      items={buttonUser}
-      {...props}
-      {...getOverrideProps(props.overrides, \\"Collection\\")}
-    >
-      {(item, index) => (
-        <Flex {...getOverrideProps(props.overrides, \\"Collection.Flex\\")}>
-          <Button
-            label={item.username || \\"hspain@gmail.com\\"}
-            labelWidth={width}
-            backgroundColor={buttonColor.favoriteColor}
-            disabled={isDisabled}
-            {...getOverrideProps(props.overrides, \\"Collection.Flex.Button\\")}
-          ></Button>
-        </Flex>
-      )}
-    </Collection>
   );
 }
 "

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -86,13 +86,20 @@ describe('amplify render tests', () => {
       expect(generatedCode).toMatchSnapshot();
     });
 
-    it('should render collection data binding', () => {
+    it('should not have useDataStoreBinding when there is no predicate', () => {
+      const generatedCode = generateWithAmplifyRenderer('dataBindingWithoutPredicate');
+      expect(generatedCode).toMatchSnapshot();
+    });
+  });
+
+  describe('collection', () => {
+    it('should render collection with data binding', () => {
       const generatedCode = generateWithAmplifyRenderer('collectionWithBinding');
       expect(generatedCode).toMatchSnapshot();
     });
 
-    it('should not have useDataStoreBinding when there is no predicate', () => {
-      const generatedCode = generateWithAmplifyRenderer('dataBindingWithoutPredicate');
+    it('should render collection without data binding', () => {
+      const generatedCode = generateWithAmplifyRenderer('collectionWithoutBinding');
       expect(generatedCode).toMatchSnapshot();
     });
   });

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/collectionWithoutBinding.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/collectionWithoutBinding.json
@@ -1,0 +1,26 @@
+{
+  "name": "ListingCardCollection",
+  "children": [
+    {
+      "children": [],
+      "name": "ListingCard",
+      "componentType": "ListingCard",
+      "properties": {},
+      "overrides": {},
+      "variants": []
+    }
+  ],
+  "id": "c-7m9oAaC8SO0M40Pnvu",
+  "bindingProperties": {},
+  "componentType": "Collection",
+  "properties": {
+    "type": {
+      "value": "list"
+    },
+    "isPaginated": {
+      "value": "true"
+    }
+  },
+  "overrides": {},
+  "variants": []
+}

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/collection.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/collection.ts
@@ -22,10 +22,10 @@ export default class CollectionRenderer extends ReactComponentWithChildrenRender
     return element;
   }
 
-  private findItemsVariableName(): string {
+  private findItemsVariableName(): string | undefined {
     const collectionProps = Object.entries(this.component.collectionProperties ?? {});
     const dataProps = collectionProps.filter((value) => isDataPropertyBinding(value[1]));
-    const modelName = dataProps.length > 0 ? dataProps[0][0] : 'items';
+    const modelName = dataProps.length > 0 ? dataProps[0][0] : undefined;
     return modelName;
   }
 

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -72,7 +72,7 @@ export abstract class ReactComponentWithChildrenRenderer<TPropIn> extends Compon
     factory: NodeFactory,
     props: StudioComponentProperties,
     tagName: string,
-    itemsVariableName: string,
+    itemsVariableName?: string,
   ): JsxOpeningElement {
     const propsArray: JsxAttribute[] = [];
     for (const propKey of Object.keys(props)) {
@@ -82,7 +82,7 @@ export abstract class ReactComponentWithChildrenRenderer<TPropIn> extends Compon
 
     const itemsAttribute = factory.createJsxAttribute(
       factory.createIdentifier('items'),
-      factory.createJsxExpression(undefined, factory.createIdentifier(itemsVariableName)),
+      factory.createJsxExpression(undefined, factory.createIdentifier(itemsVariableName ? 'displayedItems' : 'items')),
     );
     propsArray.push(itemsAttribute);
 

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -28,6 +28,7 @@ import ts, {
   BindingElement,
   Modifier,
   ObjectLiteralExpression,
+  CallExpression,
 } from 'typescript';
 import prettier from 'prettier';
 import parserBabel from 'prettier/parser-babel';
@@ -319,6 +320,15 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
         propSignatures.push(propSignature);
       }
     }
+    if (component.componentType === 'Collection') {
+      const propSignature = factory.createPropertySignature(
+        undefined,
+        'items',
+        factory.createToken(SyntaxKind.QuestionToken),
+        factory.createTypeReferenceNode('any[]', undefined),
+      );
+      propSignatures.push(propSignature);
+    }
     return factory.createTypeLiteralNode(propSignatures);
   }
 
@@ -339,6 +349,16 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
           elements.push(bindingElement);
         }
       });
+
+      if (component.componentType === 'Collection') {
+        const bindingElement = factory.createBindingElement(
+          undefined,
+          undefined,
+          factory.createIdentifier('items'),
+          undefined,
+        );
+        elements.push(bindingElement);
+      }
 
       const statement = factory.createVariableStatement(
         undefined,
@@ -386,9 +406,16 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
               statements.push(this.buildPredicateDeclaration(propName, bindingProperties.predicate));
               const { model } = bindingProperties;
               this.importCollection.addImport('../models', model);
-              this.buildUseDataStoreBindingCall('collection', propName, model).forEach((value) => {
-                statements.push(value);
-              });
+              statements.push(
+                this.buildPropPrecedentStatement(
+                  'displayedItems',
+                  'items',
+                  factory.createPropertyAccessExpression(
+                    this.buildUseDataStoreBindingCall('collection', propName, model),
+                    factory.createIdentifier('buttonUser'),
+                  ),
+                ),
+              );
             }
           }
         });
@@ -405,9 +432,29 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
             statements.push(this.buildPredicateDeclaration(propName, bindingProperties.predicate));
             const { model } = bindingProperties;
             this.importCollection.addImport('../models', model);
-            this.buildUseDataStoreBindingCall('record', propName, model).forEach((value) => {
-              statements.push(value);
-            });
+            statements.push(
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createObjectBindingPattern([
+                        factory.createBindingElement(
+                          undefined,
+                          undefined,
+                          factory.createIdentifier(propName),
+                          undefined,
+                        ),
+                      ]),
+                      undefined,
+                      undefined,
+                      this.buildUseDataStoreBindingCall('record', propName, model),
+                    ),
+                  ],
+                  ts.NodeFlags.Const,
+                ),
+              ),
+            );
           }
         }
       });
@@ -415,45 +462,51 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     return statements;
   }
 
-  private buildUseDataStoreBindingCall(callType: string, propName: string, bindingModel: string): VariableStatement[] {
-    const statements: VariableStatement[] = [];
-    statements.push(
-      factory.createVariableStatement(
-        undefined,
-        factory.createVariableDeclarationList(
-          [
-            factory.createVariableDeclaration(
-              factory.createObjectBindingPattern([
-                factory.createBindingElement(undefined, undefined, factory.createIdentifier(propName), undefined),
-              ]),
-              undefined,
-              undefined,
-              factory.createCallExpression(factory.createIdentifier('useDataStoreBinding'), undefined, [
-                factory.createObjectLiteralExpression(
-                  [
-                    factory.createPropertyAssignment(
-                      factory.createIdentifier('type'),
-                      factory.createStringLiteral(callType),
-                    ),
-                    factory.createPropertyAssignment(
-                      factory.createIdentifier('model'),
-                      factory.createIdentifier(bindingModel),
-                    ),
-                    factory.createPropertyAssignment(
-                      factory.createIdentifier('criteria'),
-                      factory.createIdentifier(this.getFilterName(propName)),
-                    ),
-                  ],
-                  true,
-                ),
-              ]),
+  private buildPropPrecedentStatement(
+    precedentName: string,
+    propName: string,
+    defaultExpression: any,
+  ): VariableStatement {
+    return factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier(precedentName),
+            undefined,
+            undefined,
+            factory.createConditionalExpression(
+              factory.createBinaryExpression(
+                factory.createIdentifier(propName),
+                factory.createToken(ts.SyntaxKind.ExclamationEqualsEqualsToken),
+                factory.createIdentifier('undefined'),
+              ),
+              factory.createToken(ts.SyntaxKind.QuestionToken),
+              factory.createIdentifier(propName),
+              factory.createToken(ts.SyntaxKind.ColonToken),
+              defaultExpression,
             ),
-          ],
-          ts.NodeFlags.Const,
-        ),
+          ),
+        ],
+        ts.NodeFlags.Const,
       ),
     );
-    return statements;
+  }
+
+  private buildUseDataStoreBindingCall(callType: string, propName: string, bindingModel: string): CallExpression {
+    return factory.createCallExpression(factory.createIdentifier('useDataStoreBinding'), undefined, [
+      factory.createObjectLiteralExpression(
+        [
+          factory.createPropertyAssignment(factory.createIdentifier('type'), factory.createStringLiteral(callType)),
+          factory.createPropertyAssignment(factory.createIdentifier('model'), factory.createIdentifier(bindingModel)),
+          factory.createPropertyAssignment(
+            factory.createIdentifier('criteria'),
+            factory.createIdentifier(this.getFilterName(propName)),
+          ),
+        ],
+        true,
+      ),
+    ]);
   }
 
   private predicateToObjectLiteralExpression(predicate: StudioComponentPredicate): ObjectLiteralExpression {


### PR DESCRIPTION
Resolves #90

* Explicitly pass items when there is no binding
* `items` prop take precedent over `useDataStoreBinding`

See snapshot tests for examples
