### PR TITLE
fix: use correct identifier when using useDataStoreBinding

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -107,20 +107,20 @@ export default function CollectionOfCustomButtons(
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };
-  const displayedItems =
+  const buttonUser =
     items !== undefined
       ? items
       : useDataStoreBinding({
           type: \\"collection\\",
           model: User,
           criteria: buttonUserFilter,
-        }).buttonUser;
+        }).items;
   const buttonColorFilter = {
     field: \\"userID\\",
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
-  const { buttonColor } = useDataStoreBinding({
+  const { item: buttonColor } = useDataStoreBinding({
     type: \\"record\\",
     model: UserPreferences,
     criteria: buttonColorFilter,
@@ -131,7 +131,7 @@ export default function CollectionOfCustomButtons(
       isPaginated={true}
       gap=\\"1.5rem\\"
       backgroundColor={backgroundColor}
-      items={displayedItems}
+      items={buttonUser}
       {...props}
       {...getOverrideProps(props.overrides, \\"Collection\\")}
     >
@@ -173,13 +173,13 @@ export default function ListingCardCollection(
   props: ListingCardCollectionProps
 ): JSX.Element {
   const { items } = props;
-  const displayedItems =
+  const bananas =
     items !== undefined
       ? items
       : useDataStoreBinding({
           type: \\"collection\\",
           model: UntitledModel,
-        }).bananas;
+        }).items;
   return (
     <Collection
       isPaginated=\\"true\\"
@@ -187,7 +187,7 @@ export default function ListingCardCollection(
       type=\\"list\\"
       columns=\\"2\\"
       order=\\"left-to-right\\"
-      items={displayedItems}
+      items={bananas}
       {...props}
       {...getOverrideProps(props.overrides, \\"Collection\\")}
     >

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -82,7 +82,7 @@ export abstract class ReactComponentWithChildrenRenderer<TPropIn> extends Compon
 
     const itemsAttribute = factory.createJsxAttribute(
       factory.createIdentifier('items'),
-      factory.createJsxExpression(undefined, factory.createIdentifier(itemsVariableName ? 'displayedItems' : 'items')),
+      factory.createJsxExpression(undefined, factory.createIdentifier(itemsVariableName || 'items')),
     );
     propsArray.push(itemsAttribute);
 

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -408,7 +408,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
             this.importCollection.addImport('../models', model);
             statements.push(
               this.buildPropPrecedentStatement(
-                'displayedItems',
+                propName,
                 'items',
                 factory.createPropertyAccessExpression(
                   this.buildUseDataStoreBindingCall(
@@ -416,7 +416,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                     model,
                     bindingProperties.predicate ? this.getFilterName(propName) : undefined,
                   ),
-                  factory.createIdentifier(propName),
+                  'items',
                 ),
               ),
             );
@@ -444,7 +444,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                       factory.createObjectBindingPattern([
                         factory.createBindingElement(
                           undefined,
-                          undefined,
+                          factory.createIdentifier('item'),
                           factory.createIdentifier(propName),
                           undefined,
                         ),


### PR DESCRIPTION
Looking at the PR for `useDataStoreBinding` it appears that the golden file (and codegen) is off.
https://github.com/aws-amplify/amplify-ui/pull/418/files#diff-78fd8656c9b68a3d3d93c93d975912ac7b5c8751beb3d7885b1df7f25cc911b6R42

Codegen set the identifier as the name of collection property. https://code.amazon.com/packages/AmplifyStudioCommon/blobs/0bdd98916ce175a739eb7c3d8e992f2b9174c096/--/component_golden_files/react/collection-with-data-binding.tsx#L26

But it is clear it would not be possible for the `useDataStoreBinding` to know this.

This PR updates to the correct usage of `useDataStoreBinding`.

Update to golden files: https://code.amazon.com/reviews/CR-58177760