### PR TITLE
feat: parse string wrapped fixed values

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`react-component-render-helper buildFixedJsxExpression boolean 1`] = `"{true}"`;
+
+exports[`react-component-render-helper buildFixedJsxExpression number 1`] = `"{400}"`;
+
+exports[`react-component-render-helper buildFixedJsxExpression parsed array 1`] = `"{[1, 2, 3]}"`;
+
+exports[`react-component-render-helper buildFixedJsxExpression parsed boolean 1`] = `"{true}"`;
+
+exports[`react-component-render-helper buildFixedJsxExpression parsed null 1`] = `"{null}"`;
+
+exports[`react-component-render-helper buildFixedJsxExpression parsed number 1`] = `"{400}"`;
+
+exports[`react-component-render-helper buildFixedJsxExpression parsed object 1`] = `"{{ transponder: \\"rocinante\\" }}"`;
+
+exports[`react-component-render-helper buildFixedJsxExpression string 1`] = `"\\"some text\\""`;
+
+exports[`react-component-render-helper buildFixedJsxExpression string wrapped array 1`] = `"\\"[1,2,3]\\""`;
+
+exports[`react-component-render-helper buildFixedJsxExpression string wrapped boolean 1`] = `"\\"true\\""`;
+
+exports[`react-component-render-helper buildFixedJsxExpression string wrapped null 1`] = `"\\"null\\""`;
+
+exports[`react-component-render-helper buildFixedJsxExpression string wrapped number 1`] = `"\\"400\\""`;
+
+exports[`react-component-render-helper buildFixedJsxExpression string wrapped object 1`] = `"\\"{\\\\\\"transponder\\\\\\": \\\\\\"rocinante\\\\\\"}\\""`;

--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -76,7 +76,7 @@ export default function CustomButton(
   return (
     <Button
       color=\\"#ff0000\\"
-      width=\\"20\\"
+      width={20}
       {...rest}
       {...getOverrideProps(overrides, \\"Button\\")}
     ></Button>
@@ -1335,6 +1335,98 @@ export default function SiteHeader(props: SiteHeaderProps): React.ReactElement {
         {...getOverrideProps(overrides, \\"Flex.Button\\")}
       ></Button>
     </Flex>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
+exports[`amplify render tests should render parsed fixed values 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  Input,
+  InputProps,
+  View,
+  ViewProps,
+  findChildOverrides,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type ParsedFixedValuesProps = Partial<ViewProps> & {
+  overrides?: EscapeHatchProps | undefined | null;
+};
+export default function ParsedFixedValues(
+  props: ParsedFixedValuesProps
+): React.ReactElement {
+  const { overrides: overridesProp, ...rest } = props;
+  const overrides = { ...overridesProp };
+  return (
+    <View
+      id=\\"parsed-fixed-values\\"
+      {...rest}
+      {...getOverrideProps(overrides, \\"View\\")}
+    >
+      <Input
+        id=\\"string-value\\"
+        value=\\"raw string value\\"
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"number-value\\"
+        value=\\"67548\\"
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"parsed-number-value\\"
+        value={67548}
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"boolean-value\\"
+        value=\\"true\\"
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"parsed-boolean-value\\"
+        value={true}
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"json-value\\"
+        value='{\\"foo\\": \\"bar\\"}'
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"parsed-json-value\\"
+        value={{ foo: \\"bar\\" }}
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"array-value\\"
+        value=\\"[1,2,3]\\"
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"parsed-array-value\\"
+        value={[1, 2, 3]}
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"null-value\\"
+        value=\\"null\\"
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+      <Input
+        id=\\"parsed-null-value\\"
+        value={null}
+        {...findChildOverrides(props.overrides, \\"Input\\")}
+      ></Input>
+    </View>
   );
 }
 ",

--- a/packages/studio-ui-codegen-react/lib/__tests__/react-component-render-helper.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/react-component-render-helper.test.ts
@@ -22,7 +22,10 @@ import {
   isCollectionItemBoundProperty,
   isConcatenatedProperty,
   isConditionalProperty,
+  buildFixedJsxExpression,
 } from '../react-component-render-helper';
+
+import { assertASTMatchesSnapshot } from './__utils__/snapshot-helpers';
 
 describe('react-component-render-helper', () => {
   test('getFixedComponentPropValueExpression', () => {
@@ -87,6 +90,60 @@ describe('react-component-render-helper', () => {
           });
         });
       });
+    });
+  });
+
+  describe('buildFixedJsxExpression', () => {
+    test('string', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: 'some text' }));
+    });
+
+    test('number', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: 400 }));
+    });
+
+    test('string wrapped number', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '400' }));
+    });
+
+    test('parsed number', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '400', type: 'Number' }));
+    });
+
+    test('boolean', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: true }));
+    });
+
+    test('string wrapped boolean', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: 'true' }));
+    });
+
+    test('parsed boolean', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: 'true', type: 'Boolean' }));
+    });
+
+    test('string wrapped array', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '[1,2,3]' }));
+    });
+
+    test('parsed array', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '[1,2,3]', type: 'Object' }));
+    });
+
+    test('string wrapped object', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '{"transponder": "rocinante"}' }));
+    });
+
+    test('parsed object', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '{"transponder": "rocinante"}', type: 'Object' }));
+    });
+
+    test('string wrapped null', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: 'null' }));
+    });
+
+    test('parsed null', () => {
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: 'null', type: 'Object' }));
     });
   });
 });

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -263,4 +263,8 @@ describe('amplify render tests', () => {
       expect(generateWithAmplifyRenderer('default-value-components/collectionDefaultValue')).toMatchSnapshot();
     });
   });
+
+  it('should render parsed fixed values', () => {
+    expect(generateWithAmplifyRenderer('parsedFixedValues')).toMatchSnapshot();
+  });
 });

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/parsedFixedValues.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/parsedFixedValues.json
@@ -1,0 +1,138 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "View",
+  "name": "ParsedFixedValues",
+  "properties": {
+    "id": {
+      "value": "parsed-fixed-values"
+    }
+  },
+  "children": [
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "string-value"
+        },
+        "value": {
+          "value": "raw string value"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "number-value"
+        },
+        "value": {
+          "value": "67548"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-number-value"
+        },
+        "value": {
+          "value": "67548",
+          "type": "Number"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "boolean-value"
+        },
+        "value": {
+          "value": "true"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-boolean-value"
+        },
+        "value": {
+          "value": "true",
+          "type": "Boolean"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "json-value"
+        },
+        "value": {
+          "value": "{\"foo\": \"bar\"}"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-json-value"
+        },
+        "value": {
+          "value": "{\"foo\": \"bar\"}",
+          "type": "Object"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "array-value"
+        },
+        "value": {
+          "value": "[1,2,3]"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-array-value"
+        },
+        "value": {
+          "value": "[1,2,3]",
+          "type": "Object"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "null-value"
+        },
+        "value": {
+          "value": "null"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-null-value"
+        },
+        "value": {
+          "value": "null",
+          "type": "Object"
+        }
+      }
+    }
+  ]
+}

--- a/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.js
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.js
@@ -209,6 +209,78 @@ describe('Generated Components', () => {
         });
     });
   });
+
+  describe('Parsed Fixed Property Values', () => {
+    it('String Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values')
+        .find('#string-value')
+        .should('have.attr', 'value')
+        .should('equal', 'raw string value');
+    });
+
+    // string and parsed number values are represented the same in HTML. Snapshot tests cover differences.
+    it('String Number Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values').find('#string-number-value').should('have.attr', 'value').should('equal', '67548');
+    });
+
+    it('Parsed Number Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values').find('#parsed-number-value').should('have.attr', 'value').should('equal', '67548');
+    });
+
+    // string and parsed boolean values are represented the same in HTML. Snapshot tests cover differences.
+    it('String Boolean Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values').find('#string-boolean-value').should('have.attr', 'value').should('equal', 'true');
+    });
+
+    it('Parsed Boolean Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values').find('#parsed-boolean-value').should('have.attr', 'value').should('equal', 'true');
+    });
+
+    it('String JSON Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values')
+        .find('#string-json-value')
+        .should('have.attr', 'value')
+        .should('equal', '{"foo": "bar"}');
+    });
+
+    it('Parsed JSON Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values')
+        .find('#parsed-json-value')
+        .should('have.attr', 'value')
+        .should('equal', '[object Object]'); // shows that object was parsed
+    });
+
+    it('String Array Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values')
+        .find('#string-array-value')
+        .should('have.attr', 'value')
+        .should('equal', '[1,2,3]');
+    });
+
+    it('Parsed Array Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      // no brackets indicates array was parsed
+      cy.get('#parsed-fixed-values').find('#parsed-array-value').should('have.attr', 'value').should('equal', '1,2,3');
+    });
+
+    it('String Null Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values').find('#string-null-value').should('have.attr', 'value').should('equal', 'null');
+    });
+
+    it('Parsed Null Value', () => {
+      cy.visit('http://localhost:3000/component-tests');
+      cy.get('#parsed-fixed-values').find('#parsed-null-value').should('have.attr', 'value').should('be.empty');
+    });
+  });
 });
 
 describe('Generated Themes', () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -42,6 +42,7 @@ import ComponentWithDataBindingWithoutPredicate from './ui-components/ComponentW
 import ComponentWithDataBindingWithPredicate from './ui-components/ComponentWithDataBindingWithPredicate';
 import CollectionWithBinding from './ui-components/CollectionWithBinding';
 import CollectionWithSort from './ui-components/CollectionWithSort';
+import ParsedFixedValues from './ui-components/ParsedFixedValues';
 /* eslint-enable import/extensions */
 
 export default function ComponentTests() {
@@ -176,6 +177,9 @@ export default function ComponentTests() {
         <SimpleAndBoundDefaultValue id="simple-and-bound-override" label="Override Simple And Bound" />
         <CollectionDefaultValue id="collection-default" items={[{}]} />
         <CollectionDefaultValue id="collection-override" items={[{ username: 'Override Collection' }]} />
+      </div>
+      <div id="parsed-fixed-values">
+        <ParsedFixedValues />
       </div>
     </AmplifyProvider>
   );

--- a/packages/test-generator/lib/components/index.ts
+++ b/packages/test-generator/lib/components/index.ts
@@ -23,6 +23,7 @@ export { default as CollectionWithSort } from './collectionWithSort.json';
 export { default as ComponentWithVariant } from './componentWithVariant.json';
 export { default as ComponentWithActionSignOut } from './componentWithActionSignOut.json';
 export { default as ComponentWithActionNavigation } from './componentWithActionNavigation.json';
+export { default as ParsedFixedValues } from './parsedFixedValues.json';
 export * from './basic-components';
 export * from './property-binding';
 export * from './default-value-components';

--- a/packages/test-generator/lib/components/parsedFixedValues.json
+++ b/packages/test-generator/lib/components/parsedFixedValues.json
@@ -1,0 +1,138 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "View",
+  "name": "ParsedFixedValues",
+  "properties": {
+    "id": {
+      "value": "parsed-fixed-values"
+    }
+  },
+  "children": [
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "string-value"
+        },
+        "value": {
+          "value": "raw string value"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "string-number-value"
+        },
+        "value": {
+          "value": "67548"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-number-value"
+        },
+        "value": {
+          "value": "67548",
+          "type": "Number"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "string-boolean-value"
+        },
+        "value": {
+          "value": "true"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-boolean-value"
+        },
+        "value": {
+          "value": "true",
+          "type": "Boolean"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "string-json-value"
+        },
+        "value": {
+          "value": "{\"foo\": \"bar\"}"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-json-value"
+        },
+        "value": {
+          "value": "{\"foo\": \"bar\"}",
+          "type": "Object"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "string-array-value"
+        },
+        "value": {
+          "value": "[1,2,3]"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-array-value"
+        },
+        "value": {
+          "value": "[1,2,3]",
+          "type": "Object"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "string-null-value"
+        },
+        "value": {
+          "value": "null"
+        }
+      }
+    },
+    {
+      "componentType": "Input",
+      "properties": {
+        "id": {
+          "value": "parsed-null-value"
+        },
+        "value": {
+          "value": "null",
+          "type": "Object"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We should wait until after the demo to merge this incase there any last minute bug fixes.

Some props require json, number, or boolean values passed, but Smithy can only pass string.

The current schema says that we can receive `boolean`, `string`, and `Date` types directly, but I believe this is inaccurate. I have kept this functionality for now, but will check with the Studio UI team if this actually possible.
