### PR TITLE
feat: primitive children prop mapping

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -111,11 +111,10 @@ export default function CustomText(props: CustomTextProps): React.ReactElement {
     <Text
       color=\\"#ff0000\\"
       width=\\"20px\\"
+      children=\\"Text Value\\"
       {...rest}
       {...getOverrideProps(overrides, \\"Text\\")}
-    >
-      {\\"Text Value\\"}
-    </Text>
+    ></Text>
   );
 }
 "
@@ -232,10 +231,10 @@ export default function CollectionOfCustomButtons(
       {(item, index) => (
         <Flex {...getOverrideProps(overrides, \\"Collection.Flex[0]\\")}>
           <Button
-            label={item.username || \\"hspain@gmail.com\\"}
             labelWidth={width}
             backgroundColor={buttonColor?.favoriteColor}
             disabled={isDisabled}
+            children={item.username || \\"hspain@gmail.com\\"}
             {...getOverrideProps(overrides, \\"Collection.Flex[0].Button[0]\\")}
           ></Button>
         </Flex>
@@ -333,10 +332,10 @@ export default function CollectionOfCustomButtons(
       {(item, index) => (
         <Flex {...getOverrideProps(overrides, \\"Collection.Flex[0]\\")}>
           <Button
-            label={item.username || \\"hspain@gmail.com\\"}
             labelWidth={width}
             backgroundColor={buttonColor?.favoriteColor}
             disabled={isDisabled}
+            children={item.username || \\"hspain@gmail.com\\"}
             {...getOverrideProps(overrides, \\"Collection.Flex[0].Button[0]\\")}
           ></Button>
         </Flex>
@@ -430,10 +429,10 @@ export default function CollectionOfCustomButtons(
       {(item, index) => (
         <Flex {...getOverrideProps(overrides, \\"Collection.Flex[0]\\")}>
           <Button
-            label={item.username || \\"hspain@gmail.com\\"}
             labelWidth={width}
             backgroundColor={buttonColor?.favoriteColor}
             disabled={isDisabled}
+            children={item.username || \\"hspain@gmail.com\\"}
             {...getOverrideProps(overrides, \\"Collection.Flex[0].Button[0]\\")}
           ></Button>
         </Flex>
@@ -694,10 +693,9 @@ export default function Hi(props: HiProps): React.ReactElement {
         position=\\"relative\\"
         fontWeight=\\"400\\"
         height=\\"14px\\"
+        children=\\"Hi harriso\\"
         {...getOverrideProps(overrides, \\"Flex.Text[0]\\")}
-      >
-        {\\"Hi harriso\\"}
-      </Text>
+      ></Text>
     </Flex>
   );
 }
@@ -824,10 +822,9 @@ export default function NewComponent(
         position=\\"relative\\"
         fontWeight=\\"400\\"
         height=\\"29px\\"
+        children=\\"Hello World!\\"
         {...getOverrideProps(overrides, \\"Flex.Text[0]\\")}
-      >
-        {\\"Hello World!\\"}
-      </Text>
+      ></Text>
       <Box
         width=\\"390px\\"
         padding=\\"0px 0px 0px 0px\\"
@@ -853,10 +850,9 @@ export default function NewComponent(
         position=\\"relative\\"
         fontWeight=\\"400\\"
         height=\\"29px\\"
+        children=\\"Testing 123\\"
         {...getOverrideProps(overrides, \\"Flex.Text[1]\\")}
-      >
-        {\\"Testing 123\\"}
-      </Text>
+      ></Text>
     </Flex>
   );
 }
@@ -1079,10 +1075,9 @@ export default function MohitHome(props: MohitHomeProps): React.ReactElement {
         position=\\"relative\\"
         fontWeight=\\"700\\"
         height=\\"29px\\"
+        children=\\"Name\\"
         {...getOverrideProps(overrides, \\"Flex.Text[0]\\")}
-      >
-        {\\"Name\\"}
-      </Text>
+      ></Text>
       <Text
         padding=\\"0px 0px 0px 0px\\"
         fontFamily=\\"Roboto\\"
@@ -1094,10 +1089,9 @@ export default function MohitHome(props: MohitHomeProps): React.ReactElement {
         position=\\"relative\\"
         fontWeight=\\"400\\"
         height=\\"14px\\"
+        children=\\"Price / Address\\"
         {...getOverrideProps(overrides, \\"Flex.Text[1]\\")}
-      >
-        {\\"Price / Address\\"}
-      </Text>
+      ></Text>
       <Text
         padding=\\"0px 0px 0px 0px\\"
         fontFamily=\\"Roboto\\"
@@ -1109,10 +1103,9 @@ export default function MohitHome(props: MohitHomeProps): React.ReactElement {
         position=\\"relative\\"
         fontWeight=\\"400\\"
         height=\\"14px\\"
+        children=\\"Sqft\\"
         {...getOverrideProps(overrides, \\"Flex.Text[2]\\")}
-      >
-        {\\"Sqft\\"}
-      </Text>
+      ></Text>
     </Flex>
   );
 }
@@ -1173,10 +1166,9 @@ export default function ImageFlex(props: ImageFlexProps): React.ReactElement {
         position=\\"absolute\\"
         fontWeight=\\"400\\"
         height=\\"27.839996337890625px\\"
+        children=\\"Test\\"
         {...getOverrideProps(overrides, \\"Box.Text[0]\\")}
-      >
-        {\\"Test\\"}
-      </Text>
+      ></Text>
       <Image
         border=\\"4px SOLID rgb(0,0,0)\\"
         padding=\\"0px 0px 0px 0px\\"
@@ -1292,11 +1284,10 @@ export default function TextWithDataBinding(
     <Text
       color=\\"#ff0000\\"
       width=\\"20px\\"
+      children={textValue}
       {...rest}
       {...getOverrideProps(overrides, \\"Text\\")}
-    >
-      {textValue}
-    </Text>
+    ></Text>
   );
 }
 "
@@ -1338,9 +1329,9 @@ export default function ComponentWithDataBinding(
   return (
     /* @ts-ignore: TS2322 */
     <Button
-      label={buttonUser?.username || \\"hspain@gmail.com\\"}
       labelWidth={width}
       disabled={isDisabled}
+      children={buttonUser?.username || \\"hspain@gmail.com\\"}
       {...rest}
       {...getOverrideProps(overrides, \\"Button\\")}
     ></Button>
@@ -1393,10 +1384,9 @@ export default function SectionHeading(
           fontSize=\\"48px\\"
           lineHeight=\\"48px\\"
           fontWeight=\\"300\\"
+          children=\\"Heading 2\\"
           {...getOverrideProps(overrides, \\"Flex.Flex[0].Text[0]\\")}
-        >
-          {\\"Heading 2\\"}
-        </Text>
+        ></Text>
       </Flex>
       <Text
         fontFamily=\\"Inter\\"
@@ -1405,10 +1395,9 @@ export default function SectionHeading(
         fontSize=\\"32px\\"
         lineHeight=\\"48px\\"
         fontWeight=\\"400\\"
+        children=\\"subtitle\\"
         {...getOverrideProps(overrides, \\"Flex.Text[0]\\")}
-      >
-        {\\"subtitle\\"}
-      </Text>
+      ></Text>
     </Flex>
   );
 }
@@ -1441,9 +1430,10 @@ export default function ChildComponentWithDataBinding(
   return (
     /* @ts-ignore: TS2322 */
     <Button {...rest} {...getOverrideProps(overrides, \\"Button\\")}>
-      <Text {...getOverrideProps(overrides, \\"Button.Text[0]\\")}>
-        {textValue}
-      </Text>
+      <Text
+        children={textValue}
+        {...getOverrideProps(overrides, \\"Button.Text[0]\\")}
+      ></Text>
     </Button>
   );
 }
@@ -1534,9 +1524,12 @@ export default function ChildComponentWithDataBoundConcatenation(
   return (
     /* @ts-ignore: TS2322 */
     <Button {...rest} {...getOverrideProps(overrides, \\"Button\\")}>
-      <Text {...getOverrideProps(overrides, \\"Button.Text[0]\\")}>{\`\${
-        buttonUser?.firstname || \\"Harrison\\"
-      }\${\\" \\"}\${buttonUser?.lastname || \\"Spain\\"}\`}</Text>
+      <Text
+        children={\`\${buttonUser?.firstname || \\"Harrison\\"}\${\\" \\"}\${
+          buttonUser?.lastname || \\"Spain\\"
+        }\`}
+        {...getOverrideProps(overrides, \\"Button.Text[0]\\")}
+      ></Text>
     </Button>
   );
 }
@@ -1569,8 +1562,9 @@ export default function ChildComponentWithStaticConcatenation(
     /* @ts-ignore: TS2322 */
     <Button {...rest} {...getOverrideProps(overrides, \\"Button\\")}>
       <Text
+        children={\`\${\\"Concatenate\\"}\${\\" \\"}\${\\"Me!\\"}\`}
         {...getOverrideProps(overrides, \\"Button.Text[0]\\")}
-      >{\`\${\\"Concatenate\\"}\${\\" \\"}\${\\"Me!\\"}\`}</Text>
+      ></Text>
     </Button>
   );
 }
@@ -1611,10 +1605,10 @@ export default function CustomButton(
   return (
     /* @ts-ignore: TS2322 */
     <Button
-      label={\`\${buttonUser?.firstname || \\"Harrison\\"}\${\\" \\"}\${
+      labelWidth={width}
+      children={\`\${buttonUser?.firstname || \\"Harrison\\"}\${\\" \\"}\${
         buttonUser?.lastname || \\"Spain\\"
       }\`}
-      labelWidth={width}
       {...rest}
       {...getOverrideProps(overrides, \\"Button\\")}
     ></Button>
@@ -1657,9 +1651,6 @@ export default function CustomButton(
   return (
     /* @ts-ignore: TS2322 */
     <Button
-      label={\`\${buttonUser?.firstname || \\"Harrison\\"}\${\\" \\"}\${
-        buttonUser?.lastname || \\"Spain\\"
-      }\`}
       labelWidth={width}
       disabled={
         buttonUser?.isLoggedIn && buttonUser?.isLoggedIn === true ? true : false
@@ -1674,6 +1665,9 @@ export default function CustomButton(
           ? buttonUser?.loggedInColor
           : buttonUser?.loggedOutColor
       }
+      children={\`\${buttonUser?.firstname || \\"Harrison\\"}\${\\" \\"}\${
+        buttonUser?.lastname || \\"Spain\\"
+      }\`}
       {...rest}
       {...getOverrideProps(overrides, \\"Button\\")}
     ></Button>
@@ -2178,9 +2172,11 @@ export default function BoundDefaultValue(
   const overrides = { ...overridesProp };
   return (
     /* @ts-ignore: TS2322 */
-    <Text {...rest} {...getOverrideProps(overrides, \\"Text\\")}>
-      {label || \\"Bound Default\\"}
-    </Text>
+    <Text
+      children={label || \\"Bound Default\\"}
+      {...rest}
+      {...getOverrideProps(overrides, \\"Text\\")}
+    ></Text>
   );
 }
 ",
@@ -2228,9 +2224,10 @@ export default function CollectionDefaultValue(
       {...getOverrideProps(overrides, \\"Collection\\")}
     >
       {(item, index) => (
-        <Text {...getOverrideProps(overrides, \\"Collection.Text[0]\\")}>
-          {item.username || \\"Collection Default Value\\"}
-        </Text>
+        <Text
+          children={item.username || \\"Collection Default Value\\"}
+          {...getOverrideProps(overrides, \\"Collection.Text[0]\\")}
+        ></Text>
       )}
     </Collection>
   );
@@ -2270,9 +2267,11 @@ export default function SimpleAndBoundDefaultValue(
   const overrides = { ...overridesProp };
   return (
     /* @ts-ignore: TS2322 */
-    <Text {...rest} {...getOverrideProps(overrides, \\"Text\\")}>
-      {label || \\"Bound Double Default\\"}
-    </Text>
+    <Text
+      children={label || \\"Bound Double Default\\"}
+      {...rest}
+      {...getOverrideProps(overrides, \\"Text\\")}
+    ></Text>
   );
 }
 ",
@@ -2310,9 +2309,11 @@ export default function SimplePropertyBindingDefaultValue(
   const overrides = { ...overridesProp };
   return (
     /* @ts-ignore: TS2322 */
-    <Text {...rest} {...getOverrideProps(overrides, \\"Text\\")}>
-      {label}
-    </Text>
+    <Text
+      children={label}
+      {...rest}
+      {...getOverrideProps(overrides, \\"Text\\")}
+    ></Text>
   );
 }
 ",
@@ -2655,11 +2656,11 @@ export default function Profile(props: ProfileProps): React.ReactElement {
         {...getOverrideProps(overrides, \\"Flex.Image[0]\\")}
       ></Image>
       <Button
-        label={username}
+        children={username}
         {...getOverrideProps(overrides, \\"Flex.Button[0]\\")}
       ></Button>
       <Button
-        label={customUserAttributeIcecream}
+        children={customUserAttributeIcecream}
         {...getOverrideProps(overrides, \\"Flex.Button[1]\\")}
       ></Button>
     </Flex>

--- a/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/primitives.test.ts
+++ b/packages/studio-ui-codegen-react/lib/__tests__/amplify-ui-renderers/primitives.test.ts
@@ -18,7 +18,7 @@ import { assertASTMatchesSnapshot } from '../__utils__/snapshot-helpers';
 
 import renderString from '../../amplify-ui-renderers/string';
 import { AmplifyRenderer } from '../../amplify-ui-renderers/amplify-renderer';
-import Primitives from '../../primitives';
+import Primitive from '../../primitive';
 
 function testPrimitive(component: StudioComponent) {
   const renderedComponent = new AmplifyRenderer(component, {}).renderJsx(component);
@@ -26,7 +26,7 @@ function testPrimitive(component: StudioComponent) {
 }
 
 describe('Primitives', () => {
-  Object.values(Primitives).forEach((primitive) => {
+  Object.values(Primitive).forEach((primitive) => {
     test(primitive, () => {
       testPrimitive({
         componentType: primitive,

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/childComponentWithDataBinding.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/childComponentWithDataBinding.json
@@ -13,7 +13,7 @@
       "componentType": "Text",
       "name": "TextWithDataBinding",
       "properties": {
-        "value": {
+        "label": {
           "bindingProperties": {
             "property": "textValue"
           }

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/childComponentWithDataBoundConcatenation.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/childComponentWithDataBoundConcatenation.json
@@ -13,7 +13,7 @@
       "componentType": "Text",
       "name": "TextWithConcatenation",
       "properties": {
-        "value": {
+        "label": {
           "concat": [
             {
               "bindingProperties": {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/childComponentWithStaticConcatenation.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/childComponentWithStaticConcatenation.json
@@ -9,7 +9,7 @@
       "componentType": "Text",
       "name": "TextWithConcatenation",
       "properties": {
-        "value": {
+        "label": {
           "concat": [
             {
               "value": "Concatenate"

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest1.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest1.json
@@ -31,7 +31,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Hi harriso"
           },
           "fontWeight": {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest3.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest3.json
@@ -31,7 +31,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Hello World!"
           },
           "fontWeight": {
@@ -109,7 +109,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Testing 123"
           },
           "fontWeight": {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest6.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest6.json
@@ -31,7 +31,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Name"
           },
           "fontWeight": {
@@ -71,7 +71,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Price / Address"
           },
           "fontWeight": {
@@ -111,7 +111,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Sqft"
           },
           "fontWeight": {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest7.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/complexTest7.json
@@ -71,7 +71,7 @@
           "position": {
             "value": "absolute"
           },
-          "value": {
+          "label": {
             "value": "Test"
           },
           "fontWeight": {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/dataBindingWithoutPredicate.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/dataBindingWithoutPredicate.json
@@ -34,7 +34,7 @@
             "lineHeight": {
               "value": "48px"
             },
-            "value": {
+            "label": {
               "value": "Heading 2"
             },
             "fontWeight": {
@@ -71,7 +71,7 @@
         "lineHeight": {
           "value": "48px"
         },
-        "value": {
+        "label": {
           "value": "subtitle"
         },
         "fontWeight": {

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/boundDefaultValue.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/boundDefaultValue.json
@@ -8,7 +8,7 @@
     }
   },
   "properties": {
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "label"
       },

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/collectionDefaultValue.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/collectionDefaultValue.json
@@ -12,7 +12,7 @@
     {
       "componentType": "Text",
       "properties": {
-        "value": {
+        "label": {
           "collectionBindingProperties": {
             "property": "user",
             "field": "username"

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simpleAndBoundDefaultValue.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simpleAndBoundDefaultValue.json
@@ -9,7 +9,7 @@
     }
   },
   "properties": {
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "label"
       },

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simplePropertyBindingDefaultValue.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/default-value-components/simplePropertyBindingDefaultValue.json
@@ -9,7 +9,7 @@
     }
   },
   "properties": {
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "label"
       }

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/textGolden.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/textGolden.json
@@ -9,7 +9,7 @@
     "width": {
       "value": "20px"
     },
-    "value": {
+    "label": {
       "value": "Text Value"
     }
   }

--- a/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/textWithDataBinding.json
+++ b/packages/studio-ui-codegen-react/lib/__tests__/studio-ui-json/textWithDataBinding.json
@@ -9,7 +9,7 @@
     "width": {
       "value": "20px"
     },
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "textValue"
       }

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -53,7 +53,7 @@ import {
   ViewProps,
   VisuallyHiddenProps,
 } from '@aws-amplify/ui-react';
-import Primitives from '../primitives';
+import Primitive from '../primitive';
 import { ReactStudioTemplateRenderer } from '../react-studio-template-renderer';
 import TextRenderer from './text';
 import renderString from './string';
@@ -67,57 +67,57 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
     const node = new StudioNode(component, parent);
     const renderChildren = (children: StudioComponentChild[]) => children.map((child) => this.renderJsx(child, node));
 
-    // add primitives in alphabetical order
+    // add Primitive in alphabetical order
     switch (component.componentType) {
-      case Primitives.Alert:
+      case Primitive.Alert:
         return new ReactComponentWithChildrenRenderer<AlertProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Badge:
+      case Primitive.Badge:
         return new ReactComponentWithChildrenRenderer<BadgeProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Button:
+      case Primitive.Button:
         return new ReactComponentWithChildrenRenderer<ButtonProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.ButtonGroup:
+      case Primitive.ButtonGroup:
         return new ReactComponentWithChildrenRenderer<ButtonGroupProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Card:
+      case Primitive.Card:
         return new ReactComponentWithChildrenRenderer<CardProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.CheckboxField:
+      case Primitive.CheckboxField:
         return new ReactComponentWithChildrenRenderer<CheckboxFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Collection:
+      case Primitive.Collection:
         return new CollectionRenderer(component, this.importCollection, parent).renderElement(renderChildren);
 
-      case Primitives.Divider:
+      case Primitive.Divider:
         return new ReactComponentRenderer<DividerProps>(component, this.importCollection, parent).renderElement();
 
-      case Primitives.FieldGroup:
+      case Primitive.FieldGroup:
         // TODO: Use correct prop type
         return new ReactComponentWithChildrenRenderer<ViewProps>(
           component,
@@ -125,174 +125,174 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.FieldGroupIcon:
+      case Primitive.FieldGroupIcon:
         return new ReactComponentWithChildrenRenderer<FieldGroupIconProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.FieldGroupIconButton:
+      case Primitive.FieldGroupIconButton:
         return new ReactComponentWithChildrenRenderer<FieldGroupIconButtonProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Flex:
+      case Primitive.Flex:
         return new ReactComponentWithChildrenRenderer<FlexProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Grid:
+      case Primitive.Grid:
         return new ReactComponentWithChildrenRenderer<GridProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Heading:
+      case Primitive.Heading:
         return new ReactComponentWithChildrenRenderer<HeadingProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Icon:
+      case Primitive.Icon:
         return new ReactComponentWithChildrenRenderer<IconProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Image:
+      case Primitive.Image:
         return new ReactComponentRenderer<ImageProps>(component, this.importCollection, parent).renderElement();
 
-      case Primitives.Input:
+      case Primitive.Input:
         return new ReactComponentWithChildrenRenderer<InputProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Label:
+      case Primitive.Label:
         return new ReactComponentWithChildrenRenderer<LabelProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Link:
+      case Primitive.Link:
         return new ReactComponentWithChildrenRenderer<LinkProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Loader:
+      case Primitive.Loader:
         return new ReactComponentWithChildrenRenderer<LoaderProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Pagination:
+      case Primitive.Pagination:
         return new ReactComponentWithChildrenRenderer<PaginationProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.PasswordField:
+      case Primitive.PasswordField:
         return new ReactComponentWithChildrenRenderer<PasswordFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.PhoneNumberField:
+      case Primitive.PhoneNumberField:
         return new ReactComponentWithChildrenRenderer<PhoneNumberFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Placeholder:
+      case Primitive.Placeholder:
         return new ReactComponentWithChildrenRenderer<PlaceholderProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Radio:
+      case Primitive.Radio:
         return new ReactComponentWithChildrenRenderer<RadioProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.RadioGroupField:
+      case Primitive.RadioGroupField:
         return new ReactComponentWithChildrenRenderer<RadioGroupFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Rating:
+      case Primitive.Rating:
         return new ReactComponentWithChildrenRenderer<RatingProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.ScrollView:
+      case Primitive.ScrollView:
         return new ReactComponentWithChildrenRenderer<ScrollViewProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.SearchField:
+      case Primitive.SearchField:
         return new ReactComponentWithChildrenRenderer<SearchFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.SelectField:
+      case Primitive.SelectField:
         return new ReactComponentWithChildrenRenderer<SelectFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.StepperField:
+      case Primitive.StepperField:
         return new ReactComponentWithChildrenRenderer<StepperFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.SwitchField:
+      case Primitive.SwitchField:
         return new ReactComponentWithChildrenRenderer<SwitchFieldProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Tabs:
+      case Primitive.Tabs:
         return new ReactComponentWithChildrenRenderer<TabsProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.Text:
+      case Primitive.Text:
         return new TextRenderer(component, this.importCollection, parent).renderElement();
 
-      case Primitives.TextField:
+      case Primitive.TextField:
         // unofficial support to retain functionality
         // TODO: add official support
         return new ReactComponentWithChildrenRenderer<ViewProps>(
@@ -301,28 +301,28 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.ToggleButton:
+      case Primitive.ToggleButton:
         return new ReactComponentWithChildrenRenderer<ToggleButtonProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.ToggleButtonGroup:
+      case Primitive.ToggleButtonGroup:
         return new ReactComponentWithChildrenRenderer<ToggleButtonGroupProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.View:
+      case Primitive.View:
         return new ReactComponentWithChildrenRenderer<ViewProps>(
           component,
           this.importCollection,
           parent,
         ).renderElement(renderChildren);
 
-      case Primitives.VisuallyHidden:
+      case Primitive.VisuallyHidden:
         return new ReactComponentWithChildrenRenderer<VisuallyHiddenProps>(
           component,
           this.importCollection,

--- a/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/text.ts
+++ b/packages/studio-ui-codegen-react/lib/amplify-ui-renderers/text.ts
@@ -15,12 +15,13 @@
  */
 import { TextProps } from '@aws-amplify/ui-react';
 import { factory, JsxChild, JsxElement } from 'typescript';
-import { ReactComponentRenderer } from '../react-component-renderer';
+import { ReactComponentWithChildrenRenderer } from '../react-component-with-children-renderer';
 import { buildChildElement } from '../react-component-render-helper';
 
-export default class TextRenderer extends ReactComponentRenderer<TextProps> {
+export default class TextRenderer extends ReactComponentWithChildrenRenderer<TextProps> {
   renderElement(): JsxElement {
     const childElement = buildChildElement(this.component.properties.value);
+    delete this.component.properties.value;
     const children: JsxChild[] = childElement ? [childElement] : [];
 
     const element = factory.createJsxElement(

--- a/packages/studio-ui-codegen-react/lib/index.ts
+++ b/packages/studio-ui-codegen-react/lib/index.ts
@@ -22,3 +22,4 @@ export * from './react-output-config';
 export * from './react-render-config';
 export * from './react-output-manager';
 export * from './amplify-ui-renderers/amplify-renderer';
+export * from './primitive';

--- a/packages/studio-ui-codegen-react/lib/primitive.ts
+++ b/packages/studio-ui-codegen-react/lib/primitive.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-enum Primitives {
+enum Primitive {
   Alert = 'Alert',
   Badge = 'Badge',
   Button = 'Button',
@@ -55,4 +55,23 @@ enum Primitives {
   VisuallyHidden = 'VisuallyHidden',
 }
 
-export default Primitives;
+export default Primitive;
+
+export function isPrimitive(componentType: string): boolean {
+  return Object.values(Primitive).includes(componentType as Primitive);
+}
+
+export const PrimitiveChildrenPropMapping: Partial<Record<Primitive, string>> = {
+  [Primitive.Alert]: 'label',
+  [Primitive.Badge]: 'label',
+  [Primitive.Button]: 'label',
+  [Primitive.Heading]: 'label',
+  [Primitive.Label]: 'label',
+  [Primitive.Link]: 'label',
+  // [Primitive.MenuButton]: 'label',
+  // [Primitive.MenuItem]: 'label',
+  [Primitive.Radio]: 'label',
+  // [Primitive.TableCell]: 'label',
+  [Primitive.Text]: 'label',
+  [Primitive.ToggleButton]: 'label',
+};

--- a/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-renderer.ts
@@ -46,10 +46,9 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<TProp
   }
 
   protected renderOpeningElement(): JsxOpeningElement {
-    const attributes = Object.entries(this.component.properties)
-      // value should be child of Text, not a prop
-      .filter(([key]) => !(this.component.componentType === 'Text' && key === 'value'))
-      .map(([key, value]) => buildOpeningElementAttributes(value, key));
+    const attributes = Object.entries(this.component.properties).map(([key, value]) =>
+      buildOpeningElementAttributes(value, key),
+    );
 
     if ('events' in this.component && this.component.events !== undefined) {
       attributes.push(

--- a/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts
@@ -26,6 +26,7 @@ import {
   buildOpeningElementAttributes,
   buildOpeningElementActions,
 } from './react-component-render-helper';
+import Primitive, { PrimitiveChildrenPropMapping } from './primitive';
 
 export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithChildrenRendererBase<
   TPropIn,
@@ -38,6 +39,7 @@ export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithCh
     protected parent?: StudioNode,
   ) {
     super(component, parent);
+    this.mapSyntheticProps();
     addBindingPropertiesImports(component, importCollection);
   }
 
@@ -137,5 +139,27 @@ export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithCh
     );
 
     attributes.push(attr);
+  }
+
+  /* Some additional props are added to Amplify primitives in Studio. These "sythetic" props are mapped to real props
+   * on the primitives.
+   *
+   * Example: Text prop label is mapped to to Text prop Children
+   *
+   * This is done so that nonadvanced users of Studio do not need to interact with props that might confuse them.
+   */
+  private mapSyntheticProps() {
+    // properties.children will take precedent over mapped children prop
+    if (this.component.properties.children === undefined) {
+      const childrenPropMapping = PrimitiveChildrenPropMapping[Primitive[this.component.componentType as Primitive]];
+
+      if (childrenPropMapping !== undefined) {
+        const mappedChildrenProp = this.component.properties[childrenPropMapping];
+        if (mappedChildrenProp !== undefined) {
+          this.component.properties.children = mappedChildrenProp;
+          delete this.component.properties[childrenPropMapping];
+        }
+      }
+    }
   }
 }

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer-helper.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer-helper.ts
@@ -39,7 +39,6 @@ import fs from 'fs';
 import path from 'path';
 import temp from 'temp';
 import { ReactRenderConfig, ScriptKind, ScriptTarget, ModuleKind } from './react-render-config';
-import Primitives from './primitives';
 
 export const defaultRenderConfig = {
   script: ScriptKind.TSX,
@@ -162,8 +161,4 @@ export function bindingPropertyUsesHook(
   binding: StudioComponentDataPropertyBinding | StudioComponentSimplePropertyBinding,
 ): boolean {
   return isDataPropertyBinding(binding) && 'predicate' in binding.bindingProperties;
-}
-
-export function isPrimitive(componentType: string): boolean {
-  return Object.values(Primitives).includes(componentType as Primitives);
 }

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -69,8 +69,8 @@ import {
   json,
   jsonToLiteral,
   bindingPropertyUsesHook,
-  isPrimitive,
 } from './react-studio-template-renderer-helper';
+import { isPrimitive } from './primitive';
 
 export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer<
   string,

--- a/packages/test-generator/lib/components/basic-components/basicComponentBadge.json
+++ b/packages/test-generator/lib/components/basic-components/basicComponentBadge.json
@@ -8,7 +8,7 @@
       "name": "Text",
       "componentType": "Text",
       "properties": {
-        "value": {
+        "label": {
           "value": "Basic Component Badge"
         }
       }

--- a/packages/test-generator/lib/components/basic-components/basicComponentButton.json
+++ b/packages/test-generator/lib/components/basic-components/basicComponentButton.json
@@ -8,7 +8,7 @@
       "name": "Text",
       "componentType": "Text",
       "properties": {
-        "value": {
+        "label": {
           "value": "Basic Component Button"
         }
       }

--- a/packages/test-generator/lib/components/basic-components/basicComponentCard.json
+++ b/packages/test-generator/lib/components/basic-components/basicComponentCard.json
@@ -8,7 +8,7 @@
       "name": "Text",
       "componentType": "Text",
       "properties": {
-        "value": {
+        "label": {
           "value": "Basic Component Card"
         }
       }

--- a/packages/test-generator/lib/components/basic-components/basicComponentCollection.json
+++ b/packages/test-generator/lib/components/basic-components/basicComponentCollection.json
@@ -17,7 +17,7 @@
           "name": "CollectionCardText",
           "componentType": "Text",
           "properties": {
-            "value": {
+            "label": {
               "value": "Basic Collection Card Text"
             }
           }

--- a/packages/test-generator/lib/components/basic-components/basicComponentFlex.json
+++ b/packages/test-generator/lib/components/basic-components/basicComponentFlex.json
@@ -8,7 +8,7 @@
       "name": "Text",
       "componentType": "Text",
       "properties": {
-        "value": {
+        "label": {
           "value": "Basic Component Flex"
         }
       }

--- a/packages/test-generator/lib/components/basic-components/basicComponentView.json
+++ b/packages/test-generator/lib/components/basic-components/basicComponentView.json
@@ -8,7 +8,7 @@
       "name": "Text",
       "componentType": "Text",
       "properties": {
-        "value": {
+        "label": {
           "value": "Basic Component View"
         }
       }

--- a/packages/test-generator/lib/components/complex-tests/complexTest1.json
+++ b/packages/test-generator/lib/components/complex-tests/complexTest1.json
@@ -31,7 +31,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Hi harriso"
           },
           "fontWeight": {

--- a/packages/test-generator/lib/components/complex-tests/complexTest3.json
+++ b/packages/test-generator/lib/components/complex-tests/complexTest3.json
@@ -31,7 +31,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Hello World!"
           },
           "fontWeight": {
@@ -109,7 +109,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Testing 123"
           },
           "fontWeight": {

--- a/packages/test-generator/lib/components/complex-tests/complexTest6.json
+++ b/packages/test-generator/lib/components/complex-tests/complexTest6.json
@@ -31,7 +31,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Name"
           },
           "fontWeight": {
@@ -71,7 +71,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Price / Address"
           },
           "fontWeight": {
@@ -111,7 +111,7 @@
           "position": {
             "value": "relative"
           },
-          "value": {
+          "label": {
             "value": "Sqft"
           },
           "fontWeight": {

--- a/packages/test-generator/lib/components/complex-tests/complexTest7.json
+++ b/packages/test-generator/lib/components/complex-tests/complexTest7.json
@@ -71,7 +71,7 @@
           "position": {
             "value": "absolute"
           },
-          "value": {
+          "label": {
             "value": "Test"
           },
           "fontWeight": {

--- a/packages/test-generator/lib/components/default-value-components/boundDefaultValue.json
+++ b/packages/test-generator/lib/components/default-value-components/boundDefaultValue.json
@@ -8,7 +8,7 @@
     }
   },
   "properties": {
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "label"
       },

--- a/packages/test-generator/lib/components/default-value-components/collectionDefaultValue.json
+++ b/packages/test-generator/lib/components/default-value-components/collectionDefaultValue.json
@@ -16,7 +16,7 @@
     {
       "componentType": "Text",
       "properties": {
-        "value": {
+        "label": {
           "collectionBindingProperties": {
             "property": "user",
             "field": "username"

--- a/packages/test-generator/lib/components/default-value-components/simpleAndBoundDefaultValue.json
+++ b/packages/test-generator/lib/components/default-value-components/simpleAndBoundDefaultValue.json
@@ -9,7 +9,7 @@
     }
   },
   "properties": {
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "label"
       },

--- a/packages/test-generator/lib/components/default-value-components/simplePropertyBindingDefaultValue.json
+++ b/packages/test-generator/lib/components/default-value-components/simplePropertyBindingDefaultValue.json
@@ -9,7 +9,7 @@
     }
   },
   "properties": {
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "label"
       }

--- a/packages/test-generator/lib/components/property-binding/textWithDataBinding.json
+++ b/packages/test-generator/lib/components/property-binding/textWithDataBinding.json
@@ -9,7 +9,7 @@
     "width": {
       "value": "20px"
     },
-    "value": {
+    "label": {
       "bindingProperties": {
         "property": "textValue"
       }

--- a/packages/test-generator/lib/components/viewWithButton.json
+++ b/packages/test-generator/lib/components/viewWithButton.json
@@ -15,7 +15,7 @@
           "componentType": "Text",
           "name": "CustomText",
           "properties": {
-            "value": {
+            "label": {
               "value": "Text in Button"
             }
           }


### PR DESCRIPTION
Existing Text prop `value` functionality is preserved for now. All existing Studio apps need to update Text property `value` to `label`, then Text prop `value` functionality can be removed.

`label` was chosen because it does not have any conflicts with existing primitive props.

* Create a mapping from a "synthetic" prop to `children` for primitives that will likely have scalars as children.
* change `Primitives` enum to `Primitive` to follow enum style 

See `packages/studio-ui-codegen-react/lib/react-component-with-children-renderer.ts` for mapping logic.