### PR TITLE
fix: enable info level logging, convert test-generator output to markdown

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'packages/ui-react-types',
     'packages/amplify-ui-codegen-schema',
     'ui-components',
+    '*.md',
   ],
   extends: [
     'plugin:@typescript-eslint/recommended',

--- a/packages/test-generator/README.md
+++ b/packages/test-generator/README.md
@@ -1,11 +1,16 @@
-# `sample-renderer`
+# `test-renderer`
 
-> TODO: description
+This package can be used to render out sample files using the renderers provided in `studio-ui-codegen-react`.
 
 ## Usage
 
-```
-const sampleRenderer = require('sample-renderer');
+Test components will be rendered with both source and usage docs to STDOUT as markdown.
 
-// TODO: DEMONSTRATE API
+```sh
+# Build the package from repo root.
+lerna bootstrap
+lerna run build
+# And either render to STDOUT or a file
+node packages/test-generator/dist/index.js
+node packages/test-generator/dist/index.js > test-generator-output.md
 ```

--- a/packages/test-generator/index.ts
+++ b/packages/test-generator/index.ts
@@ -9,6 +9,8 @@ import * as schemas from './lib';
 
 Error.stackTraceLimit = Infinity;
 
+log.setLevel('info');
+
 const renderConfig: ReactRenderConfig = {
   module: ModuleKind.CommonJS,
   target: ScriptTarget.ES2015,
@@ -23,28 +25,33 @@ const outputPathDir = path.resolve(path.join(__dirname, '..', 'ui-components'));
 const outputConfig: ReactOutputConfig = {
   outputPathDir,
 };
+
+const decorateTypescriptWithMarkdown = (typescriptSource: string): string => {
+  return `\`\`\`typescript jsx\n${typescriptSource}\n\`\`\``;
+};
+
 const rendererManager = new StudioTemplateRendererManager(rendererFactory, outputConfig);
 Object.entries(schemas).forEach(([name, schema]) => {
-  log.info(name);
+  log.info(`# ${name}`);
   try {
     rendererManager.renderSchemaToTemplate(schema as any);
     const buildRenderer = rendererFactory.buildRenderer(schema as any);
 
     const compOnly = buildRenderer.renderComponentOnly();
-    log.info('Component Only Output');
-    log.info('componentImports ');
-    log.info(compOnly.importsText);
-    log.info('componentText ');
-    log.info(compOnly.compText);
+    log.info('## Component Only Output');
+    log.info('### componentImports');
+    log.info(decorateTypescriptWithMarkdown(compOnly.importsText));
+    log.info('### componentText');
+    log.info(decorateTypescriptWithMarkdown(compOnly.compText));
 
     const compOnlyAppSample = buildRenderer.renderSampleCodeSnippet();
-    log.info('Code Snippet Output');
-    log.info('componentImports ');
-    log.info(compOnlyAppSample.importsText);
-    log.info('componentText ');
-    log.info(compOnlyAppSample.compText);
+    log.info('## Code Snippet Output');
+    log.info('### componentImports');
+    log.info(decorateTypescriptWithMarkdown(compOnlyAppSample.importsText));
+    log.info('### componentText');
+    log.info(decorateTypescriptWithMarkdown(compOnlyAppSample.compText));
   } catch (err) {
-    log.info(`${name} failed with error:`);
-    log.info(err);
+    log.error(`${name} failed with error:`);
+    log.error(err);
   }
 });


### PR DESCRIPTION
Also, had to add markdown files to eslint ignore since it was complaining about my edit to the `README.md` file.
Example from logged output below.

# ComponentWithDataBinding

## Component Only Output
### componentImports
```typescript jsx
import React from "react";
import { User } from "../models";
import { Button, getOverrideProps } from "@aws-amplify/ui-react";

```
### componentText
```typescript jsx
function ComponentWithDataBinding(props) {
  const { width, isDisabled, buttonUser, buttonColor } = props;
  return React.createElement(
    Button,
    Object.assign(
      {
        label: buttonUser.username || "hspain@gmail.com",
        labelWidth: width,
        disabled: isDisabled,
      },
      props,
      getOverrideProps(props.overrides, "Button")
    )
  );
}

```
## Code Snippet Output
### componentImports
```typescript jsx
import { ComponentWithDataBinding } from "./studio-ui";

```
### componentText
```typescript jsx
export const App = () => {
    return (<ComponentWithDataBinding></ComponentWithDataBinding>);
};
```