### PR TITLE
ci: improve version and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, 'chore(release): v')"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get Version Number
+        id: get-version-number
+        run: |
+          version_number=$(echo "${{github.event.head_commit.message}}" | sed -e "s/^chore(release): v//")
+          echo "::set-output name=version_number::$version_number"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{steps.get-version-number.outputs.version_number}}
+          release_name: Release v${{steps.get-version-number.outputs.version_number}}
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ There are 3 keys steps, first you need to create a new tagged release version of
 1. Run version command: `npm run version`
 1. Create new PR with the new branch to mainline: `gh pr create`
 1. Squash and merge PR after approval.
+   Ensure the commit message follows the pattern: `chore(release): v{version_number}`.
+   The Release GitHub workflow will not work if the commit message is not formated correctly.
+1. Wait for the Release GithHub workflow to complete.
 
 \*\*N.B. Ensure that your release has a tag, manually creating if necessary. Only major/minor updates seem to automatically generate tags, but you can create one yourself with the [git-tag](https://git-scm.com/docs/git-tag) command.
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,11 +2,11 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent",
   "exact": true,
+  "version": "0.4.0",
   "command": {
     "version": {
-      "message": "chore: release"
+      "message": "chore(release): %s"
     },
     "run": {
       "ignore": "integration-test"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "setup-dev": "npm install && lerna bootstrap && lerna run build",
     "clean": "lerna run clean && lerna exec npm run rimraf tsconfig.tsbuildinfo && lerna clean --yes && npm run rimraf node_modules",
     "prepare": "husky install",
-    "version": "lerna version --conventional-commits --no-commit-hooks --sign-git-commit --sign-git-tag",
+    "version": "npm run integ:clean && lerna version --conventional-commits --no-commit-hooks --no-push",
     "format": "prettier --write 'packages/*/lib/**/*.{js,jsx,ts,tsx}'",
     "format:check": "prettier --check 'packages/*/lib/**/*.{js,jsx,ts,tsx}'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
* change lerna versioning to "in sync" rather than independent
* change git tags and releases will be created on main branch when a commit that starts with `chore(release): v`.

Example:
https://github.com/aws-amplify/amplify-codegen-ui-staging/releases/tag/v0.5.0

I will delete this fake releases when merging.