### PR TITLE
test: lock version of amplify-ui for integ tests

### DIFF
--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -12,7 +12,7 @@ npm run integ:templates
 # install
 lerna bootstrap
 lerna add --scope integration-test aws-amplify
-lerna add --scope integration-test @aws-amplify/ui-react@next
+lerna add --scope integration-test @aws-amplify/ui-react@0.0.0-next-2021101222549
 lerna add --scope integration-test @aws-amplify/datastore
 lerna add --scope integration-test @amzn/studio-ui-codegen
 lerna add --scope integration-test @amzn/studio-ui-codegen-react


### PR DESCRIPTION
A breaking change to amplify-ui is causing our integ tests to fail. Lock the version of amplify-ui in integ tests for now to unblock this issue.

https://github.com/aws-amplify/amplify-ui/pull/653/files#diff-49b7359b0a44c01df194d4892a16c2b7ac609e292561d11f4a0ba3061d195fdfL43
