### PR TITLE
feat: output type declaration

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -12,7 +12,7 @@ import {
 export type TestProps = {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function Test(props: TestProps): JSX.Element {
+export default function Test(props: TestProps): React.Element {
   const overrides = { ...props.overrides };
   return (
     <View
@@ -38,7 +38,7 @@ import {
 export type CustomButtonProps = {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function CustomButton(props: CustomButtonProps): JSX.Element {
+export default function CustomButton(props: CustomButtonProps): React.Element {
   const overrides = { ...props.overrides };
   return (
     <Button
@@ -64,7 +64,7 @@ import {
 export type CustomTextProps = {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function CustomText(props: CustomTextProps): JSX.Element {
+export default function CustomText(props: CustomTextProps): React.Element {
   const overrides = { ...props.overrides };
   return (
     <Text
@@ -102,7 +102,7 @@ export type CollectionOfCustomButtonsProps = {
 };
 export default function CollectionOfCustomButtons(
   props: CollectionOfCustomButtonsProps
-): JSX.Element {
+): React.Element {
   const { width, backgroundColor, buttonColor, items } = props;
   const overrides = { ...props.overrides };
   const buttonUserFilter = {
@@ -157,7 +157,8 @@ export default function CollectionOfCustomButtons(
 `;
 
 exports[`amplify render tests collection should render collection with data binding and sort 1`] = `
-"/* eslint-disable */
+Object {
+  "componentText": "/* eslint-disable */
 import React from \\"react\\";
 import { User, UserPreferences } from \\"../models\\";
 import {
@@ -179,7 +180,7 @@ export type CollectionOfCustomButtonsProps = {
 };
 export default function CollectionOfCustomButtons(
   props: CollectionOfCustomButtonsProps
-): JSX.Element {
+): React.Element {
   const { width, backgroundColor, buttonColor, items } = props;
   const overrides = { ...props.overrides };
   const buttonUserFilter = {
@@ -235,7 +236,10 @@ export default function CollectionOfCustomButtons(
     </Collection>
   );
 }
-"
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
 `;
 
 exports[`amplify render tests collection should render collection with data binding with no predicate 1`] = `
@@ -257,7 +261,7 @@ export type ListingCardCollectionProps = {
 };
 export default function ListingCardCollection(
   props: ListingCardCollectionProps
-): JSX.Element {
+): React.Element {
   const { items } = props;
   const overrides = { ...props.overrides };
   const bananas =
@@ -311,7 +315,7 @@ export type ListingCardCollectionProps = {
 };
 export default function ListingCardCollection(
   props: ListingCardCollectionProps
-): JSX.Element {
+): React.Element {
   const { items } = props;
   const overrides = { ...props.overrides };
   return (
@@ -346,7 +350,9 @@ import {
 export type BoxWithButtonProps = {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
+export default function BoxWithButton(
+  props: BoxWithButtonProps
+): React.Element {
   const overrides = { ...props.overrides };
   return (
     <View {...props} {...getOverrideProps(overrides, \\"Box\\")}>
@@ -377,7 +383,7 @@ export type BoxWithCustomButtonProps = {
 };
 export default function BoxWithCustomButton(
   props: BoxWithCustomButtonProps
-): JSX.Element {
+): React.Element {
   const overrides = { ...props.overrides };
   return (
     <View {...props} {...getOverrideProps(overrides, \\"Box\\")}>
@@ -405,7 +411,9 @@ import {
 export type BoxWithButtonProps = {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
+export default function BoxWithButton(
+  props: BoxWithButtonProps
+): React.Element {
   const overrides = { ...props.overrides };
   return (
     <View {...props} {...getOverrideProps(overrides, \\"Box\\")}>
@@ -436,7 +444,7 @@ export type TextWithDataBindingProps = {
 };
 export default function TextWithDataBinding(
   props: TextWithDataBindingProps
-): JSX.Element {
+): React.Element {
   const { textValue } = props;
   const overrides = { ...props.overrides };
   return (
@@ -473,7 +481,7 @@ export type ComponentWithDataBindingProps = {
 };
 export default function ComponentWithDataBinding(
   props: ComponentWithDataBindingProps
-): JSX.Element {
+): React.Element {
   const { width, isDisabled, buttonUser, buttonColor } = props;
   const overrides = { ...props.overrides };
   return (
@@ -507,7 +515,7 @@ export type SectionHeadingProps = {
 };
 export default function SectionHeading(
   props: SectionHeadingProps
-): JSX.Element {
+): React.Element {
   const { newProp6fd1 } = props;
   const overrides = { ...props.overrides };
   return (
@@ -552,7 +560,8 @@ export default function SectionHeading(
 `;
 
 exports[`amplify render tests component with variants should render variants with options provided 1`] = `
-"/* eslint-disable */
+Object {
+  "componentText": "/* eslint-disable */
 import React from \\"react\\";
 import {
   Button,
@@ -567,7 +576,7 @@ export type CustomButtonProps = {
 } & {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function CustomButton(props: CustomButtonProps): JSX.Element {
+export default function CustomButton(props: CustomButtonProps): React.Element {
   const {} = props;
   const variants = [
     {
@@ -610,7 +619,10 @@ export default function CustomButton(props: CustomButtonProps): JSX.Element {
     <Button {...props} {...getOverrideProps(overrides, \\"Button\\")}></Button>
   );
 }
-"
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
 `;
 
 exports[`amplify render tests concat and conditional transform should render component with concatenation prop 1`] = `
@@ -630,7 +642,7 @@ export type CustomButtonProps = {
 } & {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function CustomButton(props: CustomButtonProps): JSX.Element {
+export default function CustomButton(props: CustomButtonProps): React.Element {
   const { width, buttonUser, buttonColor } = props;
   const overrides = { ...props.overrides };
   return (
@@ -664,7 +676,7 @@ export type CustomButtonProps = {
 } & {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function CustomButton(props: CustomButtonProps): JSX.Element {
+export default function CustomButton(props: CustomButtonProps): React.Element {
   const { width, buttonUser, buttonColor } = props;
   const overrides = { ...props.overrides };
   return (
@@ -776,6 +788,16 @@ exports.default = BoxWithButton;
 "
 `;
 
+exports[`amplify render tests declarations should render declarations 1`] = `
+"import React from \\"react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react\\";
+export declare type ProfileProps = {
+    overrides?: EscapeHatchProps | undefined | null;
+};
+export default function Profile(props: ProfileProps): React.Element;
+"
+`;
+
 exports[`amplify render tests sample code snippet tests should generate a sample code snippet for components 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
@@ -790,7 +812,9 @@ import {
 export type BoxWithButtonProps = {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function BoxWithButton(props: BoxWithButtonProps): JSX.Element {
+export default function BoxWithButton(
+  props: BoxWithButtonProps
+): React.Element {
   const overrides = { ...props.overrides };
   return (
     <View padding-left {...props} {...getOverrideProps(overrides, \\"Box\\")}>
@@ -1007,7 +1031,7 @@ import {
 export type ProfileProps = {
   overrides?: EscapeHatchProps | undefined | null,
 };
-export default function Profile(props: ProfileProps): JSX.Element {
+export default function Profile(props: ProfileProps): React.Element {
   const {} = props;
   const overrides = { ...props.overrides };
   const {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -22,15 +22,15 @@ function generateWithAmplifyRenderer(
   jsonSchemaFile: string,
   renderConfig: ReactRenderConfig = {},
   isSampleCodeSnippet = false,
-): string {
+): { componentText: string; declaration?: string } {
   const schema = loadSchemaFromJSONFile(jsonSchemaFile);
   const rendererFactory = new StudioTemplateRendererFactory(
     (component: StudioComponent) => new AmplifyRenderer(component, renderConfig),
   );
   if (isSampleCodeSnippet) {
-    return rendererFactory.buildRenderer(schema).renderSampleCodeSnippet().compText;
+    return { componentText: rendererFactory.buildRenderer(schema).renderSampleCodeSnippet().compText };
   }
-  return rendererFactory.buildRenderer(schema).renderComponent().componentText;
+  return rendererFactory.buildRenderer(schema).renderComponent();
 }
 
 function generateWithThemeRenderer(jsonFile: string, renderConfig: ReactRenderConfig = {}): string {
@@ -45,17 +45,17 @@ describe('amplify render tests', () => {
   describe('basic component tests', () => {
     it('should generate a simple box component', () => {
       const generatedCode = generateWithAmplifyRenderer('boxTest');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should generate a simple button component', () => {
       const generatedCode = generateWithAmplifyRenderer('buttonGolden');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should generate a simple text component', () => {
       const generatedCode = generateWithAmplifyRenderer('textGolden');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should generate a simple badge component', () => {});
@@ -74,53 +74,53 @@ describe('amplify render tests', () => {
   describe('complex component tests', () => {
     it('should generate a button within a box component', () => {
       const generatedCode = generateWithAmplifyRenderer('boxGolden');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should generate a component with custom child', () => {
       const generatedCode = generateWithAmplifyRenderer('customChild');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should generate a component with exposeAs prop', () => {
       const generatedCode = generateWithAmplifyRenderer('exposedAsTest');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
   });
 
   describe('sample code snippet tests', () => {
     it('should generate a sample code snippet for components', () => {
       const generatedCode = generateWithAmplifyRenderer('sampleCodeSnippet');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
   });
 
   describe('component with data binding', () => {
     it('should add model imports', () => {
       const generatedCode = generateWithAmplifyRenderer('componentWithDataBinding');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should not have useDataStoreBinding when there is no predicate', () => {
       const generatedCode = generateWithAmplifyRenderer('dataBindingWithoutPredicate');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
   });
 
   describe('collection', () => {
     it('should render collection with data binding', () => {
       const generatedCode = generateWithAmplifyRenderer('collectionWithBinding');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should render collection without data binding', () => {
       const generatedCode = generateWithAmplifyRenderer('collectionWithoutBinding');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should render collection with data binding with no predicate', () => {
       const generatedCode = generateWithAmplifyRenderer('collectionWithBindingWithoutPredicate');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should render collection with data binding and sort', () => {
@@ -132,19 +132,19 @@ describe('amplify render tests', () => {
   describe('concat and conditional transform', () => {
     it('should render component with concatenation prop', () => {
       const generatedCode = generateWithAmplifyRenderer('concatTest');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
 
     it('should render component with conditional prop', () => {
       const generatedCode = generateWithAmplifyRenderer('conditionalTest');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
   });
 
   describe('component with binding', () => {
     it('should render build property on Text', () => {
       const generatedCode = generateWithAmplifyRenderer('textWithDataBinding');
-      expect(generatedCode).toMatchSnapshot();
+      expect(generatedCode.componentText).toMatchSnapshot();
     });
   });
 
@@ -158,24 +158,35 @@ describe('amplify render tests', () => {
   describe('custom render config', () => {
     it('should render ES5', () => {
       expect(
-        generateWithAmplifyRenderer('boxGolden', { target: ScriptTarget.ES5, script: ScriptKind.JS }),
+        generateWithAmplifyRenderer('boxGolden', { target: ScriptTarget.ES5, script: ScriptKind.JS }).componentText,
       ).toMatchSnapshot();
     });
 
     it('should render JSX', () => {
-      expect(generateWithAmplifyRenderer('boxGolden', { script: ScriptKind.JSX })).toMatchSnapshot();
+      expect(generateWithAmplifyRenderer('boxGolden', { script: ScriptKind.JSX }).componentText).toMatchSnapshot();
     });
 
     it('should render common JS', () => {
       expect(
-        generateWithAmplifyRenderer('boxGolden', { module: ModuleKind.CommonJS, script: ScriptKind.JS }),
+        generateWithAmplifyRenderer('boxGolden', { module: ModuleKind.CommonJS, script: ScriptKind.JS }).componentText,
       ).toMatchSnapshot();
     });
   });
 
   describe('user specific attributes', () => {
     it('should render user specific attributes', () => {
-      expect(generateWithAmplifyRenderer('componentWithUserSpecificAttributes')).toMatchSnapshot();
+      expect(generateWithAmplifyRenderer('componentWithUserSpecificAttributes').componentText).toMatchSnapshot();
+    });
+  });
+
+  describe('declarations', () => {
+    it('should render declarations', () => {
+      expect(
+        generateWithAmplifyRenderer('componentWithUserSpecificAttributes', {
+          script: ScriptKind.JS,
+          renderTypeDeclarations: true,
+        }).declaration,
+      ).toMatchSnapshot();
     });
   });
 

--- a/packages/studio-ui-codegen-react/lib/react-render-config.ts
+++ b/packages/studio-ui-codegen-react/lib/react-render-config.ts
@@ -7,6 +7,7 @@ export type ReactRenderConfig = FrameworkRenderConfig & {
   script?: ScriptKind;
   target?: ScriptTarget;
   module?: ModuleKind;
+  renderTypeDeclarations?: boolean;
 };
 
 export function scriptKindToFileExtension(scriptKind: ScriptKind): string {

--- a/packages/studio-ui-codegen-react/package-lock.json
+++ b/packages/studio-ui-codegen-react/package-lock.json
@@ -11,8 +11,10 @@
 			"dependencies": {
 				"@aws-amplify/ui-react": "^2.0.1-next.5",
 				"@babel/parser": "^7.15.6",
+				"@types/tmp": "^0.2.1",
 				"framer-motion": "^4",
 				"prettier": "2.3.2",
+				"tmp": "^0.2.1",
 				"typescript": "^4.2.4"
 			},
 			"devDependencies": {
@@ -6477,6 +6479,11 @@
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
 		},
+		"node_modules/@types/tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg=="
+		},
 		"node_modules/@types/yargs": {
 			"version": "16.0.4",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -6895,8 +6902,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"peer": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/base": {
 			"version": "0.11.2",
@@ -6987,7 +6993,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -7481,8 +7486,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"peer": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"node_modules/connect": {
 			"version": "3.7.0",
@@ -8285,8 +8289,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"peer": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
@@ -8364,7 +8367,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -8612,7 +8614,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -8621,8 +8622,7 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"peer": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"node_modules/invariant": {
 			"version": "2.2.4",
@@ -10128,7 +10128,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -10512,7 +10511,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -10731,7 +10729,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12460,6 +12457,31 @@
 				"xtend": "~4.0.1"
 			}
 		},
+		"node_modules/tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"dependencies": {
+				"rimraf": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.17.0"
+			}
+		},
+		"node_modules/tmp/node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -12954,8 +12976,7 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"peer": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/ws": {
 			"version": "6.2.2",
@@ -18716,6 +18737,11 @@
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
 		},
+		"@types/tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg=="
+		},
 		"@types/yargs": {
 			"version": "16.0.4",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -19056,8 +19082,7 @@
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"peer": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -19124,7 +19149,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"peer": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -19519,8 +19543,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"peer": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"connect": {
 			"version": "3.7.0",
@@ -20148,8 +20171,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"peer": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.3.2",
@@ -20205,7 +20227,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-			"peer": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -20385,7 +20406,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"peer": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -20394,8 +20414,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"peer": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -21667,7 +21686,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"peer": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -21966,7 +21984,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"peer": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -22132,8 +22149,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"peer": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -23536,6 +23552,24 @@
 				"xtend": "~4.0.1"
 			}
 		},
+		"tmp": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"requires": {
+				"rimraf": "^3.0.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
+		},
 		"tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -23930,8 +23964,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"peer": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"ws": {
 			"version": "6.2.2",

--- a/packages/studio-ui-codegen-react/package.json
+++ b/packages/studio-ui-codegen-react/package.json
@@ -20,11 +20,13 @@
   },
   "dependencies": {
     "@amzn/amplify-ui-codegen-schema": "^0.0.1",
-    "@aws-amplify/ui-react": "^2.0.1-next.5",
     "@amzn/studio-ui-codegen": "^0.0.1",
+    "@aws-amplify/ui-react": "^2.0.1-next.5",
     "@babel/parser": "^7.15.6",
+    "@types/tmp": "^0.2.1",
     "framer-motion": "^4",
     "prettier": "2.3.2",
+    "tmp": "^0.2.1",
     "typescript": "^4.2.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
* add option to output TypeScript type declarations
* change generated component type to `React.Element`
  * `JSX.Element` was causing errors when trying to compile type declarations

I used `ts.createProgram` to compile the type declarations. Our existing solution of `ts.transpileModule` does not support creating type declarations. `ts.createProgram` requires the source to be written to the filesystem. `ts.createProgram` is much less performant than `ts.transpileModule` so `ts.createProgram` is only used when necessary.