### PR TITLE
fix: remove Box to View mapping

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -51,32 +51,6 @@ export default function SiteHeader(props: SiteHeaderProps): React.ReactElement {
 }
 `;
 
-exports[`amplify render tests basic component tests should generate a simple box component 1`] = `
-"/* eslint-disable */
-import React from \\"react\\";
-import {
-  EscapeHatchProps,
-  View,
-  getOverrideProps,
-} from \\"@aws-amplify/ui-react\\";
-
-export type TestProps = {
-  overrides?: EscapeHatchProps | undefined | null;
-};
-export default function Test(props: TestProps): React.ReactElement {
-  const overrides = { ...props.overrides };
-  return (
-    <View
-      fontFamily=\\"Times New Roman\\"
-      fontSize=\\"20px\\"
-      {...props}
-      {...getOverrideProps(overrides, \\"Box\\")}
-    ></View>
-  );
-}
-"
-`;
-
 exports[`amplify render tests basic component tests should generate a simple button component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
@@ -128,6 +102,32 @@ export default function CustomText(props: CustomTextProps): React.ReactElement {
     >
       Text Value
     </Text>
+  );
+}
+"
+`;
+
+exports[`amplify render tests basic component tests should generate a simple view component 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  View,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type TestProps = {
+  overrides?: EscapeHatchProps | undefined | null;
+};
+export default function Test(props: TestProps): React.ReactElement {
+  const overrides = { ...props.overrides };
+  return (
+    <View
+      fontFamily=\\"Times New Roman\\"
+      fontSize=\\"20px\\"
+      {...props}
+      {...getOverrideProps(overrides, \\"View\\")}
+    ></View>
   );
 }
 "
@@ -390,7 +390,7 @@ export default function ListingCardCollection(
 "
 `;
 
-exports[`amplify render tests complex component tests should generate a button within a box component 1`] = `
+exports[`amplify render tests complex component tests should generate a button within a view component 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
 import {
@@ -400,19 +400,19 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type BoxWithButtonProps = {
+export type ViewWithButtonProps = {
   overrides?: EscapeHatchProps | undefined | null;
 };
-export default function BoxWithButton(
-  props: BoxWithButtonProps
+export default function ViewWithButton(
+  props: ViewWithButtonProps
 ): React.ReactElement {
   const overrides = { ...props.overrides };
   return (
-    <View {...props} {...getOverrideProps(overrides, \\"Box\\")}>
+    <View {...props} {...getOverrideProps(overrides, \\"View\\")}>
       <Button
         color=\\"#ff0000\\"
         width=\\"20px\\"
-        {...getOverrideProps(overrides, \\"Box.Button\\")}
+        {...getOverrideProps(overrides, \\"View.Button\\")}
       ></Button>
     </View>
   );
@@ -431,15 +431,15 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type BoxWithCustomButtonProps = {
+export type ViewWithCustomButtonProps = {
   overrides?: EscapeHatchProps | undefined | null;
 };
-export default function BoxWithCustomButton(
-  props: BoxWithCustomButtonProps
+export default function ViewWithCustomButton(
+  props: ViewWithCustomButtonProps
 ): React.ReactElement {
   const overrides = { ...props.overrides };
   return (
-    <View {...props} {...getOverrideProps(overrides, \\"Box\\")}>
+    <View {...props} {...getOverrideProps(overrides, \\"View\\")}>
       <CustomButton
         color=\\"#ff0000\\"
         width=\\"20px\\"
@@ -461,19 +461,19 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type BoxWithButtonProps = {
+export type ViewWithButtonProps = {
   overrides?: EscapeHatchProps | undefined | null;
 };
-export default function BoxWithButton(
-  props: BoxWithButtonProps
+export default function ViewWithButton(
+  props: ViewWithButtonProps
 ): React.ReactElement {
   const overrides = { ...props.overrides };
   return (
-    <View {...props} {...getOverrideProps(overrides, \\"Box\\")}>
+    <View {...props} {...getOverrideProps(overrides, \\"View\\")}>
       <Button
         color=\\"#ff0000\\"
         width=\\"20px\\"
-        {...getOverrideProps(overrides, \\"Box.Button\\")}
+        {...getOverrideProps(overrides, \\"View.Button\\")}
       ></Button>
     </View>
   );
@@ -763,16 +763,16 @@ exports[`amplify render tests custom render config should render ES5 1`] = `
 /* eslint-disable */
 import React from \\"react\\";
 import { Button, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
-export default function BoxWithButton(props) {
+export default function ViewWithButton(props) {
   var overrides = __assign({}, props.overrides);
   return React.createElement(
     View,
-    __assign({}, props, getOverrideProps(overrides, \\"Box\\")),
+    __assign({}, props, getOverrideProps(overrides, \\"View\\")),
     React.createElement(
       Button,
       __assign(
         { color: \\"#ff0000\\", width: \\"20px\\" },
-        getOverrideProps(overrides, \\"Box.Button\\")
+        getOverrideProps(overrides, \\"View.Button\\")
       )
     )
   );
@@ -784,14 +784,14 @@ exports[`amplify render tests custom render config should render JSX 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
 import { Button, View, getOverrideProps } from \\"@aws-amplify/ui-react\\";
-export default function BoxWithButton(props) {
+export default function ViewWithButton(props) {
   const overrides = Object.assign({}, props.overrides);
   return (
-    <View {...props} {...getOverrideProps(overrides, \\"Box\\")}>
+    <View {...props} {...getOverrideProps(overrides, \\"View\\")}>
       <Button
         color=\\"#ff0000\\"
         width=\\"20px\\"
-        {...getOverrideProps(overrides, \\"Box.Button\\")}
+        {...getOverrideProps(overrides, \\"View.Button\\")}
       ></Button>
     </View>
   );
@@ -810,25 +810,25 @@ Object.defineProperty(exports, \\"__esModule\\", { value: true });
 /* eslint-disable */
 const react_1 = __importDefault(require(\\"react\\"));
 const ui_react_1 = require(\\"@aws-amplify/ui-react\\");
-function BoxWithButton(props) {
+function ViewWithButton(props) {
   const overrides = Object.assign({}, props.overrides);
   return react_1.default.createElement(
     ui_react_1.View,
     Object.assign(
       {},
       props,
-      (0, ui_react_1.getOverrideProps)(overrides, \\"Box\\")
+      (0, ui_react_1.getOverrideProps)(overrides, \\"View\\")
     ),
     react_1.default.createElement(
       ui_react_1.Button,
       Object.assign(
         { color: \\"#ff0000\\", width: \\"20px\\" },
-        (0, ui_react_1.getOverrideProps)(overrides, \\"Box.Button\\")
+        (0, ui_react_1.getOverrideProps)(overrides, \\"View.Button\\")
       )
     )
   );
 }
-exports.default = BoxWithButton;
+exports.default = ViewWithButton;
 "
 `;
 
@@ -853,15 +853,15 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type BoxWithButtonProps = {
+export type ViewWithButtonProps = {
   overrides?: EscapeHatchProps | undefined | null;
 };
-export default function BoxWithButton(
-  props: BoxWithButtonProps
+export default function ViewWithButton(
+  props: ViewWithButtonProps
 ): React.ReactElement {
   const overrides = { ...props.overrides };
   return (
-    <View padding-left {...props} {...getOverrideProps(overrides, \\"Box\\")}>
+    <View padding-left {...props} {...getOverrideProps(overrides, \\"View\\")}>
       <CustomButton
         color=\\"#ff0000\\"
         width=\\"20px\\"

--- a/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/__snapshots__/component-renderer.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/__snapshots__/component-renderer.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Component Renderers BadgeRenderer 1`] = `"<Badge {...props} {...getOverrideProps(overrides, \\"Badge\\")}></Badge>"`;
 
-exports[`Component Renderers BoxRenderer 1`] = `"<View {...props} {...getOverrideProps(overrides, \\"Box\\")}></View>"`;
+exports[`Component Renderers BoxRenderer 1`] = `"<View {...props} {...getOverrideProps(overrides, \\"View\\")}></View>"`;
 
 exports[`Component Renderers ButtonRenderer 1`] = `"<Button {...props} {...getOverrideProps(overrides, \\"Button\\")}></Button>"`;
 

--- a/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/component-renderer.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/component-renderer.test.ts
@@ -20,7 +20,7 @@ import { assertASTMatchesSnapshot } from '../__utils__/snapshot-helpers';
 
 import BadgeRenderer from '../../amplify-ui-renderers/badge';
 import ButtonRenderer from '../../amplify-ui-renderers/button';
-import BoxRenderer from '../../amplify-ui-renderers/box';
+import ViewRenderer from '../../amplify-ui-renderers/view';
 import CardRenderer from '../../amplify-ui-renderers/card';
 import DividerRenderer from '../../amplify-ui-renderers/divider';
 import FlexRenderer from '../../amplify-ui-renderers/flex';
@@ -34,7 +34,7 @@ function testComponentRenderer(
   Renderer:
     | typeof BadgeRenderer
     | typeof ButtonRenderer
-    | typeof BoxRenderer
+    | typeof ViewRenderer
     | typeof CardRenderer
     | typeof DividerRenderer
     | typeof FlexRenderer
@@ -73,12 +73,12 @@ describe('Component Renderers', () => {
 
   test('BoxRenderer', () => {
     const component = {
-      componentType: 'Box',
-      name: 'MyBox',
+      componentType: 'View',
+      name: 'MyView',
       properties: {},
       bindingProperties: {},
     };
-    testComponentRenderer(BoxRenderer, component);
+    testComponentRenderer(ViewRenderer, component);
   });
 
   test('CardRenderer', () => {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -58,8 +58,8 @@ function generateWithThemeRenderer(jsonFile: string, renderConfig: ReactRenderCo
 
 describe('amplify render tests', () => {
   describe('basic component tests', () => {
-    it('should generate a simple box component', () => {
-      const generatedCode = generateWithAmplifyRenderer('boxTest');
+    it('should generate a simple view component', () => {
+      const generatedCode = generateWithAmplifyRenderer('viewTest');
       expect(generatedCode.componentText).toMatchSnapshot();
     });
 
@@ -87,8 +87,8 @@ describe('amplify render tests', () => {
   });
 
   describe('complex component tests', () => {
-    it('should generate a button within a box component', () => {
-      const generatedCode = generateWithAmplifyRenderer('boxGolden');
+    it('should generate a button within a view component', () => {
+      const generatedCode = generateWithAmplifyRenderer('viewGolden');
       expect(generatedCode.componentText).toMatchSnapshot();
     });
 
@@ -173,17 +173,17 @@ describe('amplify render tests', () => {
   describe('custom render config', () => {
     it('should render ES5', () => {
       expect(
-        generateWithAmplifyRenderer('boxGolden', { target: ScriptTarget.ES5, script: ScriptKind.JS }).componentText,
+        generateWithAmplifyRenderer('viewGolden', { target: ScriptTarget.ES5, script: ScriptKind.JS }).componentText,
       ).toMatchSnapshot();
     });
 
     it('should render JSX', () => {
-      expect(generateWithAmplifyRenderer('boxGolden', { script: ScriptKind.JSX }).componentText).toMatchSnapshot();
+      expect(generateWithAmplifyRenderer('viewGolden', { script: ScriptKind.JSX }).componentText).toMatchSnapshot();
     });
 
     it('should render common JS', () => {
       expect(
-        generateWithAmplifyRenderer('boxGolden', { module: ModuleKind.CommonJS, script: ScriptKind.JS }).componentText,
+        generateWithAmplifyRenderer('viewGolden', { module: ModuleKind.CommonJS, script: ScriptKind.JS }).componentText,
       ).toMatchSnapshot();
     });
   });

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/customChild.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/customChild.json
@@ -1,7 +1,7 @@
 {
   "id": "1234-5678-9010",
-  "componentType": "Box",
-  "name": "BoxWithCustomButton",
+  "componentType": "View",
+  "name": "ViewWithCustomButton",
   "properties": {},
   "children": [
     {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/exposedAsTest.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/exposedAsTest.json
@@ -1,7 +1,7 @@
 {
   "id": "1234-5678-9010",
-  "componentType": "Box",
-  "name": "BoxWithButton",
+  "componentType": "View",
+  "name": "ViewWithButton",
   "properties": {},
   "children": [
     {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/sampleCodeSnippet.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/sampleCodeSnippet.json
@@ -1,7 +1,7 @@
 {
   "id": "1234-5678-9010",
-  "componentType": "Box",
-  "name": "BoxWithButton",
+  "componentType": "View",
+  "name": "ViewWithButton",
   "properties": {
     "padding-left": {
       "exposedAs": "paddingLeft"

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/viewGolden.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/viewGolden.json
@@ -1,7 +1,7 @@
 {
   "id": "1234-5678-9010",
-  "componentType": "Box",
-  "name": "BoxWithButton",
+  "componentType": "View",
+  "name": "ViewWithButton",
   "properties": {},
   "children": [
     {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/viewTest.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/viewTest.json
@@ -1,5 +1,5 @@
 {
-  "componentType": "Box",
+  "componentType": "View",
   "id": "I:5",
   "properties": {
     "fontFamily": {

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -20,7 +20,7 @@ import { ReactStudioTemplateRenderer } from '../react-studio-template-renderer';
 
 import BadgeRenderer from './badge';
 import ButtonRenderer from './button';
-import BoxRenderer from './box';
+import ViewRenderer from './view';
 import CardRenderer from './card';
 import DividerRenderer from './divider';
 import FlexRenderer from './flex';
@@ -48,8 +48,8 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
           children.map((child) => this.renderJsx(child, node)),
         );
 
-      case 'Box':
-        return new BoxRenderer(component, this.importCollection, parent).renderElement((children) =>
+      case 'View':
+        return new ViewRenderer(component, this.importCollection, parent).renderElement((children) =>
           children.map((child) => this.renderJsx(child, node)),
         );
 

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/view.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/view.ts
@@ -13,14 +13,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { ViewProps as BoxProps } from '@aws-amplify/ui-react';
+import { ViewProps } from '@aws-amplify/ui-react';
 
 import { StudioComponentChild } from '@amzn/amplify-ui-codegen-schema';
 
 import { factory, JsxChild, JsxElement } from 'typescript';
 import { ReactComponentWithChildrenRenderer } from '../react-component-with-children-renderer';
 
-export default class BoxRenderer extends ReactComponentWithChildrenRenderer<BoxProps> {
+export default class ViewRenderer extends ReactComponentWithChildrenRenderer<ViewProps> {
   renderElement(renderChildren: (children: StudioComponentChild[]) => JsxChild[]): JsxElement {
     const tagName = 'View';
 

--- a/packages/test-generator/lib/components/basic-components/basicComponentView.json
+++ b/packages/test-generator/lib/components/basic-components/basicComponentView.json
@@ -1,7 +1,7 @@
 {
   "id": "1234-5678-9010",
-  "componentType": "Box",
-  "name": "BasicComponentBox",
+  "componentType": "View",
+  "name": "BasicComponentView",
   "properties": {},
   "children": [
     {
@@ -9,7 +9,7 @@
       "componentType": "Text",
       "properties": {
         "value": {
-          "value": "Basic Component Box"
+          "value": "Basic Component View"
         }
       }
     }

--- a/packages/test-generator/lib/components/basic-components/index.ts
+++ b/packages/test-generator/lib/components/basic-components/index.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 export { default as BasicComponentBadge } from './basicComponentBadge.json';
-export { default as BasicComponentBox } from './basicComponentBox.json';
+export { default as BasicComponentView } from './basicComponentView.json';
 export { default as BasicComponentButton } from './basicComponentButton.json';
 export { default as BasicComponentCard } from './basicComponentCard.json';
 export { default as BasicComponentCollection } from './basicComponentCollection.json';

--- a/packages/test-generator/lib/components/componentWithExposedAs.json
+++ b/packages/test-generator/lib/components/componentWithExposedAs.json
@@ -1,6 +1,6 @@
 {
   "id": "1234-5678-9010",
-  "componentType": "Box",
+  "componentType": "View",
   "name": "ComponentWithExposedAs",
   "properties": {},
   "children": [

--- a/packages/test-generator/lib/components/index.ts
+++ b/packages/test-generator/lib/components/index.ts
@@ -13,8 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-export { default as BoxWithButton } from './boxWithButton.json';
-export { default as BoxTest } from './boxTest.json';
+export { default as ViewWithButton } from './viewWithButton.json';
+export { default as ViewTest } from './viewTest.json';
 export { default as CustomButton } from './customButton.json';
 export { default as ComponentWithExposedAs } from './componentWithExposedAs.json';
 export { default as ComponentWithDataBinding } from './componentWithDataBinding.json';

--- a/packages/test-generator/lib/components/viewTest.json
+++ b/packages/test-generator/lib/components/viewTest.json
@@ -1,5 +1,5 @@
 {
-  "componentType": "Box",
+  "componentType": "View",
   "id": "I:5",
   "properties": {
     "fontFamily": {
@@ -10,5 +10,5 @@
     }
   },
   "overrides": {},
-  "name": "BoxTest"
+  "name": "ViewTest"
 }

--- a/packages/test-generator/lib/components/viewWithButton.json
+++ b/packages/test-generator/lib/components/viewWithButton.json
@@ -1,7 +1,7 @@
 {
   "id": "1234-5678-9010",
-  "componentType": "Box",
-  "name": "BoxWithButton",
+  "componentType": "View",
+  "name": "ViewWithButton",
   "properties": {},
   "children": [
     {

--- a/packages/test-generator/test-app-templates/cypress/integration/generated-components-spec.js
+++ b/packages/test-generator/test-app-templates/cypress/integration/generated-components-spec.js
@@ -11,9 +11,9 @@ describe('Generated Components', () => {
       cy.get('#basic-components').contains('Basic Component Badge');
     });
 
-    it('Renders Box component', () => {
+    it('Renders View component', () => {
       cy.visit('http://localhost:3000');
-      cy.get('#basic-components').contains('Basic Component Box');
+      cy.get('#basic-components').contains('Basic Component View');
     });
 
     it('Renders Button component', () => {

--- a/packages/test-generator/test-app-templates/src/App.tsx
+++ b/packages/test-generator/test-app-templates/src/App.tsx
@@ -14,12 +14,12 @@
   limitations under the License.
  */
 import React from 'react';
-import BoxTest from './ui-components/BoxTest';
-import BoxWithButton from './ui-components/BoxWithButton';
+import ViewTest from './ui-components/ViewTest';
+import ViewWithButton from './ui-components/ViewWithButton';
 import CustomButton from './ui-components/CustomButton';
 import withTheme from './ui-components/theme';
 import BasicComponentBadge from './ui-components/BasicComponentBadge';
-import BasicComponentBox from './ui-components/BasicComponentBox';
+import BasicComponentView from './ui-components/BasicComponentView';
 import BasicComponentButton from './ui-components/BasicComponentButton';
 import BasicComponentCard from './ui-components/BasicComponentCard';
 import BasicComponentText from './ui-components/BasicComponentText';
@@ -32,13 +32,13 @@ function App() {
       <div id={'basic-components'}>
         <h2>Basic Components</h2>
         <BasicComponentBadge />
-        <BasicComponentBox />
+        <BasicComponentView />
         <BasicComponentButton />
         <BasicComponentCard />
         <BasicComponentText />
       </div>
-      <BoxTest />
-      <BoxWithButton />
+      <ViewTest />
+      <ViewWithButton />
       <CustomButton />
       {/* <TextWithDataBinding /> // TODO: add back in with data binding tests /*}
       {/*


### PR DESCRIPTION
The mapping between `componentType: 'Box'` and primitive `View` should not exist. The old goldens use `Box` because they were written before the primitives were created and the naming was not solidified.

* removes the mapping between `Box` and `View`
* removes support for `componentType: 'Box'` because there is no `Box` primitive.