### PR TITLE
feat: replacing dependency on helper for collections sort with inline sort function

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -260,7 +260,7 @@ import {
   Collection,
   EscapeHatchProps,
   Flex,
-  convertSortPredicatesToDataStore,
+  SortDirection,
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
@@ -283,12 +283,9 @@ export default function CollectionOfCustomButtons(
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };
-  const buttonUserSort = convertSortPredicatesToDataStore([
-    { field: \\"firstName\\", direction: \\"ASC\\" },
-    { field: \\"lastName\\", direction: \\"DESC\\" },
-  ]);
   const buttonUserPagination = {
-    sort: buttonUserSort,
+    sort: (s) =>
+      s.firstName(SortDirection.ASCENDING).lastName(SortDirection.DESCENDING),
   };
   const buttonUser =
     items !== undefined


### PR DESCRIPTION
… sort function

*Issue #, if available:*

*Description of changes:*

Rather than add an explicit external helper, I think I'd prefer this feature to just directly write code the way an end user would.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
