### PR TITLE
feat: throw error on invalid script kind

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/react-render-config.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/react-render-config.test.ts
@@ -1,0 +1,22 @@
+import { ScriptKind } from 'typescript';
+import { scriptKindToFileExtension } from '../react-render-config';
+
+describe('ReactRenderConfig', () => {
+  describe('scriptKindToFileExtension', () => {
+    test('JS', () => {
+      expect(scriptKindToFileExtension(ScriptKind.JS)).toEqual('js');
+    });
+
+    test('JSX', () => {
+      expect(scriptKindToFileExtension(ScriptKind.JSX)).toEqual('jsx');
+    });
+
+    test('TSX', () => {
+      expect(scriptKindToFileExtension(ScriptKind.TSX)).toEqual('tsx');
+    });
+
+    test('TS (not supported)', () => {
+      expect(() => scriptKindToFileExtension(ScriptKind.TS)).toThrow(new Error('Invalid script kind: TS'));
+    });
+  });
+});

--- a/packages/studio-ui-codegen-react/lib/react-render-config.ts
+++ b/packages/studio-ui-codegen-react/lib/react-render-config.ts
@@ -12,8 +12,6 @@ export type ReactRenderConfig = FrameworkRenderConfig & {
 
 export function scriptKindToFileExtension(scriptKind: ScriptKind): string {
   switch (scriptKind) {
-    case ScriptKind.TS:
-      return 'ts';
     case ScriptKind.TSX:
       return 'tsx';
     case ScriptKind.JS:
@@ -21,6 +19,6 @@ export function scriptKindToFileExtension(scriptKind: ScriptKind): string {
     case ScriptKind.JSX:
       return 'jsx';
     default:
-      return 'tsx';
+      throw new Error(`Invalid script kind: ${ScriptKind[scriptKind]}`);
   }
 }


### PR DESCRIPTION
Instead of supplying a default script kind that could result in confusion we should throw an error.

`TS` script kind is not supported becauase TypeScript does not have the option to transpile from TSX (generated source) to TS.
