### PR TITLE
fix: remove unnecessary types file from generated index

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/react-index-studio-template-renderer.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-index-studio-template-renderer.test.ts
@@ -1,0 +1,34 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { ReactRenderConfig } from '..';
+import { ReactIndexStudioTemplateRenderer } from '../react-index-studio-template-renderer';
+
+class ReactIndexStudioTemplateRendererWithExposedRenderConfig extends ReactIndexStudioTemplateRenderer {
+  getRenderConfig(): ReactRenderConfig {
+    return this.renderConfig;
+  }
+}
+
+describe('ReactIndexStudioTemplateRenderer', () => {
+  describe('constructor', () => {
+    test('overrides renderTypeDeclarations to false', () => {
+      const renderer = new ReactIndexStudioTemplateRendererWithExposedRenderConfig([], {
+        renderTypeDeclarations: true,
+      });
+      expect(renderer.getRenderConfig().renderTypeDeclarations).toBeFalsy();
+    });
+  });
+});

--- a/packages/codegen-ui-react/lib/react-index-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-index-studio-template-renderer.ts
@@ -49,6 +49,7 @@ export class ReactIndexStudioTemplateRenderer extends StudioTemplateRenderer<
     this.renderConfig = {
       ...defaultRenderConfig,
       ...renderConfig,
+      renderTypeDeclarations: false, // Never render type declarations for index.js|ts file.
     };
     this.fileName = `index.${scriptKindToFileExtensionNonReact(this.renderConfig.script)}`;
   }


### PR DESCRIPTION
Today we generate an index.d.js file, which isn't helpful to the user.