### PR TITLE
ci: automate npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,22 @@ jobs:
           body_path: release_description.md
           draft: false
           prerelease: false
+
+  npm-release:
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+      - name: Install packages
+        run: npm ci
+      - name: Lerna bootstrap
+        run: lerna bootstrap
+      - name: NPM Login
+        run: npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_ACCESS_TOKEN }}
+      - name: NPM Publish
+        run: lerna publish from-git -y

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,13 @@ npm run integ
 
 ### Release Process
 
-Until this package is public and publishes to NPM, we have a slightly complicated release process (though mostly automated).
+There are 3 keys steps, first you need to create a new tagged release version of the packages which will be used by our dependencies to consume the latest code.
+After that you'll need to update the CLI repo to point to this new version.
+Then execute an import script in StudioUI to pull the latest external code into their service.
 
-There are 3 keys steps, first you need to create a new tagged release version of the packages which will be used by our dependencies to consume the latest code. After that you'll need to update the CLI repo to point to this new version, and then execute an import script in StudioUI to pull the latest external code into their service.
+#### Publish a Release
 
-#### Versioning
-
-1. Ensure you've pull main, including tags: `git fetch origin && git checkout main && git pull`
+1. Ensure you've pulled main, including tags: `git fetch origin && git checkout main && git pull`
 1. Ensure you have the latest tags: `git pull --tags -f`
 1. Create new branch: `git checkout -b new-release`
 1. Run version command: `npm run version`
@@ -72,21 +72,29 @@ There are 3 keys steps, first you need to create a new tagged release version of
 1. Squash and merge PR after approval.
    Ensure the commit message follows the pattern: `chore(release): v{version_number}`.
    The Release GitHub workflow will not work if the commit message is not formated correctly.
-1. Wait for the [Release GithHub workflow](https://github.com/aws-amplify/amplify-codegen-ui/actions/workflows/release.yml) to complete.
+1. Wait for the [Release GithHub workflow](https://github.com/aws-amplify/amplify-codegen-ui/actions/workflows/release.yml) to complete and verify the correct verify the correct release artifacts were created.
+1. `github-release` will create a new release on [the releases
+   page](https://github.com/aws-amplify/amplify-codegen-ui/releases).
+1. `npm-release` will publish the packages to the public NPM registry.
 
-\*\*N.B. Ensure that your release has a tag, manually creating if necessary. Only major/minor updates seem to automatically generate tags, but you can create one yourself with the [git-tag](https://git-scm.com/docs/git-tag) command.
 
-#### Amplify CLI
+    * https://www.npmjs.com/package/@aws-amplify/codegen-ui
+    * https://www.npmjs.com/package/@aws-amplify/codegen-ui-react
 
-1. Navigate to the Studio Category repo's [configuration file](https://github.com/johnpc/amplify-category-studio/blob/master/.github/variables/codegenVersion.env) for the codegen version, and update this to point to the version you've just published.
-1. Create new PR for the release with `gh pr create`
-1. Ask the CLI team to merge the PR after approval.
+#### Update Amplify CLI
 
-#### Studio UI
+Codegen UI is consumed in the Amplify CLI through
+[@aws-amplify/amplify-util-uibuilder](https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-util-uibuilder).
+Update the Codegen UI version number in
+[package.json](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-util-uibuilder/package.json#L15-L16).
+
+#### Update Studio UI
+
+Studio UI does not yet consume Codegen UI from NPM and instead the Codegen UI source is copied to Studio UI.
 
 1. Pull down the necessary packages to integrate into studio UI.
 1. Execute the 'update-codegen.sh' script, providing the newly created tag.
-1. Ensure review and merge of the CR, after manual verification testing.
+1. Ensure review and merge the CR, after manual verification testing.
 
 ### Icons
 


### PR DESCRIPTION
It is a little difficult to fully test this without publishing to NPM. We could make a fake release to fully test it out if we want to. I did confirm that `lerna publish from-git -y` will not publish if the HEAD commit does not have a tag so there is limited risk of accidentaly publishing.
