### PR TITLE
build: ignore integration-test for lerna run

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,6 +7,9 @@
   "command": {
     "version": {
       "message": "chore: release"
+    },
+    "run": {
+      "ignore": "integration-test"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "lerna run test --stream",
     "test:update": "lerna run test:update --stream",
-    "build": "lerna run build --stream --ignore integration-tests",
+    "build": "lerna run build --stream",
     "prepublishOnly": "npm run build && npm run test",
     "setup-dev": "npm install && lerna bootstrap && lerna run build",
     "clean": "lerna run clean && lerna exec npm run rimraf tsconfig.tsbuildinfo && lerna clean --yes && npm run rimraf node_modules",


### PR DESCRIPTION
This will ignore `integration-test` package for all `lerna run` commands. i.e. `lerna run build`.

This will prevent the integration-test package from building unnecessarily and wasting time when developing.
