### PR TITLE
(DO NOT MERGE)feat: add Expander primitive

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -2417,6 +2417,87 @@ export default function CheckBoxFieldPrimitive(
 "
 `;
 
+exports[`amplify render tests primitives Expander 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import {
+  EscapeHatchProps,
+  Expander,
+  ExpanderItem,
+  ExpanderProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type ExpanderPrimitiveProps = React.PropsWithChildren<
+  Partial<ExpanderProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function ExpanderPrimitive(
+  props: ExpanderPrimitiveProps
+): React.ReactElement {
+  const { overrides: overridesProp, ...rest } = props;
+  const overrides = { ...overridesProp };
+  return (
+    /* @ts-ignore: TS2322 */
+    <Expander
+      type=\\"single\\"
+      isCollapsible={true}
+      {...rest}
+      {...getOverrideProps(overrides, \\"Expander\\")}
+    >
+      <ExpanderItem
+        title=\\"title1\\"
+        value=\\"ExpanderItem1\\"
+        children=\\"ExpanderItem1Content\\"
+        {...getOverrideProps(overrides, \\"Expander.ExpanderItem[0]\\")}
+      ></ExpanderItem>
+      <ExpanderItem
+        title=\\"title2\\"
+        value=\\"ExpanderItem2\\"
+        children=\\"ExpanderItem2Content\\"
+        {...getOverrideProps(overrides, \\"Expander.ExpanderItem[1]\\")}
+      ></ExpanderItem>
+    </Expander>
+  );
+}
+"
+`;
+
+exports[`amplify render tests primitives ExpanderItem 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import {
+  EscapeHatchProps,
+  ExpanderItem,
+  ExpanderItemProps,
+} from \\"@aws-amplify/ui-react\\";
+
+export type ComponentWithoutNameProps = React.PropsWithChildren<
+  Partial<ExpanderItemProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function unknown_component_name(
+  props: unknown_component_nameProps
+): React.ReactElement {
+  const { overrides: overridesProp, ...rest } = props;
+  const overrides = { ...overridesProp };
+  return (
+    /* @ts-ignore: TS2322 */
+    <ExpanderItem
+      title=\\"title1\\"
+      value=\\"ExpanderItem1\\"
+      children=\\"ExpanderItem1Content\\"
+      {...rest}
+      {...getOverrideProps(overrides, \\"ExpanderItem\\")}
+    ></ExpanderItem>
+  );
+}
+"
+`;
+
 exports[`amplify render tests primitives SliderField 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";

--- a/packages/codegen-ui-react/lib/__tests__/amplify-ui-renderers/__snapshots__/primitives.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/amplify-ui-renderers/__snapshots__/primitives.test.ts.snap
@@ -16,6 +16,10 @@ exports[`Primitives Collection 1`] = `"<Collection items={items || []} {...rest}
 
 exports[`Primitives Divider 1`] = `"<Divider {...rest} {...getOverrideProps(overrides, \\"Divider\\")}></Divider>"`;
 
+exports[`Primitives Expander 1`] = `"<Expander {...rest} {...getOverrideProps(overrides, \\"Expander\\")}></Expander>"`;
+
+exports[`Primitives ExpanderItem 1`] = `"<ExpanderItem {...rest} {...getOverrideProps(overrides, \\"ExpanderItem\\")}></ExpanderItem>"`;
+
 exports[`Primitives Flex 1`] = `"<Flex {...rest} {...getOverrideProps(overrides, \\"Flex\\")}></Flex>"`;
 
 exports[`Primitives Grid 1`] = `"<Grid {...rest} {...getOverrideProps(overrides, \\"Grid\\")}></Grid>"`;

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -394,6 +394,14 @@ describe('amplify render tests', () => {
   });
 
   describe('primitives', () => {
+    test('Expander', () => {
+      expect(generateWithAmplifyRenderer('primitives/ExpanderPrimitive').componentText).toMatchSnapshot();
+    });
+
+    test('ExpanderItem', () => {
+      expect(generateWithAmplifyRenderer('primitives/ExpanderItemPrimitive').componentText).toMatchSnapshot();
+    });
+
     test('TextField', () => {
       expect(generateWithAmplifyRenderer('primitives/TextFieldPrimitive').componentText).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-json/primitives/ExpanderItemPrimitive.json
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-json/primitives/ExpanderItemPrimitive.json
@@ -1,0 +1,14 @@
+{
+  "componentType": "ExpanderItem",
+  "properties": {
+    "title": {
+      "value": "title1"
+    },
+    "value": {
+      "value": "ExpanderItem1"
+    },
+    "children": {
+      "value": "ExpanderItem1Content"
+    }
+  }
+}

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-json/primitives/ExpanderPrimitive.json
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-json/primitives/ExpanderPrimitive.json
@@ -1,0 +1,45 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Expander",
+  "name": "ExpanderPrimitive",
+  "properties": {
+    "type": {
+      "value": "single",
+      "type": "String"
+    },
+    "isCollapsible": {
+      "value": true,
+      "type": "Boolean"
+    }
+  },
+  "children": [
+    {
+      "componentType": "ExpanderItem",
+      "properties": {
+        "title": {
+          "value": "title1"
+        },
+        "value": {
+          "value": "ExpanderItem1"
+        },
+        "children": {
+          "value": "ExpanderItem1Content"
+        }
+      }
+    },
+    {
+      "componentType": "ExpanderItem",
+      "properties": {
+        "title": {
+          "value": "title2"
+        },
+        "value": {
+          "value": "ExpanderItem2"
+        },
+        "children": {
+          "value": "ExpanderItem2Content"
+        }
+      }
+    }
+  ]
+}

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -24,6 +24,8 @@ import {
   CardProps,
   CheckboxFieldProps,
   DividerProps,
+  ExpanderProps,
+  ExpanderItemProps,
   FlexProps,
   GridProps,
   HeadingProps,
@@ -123,6 +125,20 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
 
       case Primitive.Divider:
         return new ReactComponentRenderer<DividerProps>(component, this.importCollection, parent).renderElement();
+
+      case Primitive.Expander:
+        return new ReactComponentWithChildrenRenderer<ExpanderProps>(
+          component,
+          this.importCollection,
+          parent,
+        ).renderElement(renderChildren);
+
+      case Primitive.ExpanderItem:
+        return new ReactComponentWithChildrenRenderer<ExpanderItemProps>(
+          component,
+          this.importCollection,
+          parent,
+        ).renderElement(renderChildren);
 
       case Primitive.Flex:
         return new ReactComponentWithChildrenRenderer<FlexProps>(

--- a/packages/codegen-ui-react/lib/primitive.ts
+++ b/packages/codegen-ui-react/lib/primitive.ts
@@ -25,6 +25,8 @@ enum Primitive {
   CheckboxField = 'CheckboxField',
   Collection = 'Collection',
   Divider = 'Divider',
+  Expander = 'Expander',
+  ExpanderItem = 'ExpanderItem',
   Flex = 'Flex',
   Grid = 'Grid',
   Heading = 'Heading',

--- a/packages/test-generator/integration-test-templates/cypress/integration/primitives-spec.js
+++ b/packages/test-generator/integration-test-templates/cypress/integration/primitives-spec.js
@@ -75,6 +75,30 @@ describe('Primitives', () => {
     });
   });
 
+  describe('Expander', () => {
+    it('Basic', () => {
+      cy.visit('http://localhost:3000/primitives-tests');
+      cy.get('#expander')
+        .find('.amplify-expander')
+        .within(() => {
+          cy.get('.amplify-expander__item')
+            .eq(0)
+            .within(() => {
+              cy.get('.amplify-expander__trigger').should('have.text', 'title1');
+              cy.get('.amplify-expander__trigger').click();
+              cy.get('.amplify-expander__content__text').should('have.text', 'ExpanderItem1Content');
+            });
+          cy.get('.amplify-expander__item')
+            .eq(1)
+            .within(() => {
+              cy.get('.amplify-expander__trigger').should('have.text', 'title2');
+              cy.get('.amplify-expander__trigger').click();
+              cy.get('.amplify-expander__content__text').should('have.text', 'ExpanderItem2Content');
+            });
+        });
+    });
+  });
+
   describe('Flex', () => {
     it('Basic', () => {
       cy.visit('http://localhost:3000/primitives-tests');

--- a/packages/test-generator/integration-test-templates/src/PrimitivesTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/PrimitivesTests.tsx
@@ -10,6 +10,7 @@ import {
   CheckboxFieldPrimitive,
   CollectionPrimitive,
   DividerPrimitive,
+  ExpanderPrimitive,
   FlexPrimitive,
   GridPrimitive,
   HeadingPrimitive,
@@ -73,6 +74,10 @@ export default function PrimitivesTests() {
       <View id="divider">
         <Heading>Divider</Heading>
         <DividerPrimitive />
+      </View>
+      <View id="expander">
+        <Heading>Expander</Heading>
+        <ExpanderPrimitive />
       </View>
       <View id="flex">
         <Heading>Flex</Heading>

--- a/packages/test-generator/lib/components/primitives/ExpanderPrimitive.json
+++ b/packages/test-generator/lib/components/primitives/ExpanderPrimitive.json
@@ -1,0 +1,45 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Expander",
+  "name": "ExpanderPrimitive",
+  "properties": {
+    "type": {
+      "value": "single",
+      "type": "String"
+    },
+    "isCollapsible": {
+      "value": true,
+      "type": "Boolean"
+    }
+  },
+  "children": [
+    {
+      "componentType": "ExpanderItem",
+      "properties": {
+        "title": {
+          "value": "title1"
+        },
+        "value": {
+          "value": "ExpanderItem1"
+        },
+        "children": {
+          "value": "ExpanderItem1Content"
+        }
+      }
+    },
+    {
+      "componentType": "ExpanderItem",
+      "properties": {
+        "title": {
+          "value": "title2"
+        },
+        "value": {
+          "value": "ExpanderItem2"
+        },
+        "children": {
+          "value": "ExpanderItem2Content"
+        }
+      }
+    }
+  ]
+}

--- a/packages/test-generator/lib/components/primitives/index.ts
+++ b/packages/test-generator/lib/components/primitives/index.ts
@@ -21,6 +21,7 @@ export { default as CardPrimitive } from './CardPrimitive.json';
 export { default as CheckboxFieldPrimitive } from './CheckboxFieldPrimitive.json';
 export { default as CollectionPrimitive } from './CollectionPrimitive.json';
 export { default as DividerPrimitive } from './DividerPrimitive.json';
+export { default as ExpanderPrimitive } from './ExpanderPrimitive.json';
 export { default as FlexPrimitive } from './FlexPrimitive.json';
 export { default as GridPrimitive } from './GridPrimitive.json';
 export { default as HeadingPrimitive } from './HeadingPrimitive.json';


### PR DESCRIPTION
add Expander primitive, since this is not a launch item, will merge this after the launch

*Description of changes:*

https://quip-amazon.com/Bi4LA9ScxIp4/Amplify-UI-Primitives#temp:C:BMSac0323b38971466db4d3418d9
adding support for expander primitive, both of the primitives would contain children


sample input
```
{
  "id": "1234-5678-9010",
  "componentType": "Expander",
  "name": "ExpanderPrimitive",
  "properties": {
    "type": {
      "value": "single",
      "type": "String"
    },
    "isCollapsible": {
      "value": true,
      "type": "Boolean"
    }
  },
  "children": [
    {
      "componentType": "ExpanderItem",
      "properties": {
        "title": {
          "value": "title1"
        },
        "value": {
          "value": "ExpanderItem1"
        },
        "children": {
          "value": "ExpanderItem1Content"
        }
      }
    },
    {
      "componentType": "ExpanderItem",
      "properties": {
        "title": {
          "value": "title2"
        },
        "value": {
          "value": "ExpanderItem2"
        },
        "children": {
          "value": "ExpanderItem2Content"
        }
      }
    }
  ]
}
```


output
```
/* eslint-disable */
import React from "react";
import { getOverrideProps } from "@aws-amplify/ui-react/internal";
import {
  EscapeHatchProps,
  Expander,
  ExpanderItem,
  ExpanderProps,
} from "@aws-amplify/ui-react";

export type ExpanderPrimitiveProps = React.PropsWithChildren<
  Partial<ExpanderProps> & {
    overrides?: EscapeHatchProps | undefined | null;
  }
>;
export default function ExpanderPrimitive(
  props: ExpanderPrimitiveProps
): React.ReactElement {
  const { overrides: overridesProp, ...rest } = props;
  const overrides = { ...overridesProp };
  return (
    /* @ts-ignore: TS2322 */
    <Expander
      type="single"
      isCollapsible={true}
      {...rest}
      {...getOverrideProps(overrides, "Expander")}
    >
      <ExpanderItem
        title="title1"
        value="ExpanderItem1"
        children="ExpanderItem1Content"
        {...getOverrideProps(overrides, "Expander.ExpanderItem[0]")}
      ></ExpanderItem>
      <ExpanderItem
        title="title2"
        value="ExpanderItem2"
        children="ExpanderItem2Content"
        {...getOverrideProps(overrides, "Expander.ExpanderItem[1]")}
      ></ExpanderItem>
    </Expander>
  );
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
