### PR TITLE
fix: add children prop to all custom components

### DIFF
--- a/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/studio-ui-codegen-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -13,9 +13,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type SiteHeaderProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type SiteHeaderProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function SiteHeader(props: SiteHeaderProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -62,9 +64,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CustomButtonProps = Partial<ButtonProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomButtonProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomButton(
   props: CustomButtonProps
 ): React.ReactElement {
@@ -92,9 +96,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CustomTextProps = Partial<TextProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomTextProps = React.PropsWithChildren<
+  Partial<TextProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomText(props: CustomTextProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -122,9 +128,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type TestProps = Partial<ViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type TestProps = React.PropsWithChildren<
+  Partial<ViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function Test(props: TestProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -154,14 +162,16 @@ import {
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CollectionOfCustomButtonsProps = Partial<CollectionProps<any>> & {
-  width?: Number;
-  backgroundColor?: String;
-  buttonColor?: UserPreferences;
-  items?: any[];
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    width?: Number;
+    backgroundColor?: String;
+    buttonColor?: UserPreferences;
+    items?: any[];
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CollectionOfCustomButtons(
   props: CollectionOfCustomButtonsProps
 ): React.ReactElement {
@@ -241,14 +251,16 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import { SortDirection, SortPredicate } from \\"@aws-amplify/datastore\\";
 
-export type CollectionOfCustomButtonsProps = Partial<CollectionProps<any>> & {
-  width?: Number;
-  backgroundColor?: String;
-  buttonColor?: UserPreferences;
-  items?: any[];
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    width?: Number;
+    backgroundColor?: String;
+    buttonColor?: UserPreferences;
+    items?: any[];
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CollectionOfCustomButtons(
   props: CollectionOfCustomButtonsProps
 ): React.ReactElement {
@@ -334,14 +346,16 @@ import {
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CollectionOfCustomButtonsProps = Partial<CollectionProps<any>> & {
-  width?: Number;
-  backgroundColor?: String;
-  buttonColor?: UserPreferences;
-  items?: any[];
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    width?: Number;
+    backgroundColor?: String;
+    buttonColor?: UserPreferences;
+    items?: any[];
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CollectionOfCustomButtons(
   props: CollectionOfCustomButtonsProps
 ): React.ReactElement {
@@ -418,11 +432,13 @@ import {
 import ListingCard from \\"./ListingCard\\";
 import { UntitledModel } from \\"../models\\";
 
-export type ListingCardCollectionProps = Partial<CollectionProps<any>> & {
-  items?: any[];
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ListingCardCollectionProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    items?: any[];
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ListingCardCollection(
   props: ListingCardCollectionProps
 ): React.ReactElement {
@@ -472,11 +488,13 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import ListingCard from \\"./ListingCard\\";
 
-export type ListingCardCollectionProps = Partial<CollectionProps<any>> & {
-  items?: any[];
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ListingCardCollectionProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    items?: any[];
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ListingCardCollection(
   props: ListingCardCollectionProps
 ): React.ReactElement {
@@ -512,9 +530,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type ViewWithButtonProps = Partial<ViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ViewWithButtonProps = React.PropsWithChildren<
+  Partial<ViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ViewWithButton(
   props: ViewWithButtonProps
 ): React.ReactElement {
@@ -544,9 +564,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import CustomButton from \\"./CustomButton\\";
 
-export type ViewWithCustomButtonProps = Partial<ViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ViewWithCustomButtonProps = React.PropsWithChildren<
+  Partial<ViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ViewWithCustomButton(
   props: ViewWithCustomButtonProps
 ): React.ReactElement {
@@ -576,9 +598,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type ViewWithButtonProps = Partial<ViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ViewWithButtonProps = React.PropsWithChildren<
+  Partial<ViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ViewWithButton(
   props: ViewWithButtonProps
 ): React.ReactElement {
@@ -608,9 +632,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type HiProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type HiProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function Hi(props: HiProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -658,9 +684,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import Box from \\"./Box\\";
 
-export type VerticalFlexFixedProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type VerticalFlexFixedProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function VerticalFlexFixed(
   props: VerticalFlexFixedProps
 ): React.ReactElement {
@@ -729,9 +757,11 @@ import {
 import Box from \\"./Box\\";
 import ReneButton from \\"./ReneButton\\";
 
-export type NewComponentProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type NewComponentProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function NewComponent(
   props: NewComponentProps
 ): React.ReactElement {
@@ -813,11 +843,13 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import Box from \\"./Box\\";
 
-export type GroupReferenceProps = Partial<FlexProps> & {
-  colors?: \\"Red/Orange\\";
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type GroupReferenceProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    colors?: \\"Red/Orange\\";
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function GroupReference(
   props: GroupReferenceProps
 ): React.ReactElement {
@@ -927,9 +959,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import Box from \\"./Box\\";
 
-export type FlexTestProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type FlexTestProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function FlexTest(props: FlexTestProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -979,9 +1013,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type MohitHomeProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type MohitHomeProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function MohitHome(props: MohitHomeProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -1058,9 +1094,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import Box, { BoxProps } from \\"./Box\\";
 
-export type ImageFlexProps = Partial<BoxProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ImageFlexProps = React.PropsWithChildren<
+  Partial<BoxProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ImageFlex(props: ImageFlexProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -1131,9 +1169,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import Box from \\"./Box\\";
 
-export type VerticalFlexFillProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type VerticalFlexFillProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function VerticalFlexFill(
   props: VerticalFlexFillProps
 ): React.ReactElement {
@@ -1197,11 +1237,13 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type TextWithDataBindingProps = Partial<TextProps> & {
-  textValue?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type TextWithDataBindingProps = React.PropsWithChildren<
+  Partial<TextProps> & {
+    textValue?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function TextWithDataBinding(
   props: TextWithDataBindingProps
 ): React.ReactElement {
@@ -1232,14 +1274,16 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type ComponentWithDataBindingProps = Partial<ButtonProps> & {
-  width?: Number;
-  isDisabled?: Boolean;
-  buttonUser?: User;
-  buttonColor?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ComponentWithDataBindingProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    width?: Number;
+    isDisabled?: Boolean;
+    buttonUser?: User;
+    buttonColor?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ComponentWithDataBinding(
   props: ComponentWithDataBindingProps
 ): React.ReactElement {
@@ -1277,11 +1321,13 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type SectionHeadingProps = Partial<FlexProps> & {
-  newProp6fd1?: UntitledModel;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type SectionHeadingProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    newProp6fd1?: UntitledModel;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function SectionHeading(
   props: SectionHeadingProps
 ): React.ReactElement {
@@ -1339,11 +1385,13 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type ChildComponentWithDataBindingProps = Partial<ButtonProps> & {
-  textValue?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ChildComponentWithDataBindingProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    textValue?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ChildComponentWithDataBinding(
   props: ChildComponentWithDataBindingProps
 ): React.ReactElement {
@@ -1373,12 +1421,14 @@ import {
   getOverridesFromVariants,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CustomButtonProps = Partial<ButtonProps> & {
-  variant?: \\"primary\\" | \\"secondary\\";
-  size?: \\"large\\";
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomButtonProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    variant?: \\"primary\\" | \\"secondary\\";
+    size?: \\"large\\";
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomButton(
   props: CustomButtonProps
 ): React.ReactElement {
@@ -1424,11 +1474,13 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 
 export type ChildComponentWithDataBoundConcatenationProps =
-  Partial<ButtonProps> & {
-    textValue?: String;
-  } & {
-    overrides?: EscapeHatchProps | undefined | null;
-  };
+  React.PropsWithChildren<
+    Partial<ButtonProps> & {
+      textValue?: String;
+    } & {
+      overrides?: EscapeHatchProps | undefined | null;
+    }
+  >;
 export default function ChildComponentWithDataBoundConcatenation(
   props: ChildComponentWithDataBoundConcatenationProps
 ): React.ReactElement {
@@ -1457,9 +1509,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 
 export type ChildComponentWithStaticConcatenationProps =
-  Partial<ButtonProps> & {
-    overrides?: EscapeHatchProps | undefined | null;
-  };
+  React.PropsWithChildren<
+    Partial<ButtonProps> & {
+      overrides?: EscapeHatchProps | undefined | null;
+    }
+  >;
 export default function ChildComponentWithStaticConcatenation(
   props: ChildComponentWithStaticConcatenationProps
 ): React.ReactElement {
@@ -1487,13 +1541,15 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CustomButtonProps = Partial<ButtonProps> & {
-  width?: Number;
-  buttonUser?: User;
-  buttonColor?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomButtonProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    width?: Number;
+    buttonUser?: User;
+    buttonColor?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomButton(
   props: CustomButtonProps
 ): React.ReactElement {
@@ -1530,13 +1586,15 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CustomButtonProps = Partial<ButtonProps> & {
-  width?: Number;
-  buttonUser?: User;
-  buttonColor?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomButtonProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    width?: Number;
+    buttonUser?: User;
+    buttonColor?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomButton(
   props: CustomButtonProps
 ): React.ReactElement {
@@ -1585,11 +1643,13 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type CustomButtonProps = Partial<ButtonProps> & {
-  buttonColor?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomButtonProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    buttonColor?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomButton(
   props: CustomButtonProps
 ): React.ReactElement {
@@ -1613,9 +1673,11 @@ import { EscapeHatchProps, getOverrideProps } from \\"@aws-amplify/ui-react\\";
 import CustomButton from \\"./CustomButton\\";
 import MyView, { MyViewProps } from \\"./MyView\\";
 
-export type CustomChildrenProps = Partial<MyViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomChildrenProps = React.PropsWithChildren<
+  Partial<MyViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomChildren(
   props: CustomChildrenProps
 ): React.ReactElement {
@@ -1690,9 +1752,9 @@ exports[`amplify render tests custom components custom children should render de
 "import React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react\\";
 import { MyViewProps } from \\"./MyView\\";
-export declare type CustomChildrenProps = Partial<MyViewProps> & {
+export declare type CustomChildrenProps = React.PropsWithChildren<Partial<MyViewProps> & {
     overrides?: EscapeHatchProps | undefined | null;
-};
+}>;
 export default function CustomChildren(props: CustomChildrenProps): React.ReactElement;
 "
 `;
@@ -1704,9 +1766,11 @@ import { EscapeHatchProps, getOverrideProps } from \\"@aws-amplify/ui-react\\";
 import CustomButton from \\"./CustomButton\\";
 import ViewTest, { ViewTestProps } from \\"./ViewTest\\";
 
-export type CustomParentAndChildrenProps = Partial<ViewTestProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomParentAndChildrenProps = React.PropsWithChildren<
+  Partial<ViewTestProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomParentAndChildren(
   props: CustomParentAndChildrenProps
 ): React.ReactElement {
@@ -1781,9 +1845,9 @@ exports[`amplify render tests custom components custom parent and children shoul
 "import React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react\\";
 import { ViewTestProps } from \\"./ViewTest\\";
-export declare type CustomParentAndChildrenProps = Partial<ViewTestProps> & {
+export declare type CustomParentAndChildrenProps = React.PropsWithChildren<Partial<ViewTestProps> & {
     overrides?: EscapeHatchProps | undefined | null;
-};
+}>;
 export default function CustomParentAndChildren(props: CustomParentAndChildrenProps): React.ReactElement;
 "
 `;
@@ -1798,9 +1862,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import MyView, { MyViewProps } from \\"./MyView\\";
 
-export type CustomParentProps = Partial<MyViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CustomParentProps = React.PropsWithChildren<
+  Partial<MyViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CustomParent(
   props: CustomParentProps
 ): React.ReactElement {
@@ -1872,9 +1938,9 @@ exports[`amplify render tests custom components custom parent should render decl
 "import React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react\\";
 import { MyViewProps } from \\"./MyView\\";
-export declare type CustomParentProps = Partial<MyViewProps> & {
+export declare type CustomParentProps = React.PropsWithChildren<Partial<MyViewProps> & {
     overrides?: EscapeHatchProps | undefined | null;
-};
+}>;
 export default function CustomParent(props: CustomParentProps): React.ReactElement;
 "
 `;
@@ -2027,9 +2093,9 @@ exports.default = ViewWithButton;
 exports[`amplify render tests declarations should render declarations 1`] = `
 "import React from \\"react\\";
 import { EscapeHatchProps, FlexProps } from \\"@aws-amplify/ui-react\\";
-export declare type ProfileProps = Partial<FlexProps> & {
+export declare type ProfileProps = React.PropsWithChildren<Partial<FlexProps> & {
     overrides?: EscapeHatchProps | undefined | null;
-};
+}>;
 export default function Profile(props: ProfileProps): React.ReactElement;
 "
 `;
@@ -2045,11 +2111,13 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type BoundDefaultValueProps = Partial<TextProps> & {
-  label?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type BoundDefaultValueProps = React.PropsWithChildren<
+  Partial<TextProps> & {
+    label?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function BoundDefaultValue(
   props: BoundDefaultValueProps
 ): React.ReactElement {
@@ -2081,9 +2149,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import { User } from \\"../models\\";
 
-export type CollectionDefaultValueProps = Partial<CollectionProps<any>> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type CollectionDefaultValueProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function CollectionDefaultValue(
   props: CollectionDefaultValueProps
 ): React.ReactElement {
@@ -2127,11 +2197,13 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type SimpleAndBoundDefaultValueProps = Partial<TextProps> & {
-  label?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type SimpleAndBoundDefaultValueProps = React.PropsWithChildren<
+  Partial<TextProps> & {
+    label?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function SimpleAndBoundDefaultValue(
   props: SimpleAndBoundDefaultValueProps
 ): React.ReactElement {
@@ -2164,11 +2236,13 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type SimplePropertyBindingDefaultValueProps = Partial<TextProps> & {
-  label?: String;
-} & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type SimplePropertyBindingDefaultValueProps = React.PropsWithChildren<
+  Partial<TextProps> & {
+    label?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function SimplePropertyBindingDefaultValue(
   props: SimplePropertyBindingDefaultValueProps
 ): React.ReactElement {
@@ -2201,9 +2275,11 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import CustomButton from \\"./CustomButton\\";
 
-export type ViewWithButtonProps = Partial<ViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ViewWithButtonProps = React.PropsWithChildren<
+  Partial<ViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ViewWithButton(
   props: ViewWithButtonProps
 ): React.ReactElement {
@@ -2236,9 +2312,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type SiteHeaderProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type SiteHeaderProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function SiteHeader(props: SiteHeaderProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
@@ -2314,9 +2392,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type ParsedFixedValuesProps = Partial<ViewProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ParsedFixedValuesProps = React.PropsWithChildren<
+  Partial<ViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function ParsedFixedValues(
   props: ParsedFixedValuesProps
 ): React.ReactElement {
@@ -2492,9 +2572,11 @@ import {
   getOverrideProps,
 } from \\"@aws-amplify/ui-react\\";
 
-export type ProfileProps = Partial<FlexProps> & {
-  overrides?: EscapeHatchProps | undefined | null;
-};
+export type ProfileProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
 export default function Profile(props: ProfileProps): React.ReactElement {
   const { overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };

--- a/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
+++ b/packages/studio-ui-codegen-react/lib/react-studio-template-renderer.ts
@@ -281,14 +281,16 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       [factory.createModifier(ts.SyntaxKind.ExportKeyword)],
       factory.createIdentifier(componentPropType),
       undefined,
-      factory.createIntersectionTypeNode(
-        this.dropMissingListElements([
-          this.buildPrimitivePropNode(component),
-          this.buildComponentPropNode(component),
-          this.buildVariantPropNode(component),
-          escapeHatchTypeNode,
-        ]),
-      ),
+      factory.createTypeReferenceNode(factory.createIdentifier('React.PropsWithChildren'), [
+        factory.createIntersectionTypeNode(
+          this.dropMissingListElements([
+            this.buildPrimitivePropNode(component),
+            this.buildComponentPropNode(component),
+            this.buildVariantPropNode(component),
+            escapeHatchTypeNode,
+          ]),
+        ),
+      ]),
     );
   }
 


### PR DESCRIPTION
The integration-test app currently fails when using `npm start`. (For some reason running the integration tests don't fail). 
```
Type '{ children: Element; as?: ElementType | undefined; isDisabled?: boolean | undefined; style?: CSSProperties | undefined; id: string; className?: string | undefined; ... 50 more ...; role?: AriaRole | undefined; }' is not assignable to type 'IntrinsicAttributes & Partial<ViewProps> & { overrides?: EscapeHatchProps | null | undefined; }'.
  Property 'children' does not exist on type 'IntrinsicAttributes & Partial<ViewProps> & { overrides?: EscapeHatchProps | null | undefined; }'.  TS2322

    23 |   const overrides = { ...overridesProp };
    24 |   return (
  > 25 |     <ViewTest
       |      ^
    26 |       id="custom-parent"
    27 |       {...rest}
    28 |       {...getOverrideProps(overrides, "ViewTest")}
```

This change will add `children` as an available prop for all custom components and resolve the typescript error.