### PR TITLE
feat: update model validator to throw on names and component types with whitespace

### DIFF
--- a/packages/studio-ui-codegen/lib/__tests__/__snapshots__/validation-helper.test.ts.snap
+++ b/packages/studio-ui-codegen/lib/__tests__/__snapshots__/validation-helper.test.ts.snap
@@ -4,13 +4,17 @@ exports[`validation-helper validateComponentSchema child component requires comp
 
 exports[`validation-helper validateComponentSchema deeply nested child components requires properties 1`] = `"children[0].children[0].children[0].properties is a required field"`;
 
+exports[`validation-helper validateComponentSchema fails on componentType with leading number 1`] = `"Expected an alphanumeric string, starting with a character"`;
+
+exports[`validation-helper validateComponentSchema fails on componentType with whitespace 1`] = `"Expected an alphanumeric string, starting with a character"`;
+
 exports[`validation-helper validateComponentSchema top-level component requires componentType 1`] = `"componentType is a required field"`;
 
 exports[`validation-helper validateComponentSchema top-level component requires componentType to be the correct type 1`] = `"componentType must be a \`string\` type, but the final value was: \`2\`."`;
 
 exports[`validation-helper validateComponentSchema top-level component requires properties 1`] = `"properties is a required field"`;
 
-exports[`validation-helper validateThemeSchema children objects should not be empty 1`] = `"values[1].key is a required field"`;
+exports[`validation-helper validateThemeSchema children objects should not be empty 1`] = `"values[1].key is a required field, values[1].value is a required field"`;
 
 exports[`validation-helper validateThemeSchema overrides should contain the right shape 1`] = `"overrides[0].key is a required field"`;
 

--- a/packages/studio-ui-codegen/lib/__tests__/validation-helper.test.ts
+++ b/packages/studio-ui-codegen/lib/__tests__/validation-helper.test.ts
@@ -95,6 +95,49 @@ describe('validation-helper', () => {
         });
       }).toThrowErrorMatchingSnapshot();
     });
+
+    test('fails on componentType with whitespace', () => {
+      expect(() => {
+        validateComponentSchema({
+          name: 'CustomComponent',
+          componentType: 'View 2',
+          properties: {},
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('fails on componentType with leading number', () => {
+      expect(() => {
+        validateComponentSchema({
+          name: 'CustomComponent',
+          componentType: '2View',
+          properties: {},
+        });
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('succeeds on componentType with trailing number', () => {
+      validateComponentSchema({
+        name: 'CustomComponent',
+        componentType: 'View2',
+        properties: {},
+      });
+    });
+
+    test('child component name may contain whitespace', () => {
+      validateComponentSchema({
+        name: 'CustomComponent',
+        componentType: 'View',
+        properties: {},
+        children: [
+          {
+            name: 'I Have Spaces',
+            componentType: 'Button',
+            properties: {},
+          },
+        ],
+      });
+    });
   });
 
   describe('validateThemeSchema', () => {

--- a/packages/test-generator/integration-test-templates/cypress/integration/generate-spec.js
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generate-spec.js
@@ -1,4 +1,9 @@
-const EXPECTED_INVALID_INPUT_CASES = new Set(['ComponentMissingProperties', 'ComponentMissingType', 'InvalidTheme']);
+const EXPECTED_INVALID_INPUT_CASES = new Set([
+  'ComponentMissingProperties',
+  'ComponentMissingType',
+  'InvalidTheme',
+  'CardWithInvalidChildComponentType',
+]);
 const EXPECTED_INTERNAL_ERROR_CASES = new Set([]);
 
 const TARGET_GENERATORS = ['ES2016_TSX', 'ES2016_JSX', 'ES5_TSX', 'ES5_JSX'];

--- a/packages/test-generator/lib/components/custom/cardWithInvalidChildComponentType.json
+++ b/packages/test-generator/lib/components/custom/cardWithInvalidChildComponentType.json
@@ -1,0 +1,70 @@
+{
+  "name": "CardWithInvalidChildComponentType",
+  "children": [
+    {
+      "children": [
+        {
+          "children": [],
+          "name": "Frame 2",
+          "componentType": "Frame 2",
+          "properties": {
+            "width": {
+              "value": "323px"
+            },
+            "height": {
+              "value": "100px"
+            },
+            "alignItems": {
+              "value": "center"
+            }
+          },
+          "overrides": {},
+          "variants": []
+        }
+      ],
+      "name": "Card",
+      "componentType": "Card",
+      "properties": {
+        "style": {
+          "value": "plain"
+        }
+      },
+      "overrides": {},
+      "variants": []
+    }
+  ],
+  "id": "1736:4332",
+  "bindingProperties": {},
+  "componentType": "Flex",
+  "properties": {
+    "width": {
+      "value": "375px"
+    },
+    "height": {
+      "value": "152px"
+    },
+    "gap": {
+      "value": "10px"
+    },
+    "direction": {
+      "value": "row"
+    },
+    "alignItems": {
+      "value": "flex-start"
+    },
+    "overflow": {
+      "value": "hidden"
+    },
+    "position": {
+      "value": "relative"
+    },
+    "padding": {
+      "value": "10px 10px 10px 10px"
+    },
+    "backgroundColor": {
+      "value": "rgba(255,255,255,1)"
+    }
+  },
+  "overrides": {},
+  "variants": []
+}

--- a/packages/test-generator/lib/components/custom/index.ts
+++ b/packages/test-generator/lib/components/custom/index.ts
@@ -16,3 +16,4 @@
 export { default as CustomParent } from './customParent.json';
 export { default as CustomChildren } from './customChildren.json';
 export { default as CustomParentAndChildren } from './customParentAndChildren.json';
+export { default as CardWithInvalidChildComponentType } from './cardWithInvalidChildComponentType.json';

--- a/packages/test-generator/lib/generators/GenerateTestApp.ts
+++ b/packages/test-generator/lib/generators/GenerateTestApp.ts
@@ -29,6 +29,7 @@ const DISABLED_SCHEMAS = [
   'ComponentMissingProperties', // Expected failure cases
   'ComponentMissingType', // Expected failure cases
   'InvalidTheme', // Expected failure cases
+  'CardWithInvalidChildComponentType', // Expected failure cases
 ];
 
 const generator = new NodeTestGenerator({


### PR DESCRIPTION
- feat: update model validator to throw on names and component types with whitespace

Additionally, moved the 'strict' flag into the method call, to tidy up the schema definition a bit.