### PR TITLE
fix: use temp package that does not break browser

### DIFF
--- a/packages/studio-ui-codegen-react/package-lock.json
+++ b/packages/studio-ui-codegen-react/package-lock.json
@@ -10,10 +10,10 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/parser": "^7.15.6",
-				"@types/tmp": "^0.2.1",
+				"@types/temp": "^0.9.1",
 				"framer-motion": "^4",
 				"prettier": "2.3.2",
-				"tmp": "^0.2.1",
+				"temp": "^0.9.4",
 				"typescript": "^4.2.4"
 			},
 			"devDependencies": {
@@ -7291,8 +7291,7 @@
 		"node_modules/@types/node": {
 			"version": "16.10.9",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.9.tgz",
-			"integrity": "sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw==",
-			"dev": true
+			"integrity": "sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw=="
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.4",
@@ -7317,10 +7316,13 @@
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
 		},
-		"node_modules/@types/tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg=="
+		"node_modules/@types/temp": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@types/temp/-/temp-0.9.1.tgz",
+			"integrity": "sha512-yDQ8Y+oQi9V7VkexwE6NBSVyNuyNFeGI275yWXASc2DjmxNicMi9O50KxDpNlST1kBbV9jKYBHGXhgNYFMPqtA==",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "16.0.4",
@@ -10367,6 +10369,32 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/jscodeshift/node_modules/rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/jscodeshift/node_modules/temp": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+			"integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"rimraf": "~2.6.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/jscodeshift/node_modules/to-regex-range": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
@@ -11382,6 +11410,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/metro/node_modules/temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"dev": true,
+			"engines": [
+				"node >=0.8.0"
+			],
+			"peer": true,
+			"dependencies": {
+				"os-tmpdir": "^1.0.0",
+				"rimraf": "~2.2.6"
+			}
+		},
+		"node_modules/metro/node_modules/temp/node_modules/rimraf": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
 		"node_modules/metro/node_modules/wrap-ansi": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -11519,9 +11571,7 @@
 		"node_modules/minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"node_modules/mixin-deep": {
 			"version": "1.3.2",
@@ -11541,8 +11591,6 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
 			},
@@ -14085,25 +14133,24 @@
 			}
 		},
 		"node_modules/temp": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-			"dev": true,
-			"engines": [
-				"node >=0.8.0"
-			],
-			"peer": true,
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
 			"dependencies": {
-				"os-tmpdir": "^1.0.0",
-				"rimraf": "~2.2.6"
+				"mkdirp": "^0.5.1",
+				"rimraf": "~2.6.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/temp/node_modules/rimraf": {
-			"version": "2.2.8",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-			"dev": true,
-			"peer": true,
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
 			"bin": {
 				"rimraf": "bin.js"
 			}
@@ -14124,31 +14171,6 @@
 			"dependencies": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
-			}
-		},
-		"node_modules/tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dependencies": {
-				"rimraf": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8.17.0"
-			}
-		},
-		"node_modules/tmp/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/tmpl": {
@@ -20977,8 +20999,7 @@
 		"@types/node": {
 			"version": "16.10.9",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.9.tgz",
-			"integrity": "sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw==",
-			"dev": true
+			"integrity": "sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw=="
 		},
 		"@types/prop-types": {
 			"version": "15.7.4",
@@ -21003,10 +21024,13 @@
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
 		},
-		"@types/tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg=="
+		"@types/temp": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@types/temp/-/temp-0.9.1.tgz",
+			"integrity": "sha512-yDQ8Y+oQi9V7VkexwE6NBSVyNuyNFeGI275yWXASc2DjmxNicMi9O50KxDpNlST1kBbV9jKYBHGXhgNYFMPqtA==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/yargs": {
 			"version": "16.0.4",
@@ -23468,6 +23492,26 @@
 						"to-regex": "^3.0.2"
 					}
 				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"temp": {
+					"version": "0.8.4",
+					"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+					"integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"rimraf": "~2.6.2"
+					}
+				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
@@ -23978,6 +24022,26 @@
 						"ansi-regex": "^5.0.1"
 					}
 				},
+				"temp": {
+					"version": "0.8.3",
+					"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+					"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"os-tmpdir": "^1.0.0",
+						"rimraf": "~2.2.6"
+					},
+					"dependencies": {
+						"rimraf": {
+							"version": "2.2.8",
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+							"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+							"dev": true,
+							"peer": true
+						}
+					}
+				},
 				"wrap-ansi": {
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -24465,9 +24529,7 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"mixin-deep": {
 			"version": "1.3.2",
@@ -24484,8 +24546,6 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"peer": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -26572,22 +26632,21 @@
 			}
 		},
 		"temp": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-			"dev": true,
-			"peer": true,
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
 			"requires": {
-				"os-tmpdir": "^1.0.0",
-				"rimraf": "~2.2.6"
+				"mkdirp": "^0.5.1",
+				"rimraf": "~2.6.2"
 			},
 			"dependencies": {
 				"rimraf": {
-					"version": "2.2.8",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-					"dev": true,
-					"peer": true
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
@@ -26607,24 +26666,6 @@
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
-			}
-		},
-		"tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"requires": {
-				"rimraf": "^3.0.0"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"tmpl": {

--- a/packages/studio-ui-codegen-react/package.json
+++ b/packages/studio-ui-codegen-react/package.json
@@ -15,18 +15,18 @@
     "build:watch": "npm run build -- --watch"
   },
   "devDependencies": {
+    "@aws-amplify/ui-react": "^2.0.1-next.5",
     "@types/node": "^16.3.3",
-    "@types/react": "^17.0.4",
-    "@aws-amplify/ui-react": "^2.0.1-next.5"
+    "@types/react": "^17.0.4"
   },
   "dependencies": {
     "@amzn/amplify-ui-codegen-schema": "^0.0.1",
     "@amzn/studio-ui-codegen": "^0.0.1",
     "@babel/parser": "^7.15.6",
-    "@types/tmp": "^0.2.1",
+    "@types/temp": "^0.9.1",
     "framer-motion": "^4",
     "prettier": "2.3.2",
-    "tmp": "^0.2.1",
+    "temp": "^0.9.4",
     "typescript": "^4.2.4"
   },
   "peerDependencies": {
@@ -43,9 +43,13 @@
     "collectCoverageFrom": [
       "lib/**/*.ts"
     ],
-    "coveragePathIgnorePatterns": ["<rootDir>/lib/__tests__/__utils__/"],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/lib/__tests__/__utils__/"
+    ],
     "testRegex": "(lib/__tests__/.*.test.ts)$",
-    "testPathIgnorePatterns": ["<rootDir>/lib/__tests__/__utils__/"],
+    "testPathIgnorePatterns": [
+      "<rootDir>/lib/__tests__/__utils__/"
+    ],
     "globals": {
       "ts-jest": {
         "diagnostics": false


### PR DESCRIPTION
Use a different temp file package. I think long term we should create our own temporary file solution, but for now this will unblock the UI team on this issue.

I tested this by creating a CRA and then attempting generate components in the browser. With the previous `tmp` package this would fail. With the new package it was successful in generating components. See https://github.com/aws-amplify/amplify-codegen-ui-staging/tree/test-browser 

