### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
+
+
+### Bug Fixes
+
+* use correct override index for built-in iconset components ([#266](https://github.com/aws-amplify/amplify-codegen-ui/issues/266)) ([04c3baa](https://github.com/aws-amplify/amplify-codegen-ui/commit/04c3baa68f76a8f227178488c2928248fb1b5292))
+
+
+### Features
+
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+
+
+
+
+
 # [1.0.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v0.13.1...v1.0.0) (2021-12-01)
 
 **Note:** Version bump only for package @aws-amplify/amplify-codegen-ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ There are 3 keys steps, first you need to create a new tagged release version of
 
 #### Versioning
 
+1. Ensure you've pull main, including tags: `git fetch origin && git checkout main && git pull`
+1. Ensure you have the latest tags: `git pull --tags -f`
 1. Create new branch: `git checkout -b new-release`
 1. Run version command: `npm run version`
 1. Create new PR with the new branch to mainline: `gh pr create`

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "exact": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "command": {
     "version": {
       "message": "chore(release): %s"

--- a/packages/codegen-ui-react/CHANGELOG.md
+++ b/packages/codegen-ui-react/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
+
+
+### Bug Fixes
+
+* use correct override index for built-in iconset components ([#266](https://github.com/aws-amplify/amplify-codegen-ui/issues/266)) ([04c3baa](https://github.com/aws-amplify/amplify-codegen-ui/commit/04c3baa68f76a8f227178488c2928248fb1b5292))
+
+
+### Features
+
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+
+
+
+
+
 # [1.0.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v0.13.1...v1.0.0) (2021-12-01)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui-react

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aws-amplify/codegen-ui-react",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-react",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript/vfs": "~1.3.5",

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Amplify UI React code generation implementation",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -25,10 +25,10 @@
     "pascalcase": "1.0.0"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "1.0.0",
+    "@aws-amplify/codegen-ui": "1.1.0",
+    "@typescript/vfs": "~1.3.5",
     "prettier": "2.3.2",
-    "typescript": "~4.4.4",
-    "@typescript/vfs": "~1.3.5"
+    "typescript": "~4.4.4"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/codegen-ui/CHANGELOG.md
+++ b/packages/codegen-ui/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
+
+
+### Features
+
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+
+
+
+
+
 # [1.0.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v0.13.1...v1.0.0) (2021-12-01)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aws-amplify/codegen-ui",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"yup": "^0.32.11"

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "generic component code generation interface definitions",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",

--- a/packages/test-generator/CHANGELOG.md
+++ b/packages/test-generator/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
+
+
+### Features
+
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+
+
+
+
+
 # [1.0.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v0.13.1...v1.0.0) (2021-12-01)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui-test-generator

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aws-amplify/codegen-ui-test-generator",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-test-generator",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "^15.12.1",

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Test generator with sample JSON files",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -20,8 +20,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@aws-amplify/codegen-ui": "1.0.0",
-    "@aws-amplify/codegen-ui-react": "1.0.0",
+    "@aws-amplify/codegen-ui": "1.1.0",
+    "@aws-amplify/codegen-ui-react": "1.1.0",
     "@types/node": "^15.12.1",
     "loglevel": "^1.7.1",
     "typescript": "^4.2.4"


### PR DESCRIPTION
Release addressing a few bugs identified in the launch lead-up which weren't deemed blocking.