### PR TITLE
fix: collection binding with no predicate

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -152,6 +152,60 @@ export default function CollectionOfCustomButtons(
 "
 `;
 
+exports[`amplify render tests collection should render collection with data binding with no predicate 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import {
+  Collection,
+  EscapeHatchProps,
+  ListingCard,
+  findChildOverrides,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+import { UntitledModel } from \\"../models\\";
+
+export type ListingCardCollectionProps = {
+  items?: any[],
+} & {
+  overrides?: EscapeHatchProps | undefined | null,
+};
+export default function ListingCardCollection(
+  props: ListingCardCollectionProps
+): JSX.Element {
+  const { items } = props;
+  const displayedItems =
+    items !== undefined
+      ? items
+      : useDataStoreBinding({
+          type: \\"collection\\",
+          model: UntitledModel,
+        }).bananas;
+  return (
+    <Collection
+      isPaginated=\\"true\\"
+      collectionType=\\"grid\\"
+      type=\\"list\\"
+      columns=\\"2\\"
+      order=\\"left-to-right\\"
+      items={displayedItems}
+      {...props}
+      {...getOverrideProps(props.overrides, \\"Collection\\")}
+    >
+      {(item, index) => (
+        <ListingCard
+          marginRight=\\"0\\"
+          marginBottom=\\"0\\"
+          marginTop=\\"0\\"
+          marginLeft=\\"0\\"
+          {...findChildOverrides(props.overrides, \\"ListingCard\\")}
+        ></ListingCard>
+      )}
+    </Collection>
+  );
+}
+"
+`;
+
 exports[`amplify render tests collection should render collection without data binding 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -102,6 +102,11 @@ describe('amplify render tests', () => {
       const generatedCode = generateWithAmplifyRenderer('collectionWithoutBinding');
       expect(generatedCode).toMatchSnapshot();
     });
+
+    it('should render collection with data binding with no predicate', () => {
+      const generatedCode = generateWithAmplifyRenderer('collectionWithBindingWithoutPredicate');
+      expect(generatedCode).toMatchSnapshot();
+    });
   });
 
   describe('component with binding', () => {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/collectionWithBindingWithoutPredicate.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/collectionWithBindingWithoutPredicate.json
@@ -1,0 +1,56 @@
+{
+  "name": "ListingCardCollection",
+  "children": [
+    {
+      "children": [],
+      "name": "ListingCard",
+      "componentType": "ListingCard",
+      "properties": {
+        "marginRight": {
+          "value": "0"
+        },
+        "marginBottom": {
+          "value": "0"
+        },
+        "marginTop": {
+          "value": "0"
+        },
+        "marginLeft": {
+          "value": "0"
+        }
+      },
+      "overrides": {},
+      "variants": []
+    }
+  ],
+  "id": "c-7m9oAaC8SO0M40Pnvu",
+  "bindingProperties": {},
+  "componentType": "Collection",
+  "properties": {
+    "isPaginated": {
+      "value": "true"
+    },
+    "collectionType": {
+      "value": "grid"
+    },
+    "type": {
+      "value": "list"
+    },
+    "columns": {
+      "value": "2"
+    },
+    "order": {
+      "value": "left-to-right"
+    }
+  },
+  "overrides": {},
+  "variants": [],
+  "collectionProperties": {
+    "bananas": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "UntitledModel"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The binding properites for collections was not working correctly when a predicate was not used.

See snapshots for examples.
