### PR TITLE
chore: add support for sort config in collectionProperties

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -245,6 +245,90 @@ export default function ListingCardCollection(
 "
 `;
 
+exports[`amplify render tests collection should render collection with data binding and sort 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import { User, UserPreferences } from \\"../models\\";
+import {
+  Button,
+  Collection,
+  EscapeHatchProps,
+  Flex,
+  convertSortPredicatesToDataStore,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type CollectionOfCustomButtonsProps = {
+  width?: Number,
+  backgroundColor?: String,
+  buttonColor?: UserPreferences,
+  items?: any[],
+} & {
+  overrides?: EscapeHatchProps | undefined | null,
+};
+export default function CollectionOfCustomButtons(
+  props: CollectionOfCustomButtonsProps
+): JSX.Element {
+  const { width, backgroundColor, buttonColor, items } = props;
+  const buttonUserFilter = {
+    and: [
+      { field: \\"age\\", operand: \\"10\\", operator: \\"gt\\" },
+      { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
+    ],
+  };
+  const buttonUserSort = convertSortPredicatesToDataStore([
+    { field: \\"firstName\\", direction: \\"ASC\\" },
+    { field: \\"lastName\\", direction: \\"DESC\\" },
+  ]);
+  const buttonUserPagination = {
+    sort: buttonUserSort,
+  };
+  const buttonUser =
+    items !== undefined
+      ? items
+      : useDataStoreBinding({
+          type: \\"collection\\",
+          model: User,
+          criteria: buttonUserFilter,
+          pagination: buttonUserPagination,
+        }).items;
+  const buttonColorFilter = {
+    field: \\"userID\\",
+    operand: \\"user@email.com\\",
+    operator: \\"eq\\",
+  };
+  const { item: buttonColor } = useDataStoreBinding({
+    type: \\"record\\",
+    model: UserPreferences,
+    criteria: buttonColorFilter,
+  });
+  return (
+    <Collection
+      type=\\"list\\"
+      isPaginated={true}
+      gap=\\"1.5rem\\"
+      backgroundColor={backgroundColor}
+      items={buttonUser}
+      {...props}
+      {...getOverrideProps(props.overrides, \\"Collection\\")}
+    >
+      {(item, index) => (
+        <Flex {...getOverrideProps(props.overrides, \\"Collection.Flex\\")}>
+          <Button
+            label={item.username || \\"hspain@gmail.com\\"}
+            labelWidth={width}
+            backgroundColor={buttonColor.favoriteColor}
+            disabled={isDisabled}
+            {...getOverrideProps(props.overrides, \\"Collection.Flex.Button\\")}
+          ></Button>
+        </Flex>
+      )}
+    </Collection>
+  );
+}
+"
+`;
+
 exports[`amplify render tests complex component tests should generate a button within a box component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -107,6 +107,11 @@ describe('amplify render tests', () => {
       const generatedCode = generateWithAmplifyRenderer('collectionWithBindingWithoutPredicate');
       expect(generatedCode).toMatchSnapshot();
     });
+
+    it('should render collection with data binding and sort', () => {
+      const generatedCode = generateWithAmplifyRenderer('collectionWithBindingAndSort');
+      expect(generatedCode).toMatchSnapshot();
+    });
   });
 
   describe('concat and conditional transform', () => {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/collectionWithBindingAndSort.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/collectionWithBindingAndSort.json
@@ -1,0 +1,105 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Collection",
+  "name": "CollectionOfCustomButtons",
+  "properties": {
+    "type": {
+      "value": "list"
+    },
+    "isPaginated": {
+      "value": true
+    },
+    "gap": {
+      "value": "1.5rem"
+    },
+    "backgroundColor": {
+      "bindingProperties": {
+        "property": "backgroundColor"
+      }
+    }
+  },
+  "bindingProperties": {
+    "width": {
+      "type": "Number"
+    },
+    "backgroundColor": {
+      "type": "String"
+    },
+    "buttonColor": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "UserPreferences",
+        "predicate": {
+          "field": "userID",
+          "operand": "user@email.com",
+          "operator": "eq"
+        }
+      }
+    }
+  },
+  "collectionProperties": {
+    "buttonUser": {
+      "model": "User",
+      "sort": [
+        {
+          "field": "firstName",
+          "direction": "ASC"
+        },
+        {
+          "field": "lastName",
+          "direction": "DESC"
+        }
+      ],
+      "predicate": {
+        "and": [
+          {
+            "field": "age",
+            "operand": "10",
+            "operator": "gt"
+          },
+          {
+            "field": "lastName",
+            "operand": "L",
+            "operator": "beginsWith"
+          }
+        ]
+      }
+    }
+  },
+  "children": [
+    {
+      "componentType": "Flex",
+      "properties": {},
+      "children": [
+        {
+          "componentType": "Button",
+          "properties": {
+            "label": {
+              "collectionBindingProperties": {
+                "property": "buttonUser",
+                "field": "username"
+              },
+              "defaultValue": "hspain@gmail.com"
+            },
+            "labelWidth": {
+              "bindingProperties": {
+                "property": "width"
+              }
+            },
+            "backgroundColor": {
+              "bindingProperties": {
+                "property": "buttonColor",
+                "field": "favoriteColor"
+              }
+            },
+            "disabled": {
+              "bindingProperties": {
+                "property": "isDisabled"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -2,6 +2,7 @@ import {
   StudioComponent,
   StudioComponentPredicate,
   StudioComponentAuthPropertyBinding,
+  StudioComponentSort,
 } from '@amzn/amplify-ui-codegen-schema';
 import {
   StudioTemplateRenderer,
@@ -454,11 +455,17 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     if (isStudioComponentWithCollectionProperties(component)) {
       Object.entries(component.collectionProperties).forEach((collectionProp) => {
-        const [propName, bindingProperties] = collectionProp;
-        if ('predicate' in bindingProperties && bindingProperties.predicate !== undefined) {
-          statements.push(this.buildPredicateDeclaration(propName, bindingProperties.predicate));
+        const [propName, { model, sort, predicate }] = collectionProp;
+        if (predicate) {
+          statements.push(this.buildPredicateDeclaration(propName, predicate));
         }
-        const { model } = bindingProperties;
+        if (sort) {
+          this.importCollection.addImport('@aws-amplify/ui-react', 'convertSortPredicatesToDataStore');
+          statements.push(
+            this.buildSortStatement(propName, sort),
+            this.buildPaginationStatement(propName, this.getSortName(propName)),
+          );
+        }
         this.importCollection.addImport('../models', model);
         statements.push(
           this.buildPropPrecedentStatement(
@@ -468,7 +475,8 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
               this.buildUseDataStoreBindingCall(
                 'collection',
                 model,
-                bindingProperties.predicate ? this.getFilterName(propName) : undefined,
+                predicate ? this.getFilterName(propName) : undefined,
+                sort ? this.getPaginationName(propName) : undefined,
               ),
               'items',
             ),
@@ -554,20 +562,88 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     );
   }
 
-  private buildUseDataStoreBindingCall(callType: string, bindingModel: string, predicateName?: string): CallExpression {
+  private buildSortStatement(propName: string, sort: StudioComponentSort[]): VariableStatement {
+    return factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier(this.getSortName(propName)),
+            undefined,
+            undefined,
+            this.buildConvertSortPredicatesToDataStoreCall(sort),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    );
+  }
+
+  private buildConvertSortPredicatesToDataStoreCall(sort: StudioComponentSort[]): CallExpression {
+    const sortExpressions = sort.map(({ field, direction }) =>
+      factory.createObjectLiteralExpression([
+        factory.createPropertyAssignment(factory.createIdentifier('field'), factory.createStringLiteral(field)),
+        factory.createPropertyAssignment(factory.createIdentifier('direction'), factory.createStringLiteral(direction)),
+      ]),
+    );
+
+    return factory.createCallExpression(factory.createIdentifier('convertSortPredicatesToDataStore'), undefined, [
+      factory.createArrayLiteralExpression(sortExpressions, true),
+    ]);
+  }
+
+  private buildPaginationStatement(propName: string, sortName?: string): VariableStatement {
+    const paginationProperties = ([] as ts.PropertyAssignment[]).concat(
+      sortName
+        ? [factory.createPropertyAssignment(factory.createIdentifier('sort'), factory.createIdentifier(sortName))]
+        : [],
+    );
+    return factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier(this.getPaginationName(propName)),
+            undefined,
+            undefined,
+            factory.createObjectLiteralExpression(paginationProperties, true),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    );
+  }
+
+  private buildUseDataStoreBindingCall(
+    callType: string,
+    bindingModel: string,
+    criteriaName?: string,
+    paginationName?: string,
+  ): CallExpression {
     const objectProperties = [
       factory.createPropertyAssignment(factory.createIdentifier('type'), factory.createStringLiteral(callType)),
       factory.createPropertyAssignment(factory.createIdentifier('model'), factory.createIdentifier(bindingModel)),
-    ].concat(
-      predicateName
-        ? [
-            factory.createPropertyAssignment(
-              factory.createIdentifier('criteria'),
-              factory.createIdentifier(predicateName),
-            ),
-          ]
-        : [],
-    );
+    ]
+      .concat(
+        criteriaName
+          ? [
+              factory.createPropertyAssignment(
+                factory.createIdentifier('criteria'),
+                factory.createIdentifier(criteriaName),
+              ),
+            ]
+          : [],
+      )
+      .concat(
+        paginationName
+          ? [
+              factory.createPropertyAssignment(
+                factory.createIdentifier('pagination'),
+                factory.createIdentifier(paginationName),
+              ),
+            ]
+          : [],
+      );
 
     return factory.createCallExpression(factory.createIdentifier('useDataStoreBinding'), undefined, [
       factory.createObjectLiteralExpression(objectProperties, true),
@@ -607,6 +683,14 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
         ts.NodeFlags.Const,
       ),
     );
+  }
+
+  private getSortName(propName: string): string {
+    return `${propName}Sort`;
+  }
+
+  private getPaginationName(propName: string): string {
+    return `${propName}Pagination`;
   }
 
   private getFilterName(propName: string): string {


### PR DESCRIPTION
Added a new test case to demonstrate usage, and adding dependency in generated sort code on `convertSortPredicatesToDataStore` which I'm working on a PR for over in the @aws-amplify/ui-react package.