### PR TITLE
feat: re-enable datastore predicates, and adding data case to verify that filtering works

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -162,6 +162,7 @@ import {
   CollectionProps,
   EscapeHatchProps,
   Flex,
+  createDataStorePredicate,
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react\\";
@@ -194,21 +195,26 @@ export default function CollectionOfCustomButtons(
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };
+  const buttonUserFilter = createDataStorePredicate<User>(buttonUserFilterObj);
   const buttonUser =
     items !== undefined
       ? items
       : useDataStoreBinding({
           type: \\"collection\\",
           model: User,
+          criteria: buttonUserFilter,
         }).items;
   const buttonColorFilterObj = {
     field: \\"userID\\",
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
+  const buttonColorFilter =
+    createDataStorePredicate<UserPreferences>(buttonColorFilterObj);
   const buttonColorDataStore = useDataStoreBinding({
     type: \\"collection\\",
     model: UserPreferences,
+    criteria: buttonColorFilter,
   }).items[0];
   const buttonColor =
     buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;
@@ -251,6 +257,7 @@ import {
   CollectionProps,
   EscapeHatchProps,
   Flex,
+  createDataStorePredicate,
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react\\";
@@ -284,6 +291,7 @@ export default function CollectionOfCustomButtons(
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };
+  const buttonUserFilter = createDataStorePredicate<User>(buttonUserFilterObj);
   const buttonUserPagination = {
     sort: (s: SortPredicate<User>) =>
       s.firstName(SortDirection.ASCENDING).lastName(SortDirection.DESCENDING),
@@ -294,6 +302,7 @@ export default function CollectionOfCustomButtons(
       : useDataStoreBinding({
           type: \\"collection\\",
           model: User,
+          criteria: buttonUserFilter,
           pagination: buttonUserPagination,
         }).items;
   const buttonColorFilterObj = {
@@ -301,9 +310,12 @@ export default function CollectionOfCustomButtons(
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
+  const buttonColorFilter =
+    createDataStorePredicate<UserPreferences>(buttonColorFilterObj);
   const buttonColorDataStore = useDataStoreBinding({
     type: \\"collection\\",
     model: UserPreferences,
+    criteria: buttonColorFilter,
   }).items[0];
   const buttonColor =
     buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;
@@ -348,6 +360,7 @@ import {
   CollectionProps,
   EscapeHatchProps,
   Flex,
+  createDataStorePredicate,
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react\\";
@@ -380,21 +393,26 @@ export default function CollectionOfCustomButtons(
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };
+  const itemsFilter = createDataStorePredicate<User>(itemsFilterObj);
   const items =
     itemsProp !== undefined
       ? itemsProp
       : useDataStoreBinding({
           type: \\"collection\\",
           model: User,
+          criteria: itemsFilter,
         }).items;
   const buttonColorFilterObj = {
     field: \\"userID\\",
     operand: \\"user@email.com\\",
     operator: \\"eq\\",
   };
+  const buttonColorFilter =
+    createDataStorePredicate<UserPreferences>(buttonColorFilterObj);
   const buttonColorDataStore = useDataStoreBinding({
     type: \\"collection\\",
     model: UserPreferences,
+    criteria: buttonColorFilter,
   }).items[0];
   const buttonColor =
     buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -668,8 +668,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
         const [propName, { model, sort, predicate }] = collectionProp;
         if (predicate) {
           statements.push(this.buildPredicateDeclaration(propName, predicate));
-          // TODO: Re-enable data store predicates https://app.asana.com/0/1200812113384502/1201289886389275/f
-          // statements.push(this.buildCreateDataStorePredicateCall(propName));
+          statements.push(this.buildCreateDataStorePredicateCall(model, propName));
         }
         if (sort) {
           this.importCollection.addImport('@aws-amplify/datastore', 'SortDirection');
@@ -698,7 +697,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     return statements;
   }
 
-  private buildCreateDataStorePredicateCall(name: string): Statement {
+  private buildCreateDataStorePredicateCall(type: string, name: string): Statement {
     this.importCollection.addImport('@aws-amplify/ui-react', 'createDataStorePredicate');
     return factory.createVariableStatement(
       undefined,
@@ -708,9 +707,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
             factory.createIdentifier(this.getFilterName(name)),
             undefined,
             undefined,
-            factory.createCallExpression(factory.createIdentifier('createDataStorePredicate'), undefined, [
-              factory.createIdentifier(this.getFilterObjName(name)),
-            ]),
+            factory.createCallExpression(
+              factory.createIdentifier('createDataStorePredicate'),
+              [factory.createTypeReferenceNode(factory.createIdentifier(type), undefined)],
+              [factory.createIdentifier(this.getFilterObjName(name))],
+            ),
           ),
         ],
         ts.NodeFlags.Const,
@@ -736,8 +737,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
              * }
              */
             statements.push(this.buildPredicateDeclaration(propName, bindingProperties.predicate));
-            // TODO: Re-enable data store predicates https://app.asana.com/0/1200812113384502/1201289886389275/f
-            // statements.push(this.buildCreateDataStorePredicateCall(propName));
+            statements.push(this.buildCreateDataStorePredicateCall(bindingProperties.model, propName));
             const { model } = bindingProperties;
             this.importCollection.addImport('../models', model);
 
@@ -957,17 +957,16 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       factory.createPropertyAssignment(factory.createIdentifier('type'), factory.createStringLiteral(callType)),
       factory.createPropertyAssignment(factory.createIdentifier('model'), factory.createIdentifier(bindingModel)),
     ]
-      // TODO: Re-enable data store predicates https://app.asana.com/0/1200812113384502/1201289886389275/f
-      // .concat(
-      //   criteriaName
-      //     ? [
-      //         factory.createPropertyAssignment(
-      //           factory.createIdentifier('criteria'),
-      //           factory.createIdentifier(criteriaName),
-      //         ),
-      //       ]
-      //     : [],
-      // )
+      .concat(
+        criteriaName
+          ? [
+              factory.createPropertyAssignment(
+                factory.createIdentifier('criteria'),
+                factory.createIdentifier(criteriaName),
+              ),
+            ]
+          : [],
+      )
       .concat(
         paginationName
           ? [

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -55,9 +55,10 @@ import PaginatedCollection from './ui-components/PaginatedCollection';
 /* eslint-enable import/extensions */
 
 const initializeUserTestData = async (): Promise<void> => {
-  await DataStore.save(new User({ firstName: 'Real', lastName: 'LUser3' }));
-  await DataStore.save(new User({ firstName: 'Another', lastName: 'LUser2' }));
-  await DataStore.save(new User({ firstName: 'Last', lastName: 'LUser1' }));
+  await DataStore.save(new User({ firstName: 'Real', lastName: 'LUser3', age: 29 }));
+  await DataStore.save(new User({ firstName: 'Another', lastName: 'LUser2', age: 72 }));
+  await DataStore.save(new User({ firstName: 'Last', lastName: 'LUser1', age: 50 }));
+  await DataStore.save(new User({ firstName: 'Too Young', lastName: 'LUser0', age: 5 }));
 };
 
 const initializeListingTestData = async (): Promise<void> => {


### PR DESCRIPTION
Release of this change is dependent on @aws-amplify/ui-react@0.0.0-next-2021101201536 being available for consumption by studio ui. Will hold until then, and bump the dep in studio ui when this is released into that scope.