### PR TITLE
fix: createDatastorePredicate call was added

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -178,12 +178,13 @@ export default function CollectionOfCustomButtons(
     ...rest
   } = props;
   const overrides = { ...overridesProp };
-  const buttonUserFilter = {
+  const buttonUserFilterObj = {
     and: [
       { field: \\"age\\", operand: \\"10\\", operator: \\"gt\\" },
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };
+  const buttonUserFilter = createDataStorePredicate(buttonUserFilterObj);
   const buttonUser =
     items !== undefined
       ? items
@@ -192,11 +193,12 @@ export default function CollectionOfCustomButtons(
           model: User,
           criteria: buttonUserFilter,
         }).items;
-  const buttonColorFilter = {
+  const buttonColorFilterObj = {
     field: \\"userID\\",
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
+  const buttonColorFilter = createDataStorePredicate(buttonColorFilterObj);
   const { item: buttonColor } = useDataStoreBinding({
     type: \\"record\\",
     model: UserPreferences,
@@ -266,12 +268,13 @@ export default function CollectionOfCustomButtons(
     ...rest
   } = props;
   const overrides = { ...overridesProp };
-  const buttonUserFilter = {
+  const buttonUserFilterObj = {
     and: [
       { field: \\"age\\", operand: \\"10\\", operator: \\"gt\\" },
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };
+  const buttonUserFilter = createDataStorePredicate(buttonUserFilterObj);
   const buttonUserPagination = {
     sort: (s) =>
       s.firstName(SortDirection.ASCENDING).lastName(SortDirection.DESCENDING),
@@ -285,11 +288,12 @@ export default function CollectionOfCustomButtons(
           criteria: buttonUserFilter,
           pagination: buttonUserPagination,
         }).items;
-  const buttonColorFilter = {
+  const buttonColorFilterObj = {
     field: \\"userID\\",
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
+  const buttonColorFilter = createDataStorePredicate(buttonColorFilterObj);
   const { item: buttonColor } = useDataStoreBinding({
     type: \\"record\\",
     model: UserPreferences,


### PR DESCRIPTION
*Description of changes:*

The function call to createDataStorePredicate is added to convert predicate in object format to DateStore predicate format.  An example of generated code:

```
 const filterCriteriaObj = {
    and: [
      {
        field: 'age',
        operand: '10',
        operator: 'gt',
      },
      {
        field: 'lastName',
        operand: 'L',
        operator: 'beginsWith',
      },
    ],
  };

  const filterCriteria = createDataStorePredicate(filterCriteriaObj);

  const { buttonUser } = useDataStoreBinding({
    type: 'collection', // returns zero or one or many records
    model: User,
    criteria: filterCriteria,
    pagination: buttonUserPagination
  });
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
