### PR TITLE
ci: install latest version of studio codegen

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -85,9 +85,9 @@ jobs:
           npm install
           npm install amplify-provider-awscloudformation
           npm install aws-sdk.tgz
-          npm install ../amplify-codegen-ui-staging/packages/amplify-ui-codegen-schema/amzn-amplify-ui-codegen-schema-0.0.1.tgz
-          npm install ../amplify-codegen-ui-staging/packages/studio-ui-codegen/amzn-studio-ui-codegen-0.0.1.tgz
-          npm install ../amplify-codegen-ui-staging/packages/studio-ui-codegen-react/amzn-studio-ui-codegen-react-0.0.1.tgz
+          npm install ../amplify-codegen-ui-staging/packages/amplify-ui-codegen-schema/amzn-amplify-ui-codegen-schema-*.tgz
+          npm install ../amplify-codegen-ui-staging/packages/studio-ui-codegen/amzn-studio-ui-codegen-*.tgz
+          npm install ../amplify-codegen-ui-staging/packages/studio-ui-codegen-react/amzn-studio-ui-codegen-react-*.tgz
       - name: Test amplify-category-studio
         working-directory: amplify-category-studio
         run: npm test


### PR DESCRIPTION
When adding versioning the CI will need to install the latest version of the package. The CI has been updated on CLI: https://github.com/johnpc/amplify-category-studio/pull/1

Wildcard is safe here because there will only ever be one `.tgz` per file.
