### PR TITLE
fix: don't redefine prop when using useDataStoreBinding

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -156,6 +156,7 @@ import {
   Flex,
   FlexProps,
   getOverrideProps,
+  useDataStoreBinding,
 } from \\"@aws-amplify/ui-react\\";
 
 export type CollectionOfCustomButtonsProps = Partial<CollectionProps<any>> & {
@@ -172,7 +173,7 @@ export default function CollectionOfCustomButtons(
   const {
     width,
     backgroundColor,
-    buttonColor,
+    buttonColor: buttonColorProp,
     items,
     overrides: overridesProp,
     ...rest
@@ -197,11 +198,13 @@ export default function CollectionOfCustomButtons(
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
-  const { item: buttonColor } = useDataStoreBinding({
-    type: \\"record\\",
+  const buttonColorDataStore = useDataStoreBinding({
+    type: \\"collection\\",
     model: UserPreferences,
     criteria: buttonColorFilter,
-  });
+  }).items[0];
+  const buttonColor =
+    buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;
   return (
     <Collection
       type=\\"list\\"
@@ -244,6 +247,7 @@ import {
   FlexProps,
   SortDirection,
   getOverrideProps,
+  useDataStoreBinding,
 } from \\"@aws-amplify/ui-react\\";
 
 export type CollectionOfCustomButtonsProps = Partial<CollectionProps<any>> & {
@@ -260,7 +264,7 @@ export default function CollectionOfCustomButtons(
   const {
     width,
     backgroundColor,
-    buttonColor,
+    buttonColor: buttonColorProp,
     items,
     overrides: overridesProp,
     ...rest
@@ -290,11 +294,13 @@ export default function CollectionOfCustomButtons(
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
-  const { item: buttonColor } = useDataStoreBinding({
-    type: \\"record\\",
+  const buttonColorDataStore = useDataStoreBinding({
+    type: \\"collection\\",
     model: UserPreferences,
     criteria: buttonColorFilter,
-  });
+  }).items[0];
+  const buttonColor =
+    buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;
   return (
     <Collection
       type=\\"list\\"

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer-helper.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer-helper.ts
@@ -13,6 +13,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+import {
+  StudioComponentDataPropertyBinding,
+  StudioComponentSimplePropertyBinding,
+} from '@amzn/amplify-ui-codegen-schema';
+import { isDataPropertyBinding } from '@amzn/studio-ui-codegen';
+
 import ts, {
   createPrinter,
   createSourceFile,
@@ -149,4 +155,10 @@ export function jsonToLiteral(
       );
     }
   }
+}
+
+export function bindingPropertyUsesHook(
+  binding: StudioComponentDataPropertyBinding | StudioComponentSimplePropertyBinding,
+): boolean {
+  return isDataPropertyBinding(binding) && 'predicate' in binding.bindingProperties;
 }


### PR DESCRIPTION
* Change `record` `useDataStoreBinding` to `collection` and get first `item`.
* don't redefine prop.
  * set prop as `{propName}Prop` and datastore as `{propName}DataStore`.
* When prop is not defined use data store value, else use prop value.