### PR TITLE
fix: pin the ui-react version to get around regression introduced in AmplifyProvider

### DIFF
--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -12,7 +12,7 @@ npm run integ:templates
 # install
 lerna bootstrap
 lerna add --scope integration-test aws-amplify
-lerna add --scope integration-test @aws-amplify/ui-react@next
+lerna add --scope integration-test @aws-amplify/ui-react@0.0.0-next-248121b-20211011203215
 lerna add --scope integration-test @aws-amplify/datastore
 lerna add --scope integration-test @amzn/studio-ui-codegen
 lerna add --scope integration-test @amzn/studio-ui-codegen-react


### PR DESCRIPTION
We should be able to revert this when this bug https://github.com/aws-amplify/amplify-ui/issues/688 is resolved.