### PR TITLE
test(studio-ui-codegen-react): add unit tests for import collection

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/import-collection.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/import-collection.test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ImportCollection addImport multiple identical imports 1`] = `
+"import React from \\"react\\";
+import { Text } from \\"@aws-amplify/ui-react\\";"
+`;
+
+exports[`ImportCollection addImport multiple imports 1`] = `
+"import React from \\"react\\";
+import { Text } from \\"@aws-amplify/ui-react\\";
+import { User } from \\"../models\\";"
+`;
+
+exports[`ImportCollection addImport multiple imports from the same package 1`] = `
+"import React from \\"react\\";
+import { Text, getOverrideProps } from \\"@aws-amplify/ui-react\\";"
+`;
+
+exports[`ImportCollection addImport one import 1`] = `
+"import React from \\"react\\";
+import { Text } from \\"@aws-amplify/ui-react\\";"
+`;
+
+exports[`ImportCollection addImport one relative import 1`] = `
+"import React from \\"react\\";
+import { User } from \\"../models\\";"
+`;
+
+exports[`ImportCollection buildImportStatements multiple imports 1`] = `
+"import React from \\"react\\";
+import { Button, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import { User } from \\"../models\\";"
+`;
+
+exports[`ImportCollection buildImportStatements no imports 1`] = `"import React from \\"react\\";"`;
+
+exports[`ImportCollection buildSampleSnippetImports 1`] = `"import { MyButton } from \\"./studio-ui\\";"`;
+
+exports[`ImportCollection mergeCollections 1`] = `
+"import React from \\"react\\";
+import { Button, Text, getOverrideProps } from \\"@aws-amplify/ui-react\\";
+import { User } from \\"../models\\";"
+`;

--- a/packages/studio-ui-codegen-react/lib/__tests__/__utils__/snapshot-helpers.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__utils__/snapshot-helpers.ts
@@ -1,0 +1,14 @@
+import { createPrinter, EmitHint, createSourceFile, ScriptTarget, ScriptKind, Node } from 'typescript';
+
+// render typescript AST to typescript then expect to match snapshot
+export function assertASTMatchesSnapshot(ast: Node | Node[]): void {
+  const file = createSourceFile('test.ts', '', ScriptTarget.ES2015, true, ScriptKind.TS);
+  const printer = createPrinter();
+  if (Array.isArray(ast)) {
+    expect(
+      ast.map((singleAST) => printer.printNode(EmitHint.Unspecified, singleAST, file)).join('\n'),
+    ).toMatchSnapshot();
+  } else {
+    expect(printer.printNode(EmitHint.Unspecified, ast, file)).toMatchSnapshot();
+  }
+}

--- a/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/component-renderer.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/component-renderer.test.ts
@@ -1,6 +1,7 @@
 import { StudioComponent } from '@amzn/amplify-ui-codegen-schema';
 import { createPrinter, EmitHint, createSourceFile, ScriptTarget, ScriptKind } from 'typescript';
 import { ImportCollection } from '../../import-collection';
+import { assertASTMatchesSnapshot } from '../__utils__/snapshot-helpers';
 
 import BadgeRenderer from '../../amplify-ui-renderers/badge';
 import ButtonRenderer from '../../amplify-ui-renderers/button';
@@ -31,10 +32,7 @@ function testComponentRenderer(
   const renderChildren = jest.fn();
   const renderedComponent = new Renderer(component, new ImportCollection()).renderElement(renderChildren);
 
-  // file is not actually written. filename does not matter
-  const file = createSourceFile('test.ts', '', ScriptTarget.ES2015, true, ScriptKind.TS);
-  const printer = createPrinter();
-  expect(printer.printNode(EmitHint.Unspecified, renderedComponent, file)).toMatchSnapshot();
+  assertASTMatchesSnapshot(renderedComponent);
 }
 
 describe('Component Renderers', () => {

--- a/packages/studio-ui-codegen-react/lib/__tests__/import-collection.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/import-collection.test.ts
@@ -1,0 +1,82 @@
+import { ImportCollection } from '../import-collection';
+import { assertASTMatchesSnapshot } from './__utils__/snapshot-helpers';
+
+function assertImportCollectionMatchesSnapshot(importCollection: ImportCollection) {
+  assertASTMatchesSnapshot(importCollection.buildImportStatements());
+}
+
+describe('ImportCollection', () => {
+  describe('buildImportStatements', () => {
+    test('no imports', () => {
+      const importCollection = new ImportCollection();
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+
+    test('multiple imports', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('@aws-amplify/ui-react', 'Button');
+      importCollection.addImport('@aws-amplify/ui-react', 'getOverrideProps');
+      importCollection.addImport('../models', 'User');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+  });
+
+  describe('addImport', () => {
+    test('one import', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('@aws-amplify/ui-react', 'Text');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+
+    test('one relative import', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('../models', 'User');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+
+    test('multiple imports', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('@aws-amplify/ui-react', 'Text');
+      importCollection.addImport('../models', 'User');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+
+    test('multiple identical imports', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('@aws-amplify/ui-react', 'Text');
+      importCollection.addImport('@aws-amplify/ui-react', 'Text');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+
+    test('multiple imports from the same package', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('@aws-amplify/ui-react', 'Text');
+      importCollection.addImport('@aws-amplify/ui-react', 'getOverrideProps');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+  });
+
+  test('mergeCollections', () => {
+    const collectionA = new ImportCollection();
+    const collectionB = new ImportCollection();
+
+    collectionA.addImport('@aws-amplify/ui-react', 'Text');
+    collectionA.addImport('@aws-amplify/ui-react', 'getOverrideProps');
+    collectionA.addImport('../models', 'User');
+
+    collectionB.addImport('@aws-amplify/ui-react', 'Button');
+    collectionB.addImport('../models', 'User');
+
+    collectionA.mergeCollections(collectionB);
+
+    assertImportCollectionMatchesSnapshot(collectionA);
+  });
+
+  test('buildSampleSnippetImports', () => {
+    const importCollection = new ImportCollection();
+    importCollection.addImport('@aws-amplify/ui-react', 'Button');
+    importCollection.addImport('@aws-amplify/ui-react', 'getOverrideProps');
+    importCollection.addImport('../models', 'User');
+    assertASTMatchesSnapshot(importCollection.buildSampleSnippetImports('MyButton'));
+  });
+});

--- a/packages/studio-ui-codegen-react/package.json
+++ b/packages/studio-ui-codegen-react/package.json
@@ -43,7 +43,9 @@
     "collectCoverageFrom": [
       "lib/**/*.ts"
     ],
+    "coveragePathIgnorePatterns": ["<rootDir>/lib/__tests__/__utils__/"],
     "testRegex": "(lib/__tests__/.*.test.ts)$",
+    "testPathIgnorePatterns": ["<rootDir>/lib/__tests__/__utils__/"],
     "globals": {
       "ts-jest": {
         "diagnostics": false


### PR DESCRIPTION
This is missing coverage on line 13 and 14 of `import-collection.ts`. These branches are actually unreachable.

```js
    6   addImport(packageName: string, importName: string) {                                                                   
    7     if (!this.#collection.has(packageName)) {                                                                            
    8       this.#collection.set(packageName, new Set());                                                                      
    9     }                                                                                                                    
   10                                                                                                                          
   11     const existingPackage = this.#collection.get(packageName);                                                           
   12                                                                                                                          
   13     if (!existingPackage?.has(importName)) {                                                                             
   14       existingPackage?.add(importName);                                                                                  
   15     }                                                                                                                    
   16   }    
```

TypeScript infers that `existingPackage` can be `undefined`. This cannot actually happen. One option would be to replace `?` with `!` to override the TypeScript compiler. I kept as is for now so that this change would only add test cases and not modify the source.