### PR TITLE
fix: simple property binding default value

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "integ": "npm run integ:setup && npm run integ:test",
     "integ:setup": "./scripts/integ-setup.sh",
     "integ:templates": "./scripts/integ-templates.sh",
-    "integ:templates:watch": "nodemon --watch packages/test-generator/integration-test-templates/ -e tsx,ts,js,json --exec 'npm run integ:templates'",
+    "integ:templates:watch": "nodemon --watch packages/test-generator/integration-test-templates/ --watch packages/test-generator/lib -e tsx,ts,js,json --exec 'npm run integ:templates'",
     "integ:test": "./scripts/integ-test.sh",
     "integ:clean": "npx rimraf packages/integration-test"
   },

--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -1066,6 +1066,113 @@ export default function Profile(props: ProfileProps): React.ReactElement;
 "
 `;
 
+exports[`amplify render tests default value should render bound default value 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  Text,
+  TextProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type BoundDefaultValueProps = Partial<TextProps> & {
+  label?: String;
+} & {
+  overrides?: EscapeHatchProps | undefined | null;
+};
+export default function BoundDefaultValue(
+  props: BoundDefaultValueProps
+): React.ReactElement {
+  const { label, overrides: overridesProp, ...rest } = props;
+  const overrides = { ...overridesProp };
+  return (
+    <Text {...rest} {...getOverrideProps(overrides, \\"Text\\")}>
+      {label || \\"Bound Default\\"}
+    </Text>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
+exports[`amplify render tests default value should render simple and bound default value 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  Text,
+  TextProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type SimpleAndBoundDefaultValueProps = Partial<TextProps> & {
+  label?: String;
+} & {
+  overrides?: EscapeHatchProps | undefined | null;
+};
+export default function SimpleAndBoundDefaultValue(
+  props: SimpleAndBoundDefaultValueProps
+): React.ReactElement {
+  const {
+    label = \\"Simple Double Default\\",
+    overrides: overridesProp,
+    ...rest
+  } = props;
+  const overrides = { ...overridesProp };
+  return (
+    <Text {...rest} {...getOverrideProps(overrides, \\"Text\\")}>
+      {label || \\"Bound Double Default\\"}
+    </Text>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
+exports[`amplify render tests default value should render simple default value 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  Text,
+  TextProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type SimplePropertyBindingDefaultValueProps = Partial<TextProps> & {
+  label?: String;
+} & {
+  overrides?: EscapeHatchProps | undefined | null;
+};
+export default function SimplePropertyBindingDefaultValue(
+  props: SimplePropertyBindingDefaultValueProps
+): React.ReactElement {
+  const {
+    label = \\"Default Binding Property\\",
+    overrides: overridesProp,
+    ...rest
+  } = props;
+  const overrides = { ...overridesProp };
+  return (
+    <Text {...rest} {...getOverrideProps(overrides, \\"Text\\")}>
+      {label}
+    </Text>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
 exports[`amplify render tests sample code snippet tests should generate a sample code snippet for components 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -243,4 +243,20 @@ describe('amplify render tests', () => {
   it('should render navigation actions', () => {
     expect(generateWithAmplifyRenderer('componentWithActionNavigation')).toMatchSnapshot();
   });
+
+  describe('default value', () => {
+    it('should render bound default value', () => {
+      expect(generateWithAmplifyRenderer('default-value-components/boundDefaultValue')).toMatchSnapshot();
+    });
+
+    it('should render simple and bound default value', () => {
+      expect(generateWithAmplifyRenderer('default-value-components/simpleAndBoundDefaultValue')).toMatchSnapshot();
+    });
+
+    it('should render simple default value', () => {
+      expect(
+        generateWithAmplifyRenderer('default-value-components/simplePropertyBindingDefaultValue'),
+      ).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/boundDefaultValue.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/boundDefaultValue.json
@@ -1,0 +1,18 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Text",
+  "name": "BoundDefaultValue",
+  "bindingProperties": {
+    "label": {
+      "type": "String"
+    }
+  },
+  "properties": {
+    "value": {
+      "bindingProperties": {
+        "property": "label"
+      },
+      "defaultValue": "Bound Default"
+    }
+  }
+}

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simpleAndBoundDefaultValue.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simpleAndBoundDefaultValue.json
@@ -1,0 +1,19 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Text",
+  "name": "SimpleAndBoundDefaultValue",
+  "bindingProperties": {
+    "label": {
+      "type": "String",
+      "defaultValue": "Simple Double Default"
+    }
+  },
+  "properties": {
+    "value": {
+      "bindingProperties": {
+        "property": "label"
+      },
+      "defaultValue": "Bound Double Default"
+    }
+  }
+}

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simplePropertyBindingDefaultValue.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simplePropertyBindingDefaultValue.json
@@ -1,0 +1,18 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Text",
+  "name": "SimplePropertyBindingDefaultValue",
+  "bindingProperties": {
+    "label": {
+      "type": "String",
+      "defaultValue": "Default Binding Property"
+    }
+  },
+  "properties": {
+    "value": {
+      "bindingProperties": {
+        "property": "label"
+      }
+    }
+  }
+}

--- a/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.js
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.js
@@ -108,6 +108,62 @@ describe('Generated Components', () => {
   describe('Collections', () => {
     // TODO: Write Collection Cases
   });
+
+  describe('Default Value', () => {
+    it('Renders simple property binding default value', () => {
+      cy.get('#default-value')
+        .get('#bound-simple-binding-default')
+        .invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal('Default Binding Property');
+        });
+    });
+
+    it('Overrides simple property binding default value', () => {
+      cy.get('#default-value')
+        .get('#bound-simple-binding-override')
+        .invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal('Override Simple Binding');
+        });
+    });
+
+    it('Renders bound default value', () => {
+      cy.get('#default-value')
+        .get('#bound-default')
+        .invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal('Bound Default');
+        });
+    });
+
+    it('Overrides bound default value', () => {
+      cy.get('#default-value')
+        .get('#bound-override')
+        .invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal('Override Bound');
+        });
+    });
+
+    it('Renders simple default value when simple and bound', () => {
+      cy.get('#default-value')
+        .get('#simple-and-bound-default')
+        .invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal('Simple Double Default');
+        });
+    });
+
+    it('Overrides simple and bound default value', () => {
+      cy.get('#default-value')
+        .get('#simple-and-bound-override')
+        .invoke('text')
+        .then((text) => {
+          expect(text.trim()).equal('Override Simple And Bound');
+        });
+    });
+  });
 });
 
 describe('Generated Themes', () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -32,6 +32,9 @@ import BasicComponentFlex from './ui-components/BasicComponentFlex';
 import BasicComponentImage from './ui-components/BasicComponentImage';
 import BasicComponentCustomRating from './ui-components/BasicComponentCustomRating';
 import ComponentWithVariant from './ui-components/ComponentWithVariant';
+import SimplePropertyBindingDefaultValue from './ui-components/SimplePropertyBindingDefaultValue';
+import BoundDefaultValue from './ui-components/BoundDefaultValue';
+import SimpleAndBoundDefaultValue from './ui-components/SimpleAndBoundDefaultValue';
 import theme from './ui-components/MyTheme';
 /* eslint-enable import/extensions */
 
@@ -109,6 +112,15 @@ export default function ComponentTests() {
         <ComponentWithVariant id="variant1" variant="primary" />
         <ComponentWithVariant id="variant2" variant="secondary" />
         <ComponentWithVariant id="variant3" variant="primary" size="large" />
+      </div>
+      <div id="default-value">
+        <h2>Default Value</h2>
+        <SimplePropertyBindingDefaultValue id="bound-simple-binding-default" />
+        <SimplePropertyBindingDefaultValue id="bound-simple-binding-override" label="Override Simple Binding" />
+        <BoundDefaultValue id="bound-default" />
+        <BoundDefaultValue id="bound-override" label="Override Bound" />
+        <SimpleAndBoundDefaultValue id="simple-and-bound-default" />
+        <SimpleAndBoundDefaultValue id="simple-and-bound-override" label="Override Simple And Bound" />
       </div>
     </AmplifyProvider>
   );

--- a/packages/test-generator/lib/components/default-value-components/boundDefaultValue.json
+++ b/packages/test-generator/lib/components/default-value-components/boundDefaultValue.json
@@ -1,0 +1,18 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Text",
+  "name": "BoundDefaultValue",
+  "bindingProperties": {
+    "label": {
+      "type": "String"
+    }
+  },
+  "properties": {
+    "value": {
+      "bindingProperties": {
+        "property": "label"
+      },
+      "defaultValue": "Bound Default"
+    }
+  }
+}

--- a/packages/test-generator/lib/components/default-value-components/index.js
+++ b/packages/test-generator/lib/components/default-value-components/index.js
@@ -1,0 +1,18 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+export { default as BoundDefaultValue } from './boundDefaultValue.json';
+export { default as SimplePropertyBindingDefaultValue } from './simplePropertyBindingDefaultValue.json';
+export { default as SimpleAndBouldDefaultValue } from './simpleAndBoundDefaultValue.json';

--- a/packages/test-generator/lib/components/default-value-components/simpleAndBoundDefaultValue.json
+++ b/packages/test-generator/lib/components/default-value-components/simpleAndBoundDefaultValue.json
@@ -1,0 +1,19 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Text",
+  "name": "SimpleAndBoundDefaultValue",
+  "bindingProperties": {
+    "label": {
+      "type": "String",
+      "defaultValue": "Simple Double Default"
+    }
+  },
+  "properties": {
+    "value": {
+      "bindingProperties": {
+        "property": "label"
+      },
+      "defaultValue": "Bound Double Default"
+    }
+  }
+}

--- a/packages/test-generator/lib/components/default-value-components/simplePropertyBindingDefaultValue.json
+++ b/packages/test-generator/lib/components/default-value-components/simplePropertyBindingDefaultValue.json
@@ -1,0 +1,18 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Text",
+  "name": "SimplePropertyBindingDefaultValue",
+  "bindingProperties": {
+    "label": {
+      "type": "String",
+      "defaultValue": "Default Binding Property"
+    }
+  },
+  "properties": {
+    "value": {
+      "bindingProperties": {
+        "property": "label"
+      }
+    }
+  }
+}

--- a/packages/test-generator/lib/components/index.ts
+++ b/packages/test-generator/lib/components/index.ts
@@ -26,3 +26,4 @@ export { default as ComponentWithVariant } from './componentWithVariant.json';
 export { default as ComponentWithActionSignOut } from './componentWithActionSignOut.json';
 export { default as ComponentWithActionNavigation } from './componentWithActionNavigation.json';
 export * from './basic-components';
+export * from './default-value-components';

--- a/scripts/integ-templates.sh
+++ b/scripts/integ-templates.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+lerna run build --scope @amzn/test-generator
 cp -r packages/test-generator/integration-test-templates/. packages/integration-test
 node packages/test-generator/dist/generators/GenerateTestApp.js


### PR DESCRIPTION
* fix simple property binding default
Previously these default values were not honored.
Example: 
```js
// previous:
const { label } = props;
// fixed
const { label: 'Default Value' } = props;
```
* add integ test default values
* enhance template watch script to rebuild test-generator on changes

I've copied the same components from integ to snapshot tests for default value cases. In the future we can improve how components are shared between these packages, but for now it is duplicated.

To Do in separate PR
* Add integ test for default value for collection bound properties. (Requires `model` type fix).