### PR TITLE
chore: setup versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,10 @@ This packages contains all of the base classes for the codegen providers. This i
 _@amzn/studio-ui-codegen-react_
 
 This package contains the necessary codegen to render directly to Amplify Components from a Studio Schema.
+
+## Versioning
+
+1. Create new branch: `git checkout -b new-release`
+1. Run version command: `npm run version`
+1. Create new PR with the new branch to mainline: `gh pr create`
+1. Squash and merge PR after approval.

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,11 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "independent",
+  "exact": true,
+  "command": {
+    "version": {
+      "message": "chore: release"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "setup-dev": "npm install && lerna bootstrap && lerna run build",
     "clean": "lerna run clean && lerna exec npm run rimraf tsconfig.tsbuildinfo && lerna clean --yes && npm run rimraf node_modules",
     "prepare": "husky install",
+    "version": "lerna version --conventional-commits --no-commit-hooks --sign-git-commit --sign-git-tag", 
     "format": "prettier --write 'packages/*/lib/**/*.{js,jsx,ts,tsx}'",
     "format:check": "prettier --check 'packages/*/lib/**/*.{js,jsx,ts,tsx}'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
This will setup easy manual versioning. Version numbers are determined automatically by conventional commits.

See readme for release instructions.
