### PR TITLE
[PENDING RELEASE APPROVAL] chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.2.0) (2021-12-07)
+
+
+### Bug Fixes
+
+* dont navigate on each test, and remove unnecessary gets from cypress suite ([#281](https://github.com/aws-amplify/amplify-codegen-ui/issues/281)) ([c72e66c](https://github.com/aws-amplify/amplify-codegen-ui/commit/c72e66cee560d7133650d242e3c36341c0356d98))
+* remove line of whitespace from LICENSE file, causing README badge to fail ([#269](https://github.com/aws-amplify/amplify-codegen-ui/issues/269)) ([85a3559](https://github.com/aws-amplify/amplify-codegen-ui/commit/85a3559c812058ed41f8e81c120ccef450b2273f))
+* use correct override index for built-in iconset components ([#266](https://github.com/aws-amplify/amplify-codegen-ui/issues/266)) ([04c3baa](https://github.com/aws-amplify/amplify-codegen-ui/commit/04c3baa68f76a8f227178488c2928248fb1b5292))
+
+
+### Features
+
+* add Expander primitive ([#252](https://github.com/aws-amplify/amplify-codegen-ui/issues/252)) ([91096ce](https://github.com/aws-amplify/amplify-codegen-ui/commit/91096ce8b3e6e7604c6dd63df8be5ef642b08b58))
+* add import mappings to non-dynamic, and correct EscapeHatchProps import type. ([#277](https://github.com/aws-amplify/amplify-codegen-ui/issues/277)) ([16acc35](https://github.com/aws-amplify/amplify-codegen-ui/commit/16acc35303f1fa62b6dbc8c72b4dd2dd22166238))
+* add support for developing on windows ([#276](https://github.com/aws-amplify/amplify-codegen-ui/issues/276)) ([985f576](https://github.com/aws-amplify/amplify-codegen-ui/commit/985f576f1df7251b4890366096326fee097fb7fc))
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+* validate property values are not empty ([#247](https://github.com/aws-amplify/amplify-codegen-ui/issues/247)) ([d6933d5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d6933d505b000856451bb873ef4406500345dd65))
+
+
+
+
+
 # [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "exact": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "command": {
     "version": {
       "message": "chore(release): %s"

--- a/packages/codegen-ui-react/CHANGELOG.md
+++ b/packages/codegen-ui-react/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.2.0) (2021-12-07)
+
+
+### Bug Fixes
+
+* dont navigate on each test, and remove unnecessary gets from cypress suite ([#281](https://github.com/aws-amplify/amplify-codegen-ui/issues/281)) ([c72e66c](https://github.com/aws-amplify/amplify-codegen-ui/commit/c72e66cee560d7133650d242e3c36341c0356d98))
+* use correct override index for built-in iconset components ([#266](https://github.com/aws-amplify/amplify-codegen-ui/issues/266)) ([04c3baa](https://github.com/aws-amplify/amplify-codegen-ui/commit/04c3baa68f76a8f227178488c2928248fb1b5292))
+
+
+### Features
+
+* add Expander primitive ([#252](https://github.com/aws-amplify/amplify-codegen-ui/issues/252)) ([91096ce](https://github.com/aws-amplify/amplify-codegen-ui/commit/91096ce8b3e6e7604c6dd63df8be5ef642b08b58))
+* add import mappings to non-dynamic, and correct EscapeHatchProps import type. ([#277](https://github.com/aws-amplify/amplify-codegen-ui/issues/277)) ([16acc35](https://github.com/aws-amplify/amplify-codegen-ui/commit/16acc35303f1fa62b6dbc8c72b4dd2dd22166238))
+* add support for developing on windows ([#276](https://github.com/aws-amplify/amplify-codegen-ui/issues/276)) ([985f576](https://github.com/aws-amplify/amplify-codegen-ui/commit/985f576f1df7251b4890366096326fee097fb7fc))
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+
+
+
+
+
 # [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
 
 

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aws-amplify/codegen-ui-react",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-react",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript/vfs": "~1.3.5",

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Amplify UI React code generation implementation",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -25,7 +25,7 @@
     "pascalcase": "1.0.0"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "1.1.0",
+    "@aws-amplify/codegen-ui": "1.2.0",
     "@typescript/vfs": "~1.3.5",
     "prettier": "2.3.2",
     "typescript": "~4.4.4"

--- a/packages/codegen-ui/CHANGELOG.md
+++ b/packages/codegen-ui/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.2.0) (2021-12-07)
+
+
+### Bug Fixes
+
+* dont navigate on each test, and remove unnecessary gets from cypress suite ([#281](https://github.com/aws-amplify/amplify-codegen-ui/issues/281)) ([c72e66c](https://github.com/aws-amplify/amplify-codegen-ui/commit/c72e66cee560d7133650d242e3c36341c0356d98))
+
+
+### Features
+
+* add support for developing on windows ([#276](https://github.com/aws-amplify/amplify-codegen-ui/issues/276)) ([985f576](https://github.com/aws-amplify/amplify-codegen-ui/commit/985f576f1df7251b4890366096326fee097fb7fc))
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+* validate property values are not empty ([#247](https://github.com/aws-amplify/amplify-codegen-ui/issues/247)) ([d6933d5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d6933d505b000856451bb873ef4406500345dd65))
+
+
+
+
+
 # [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
 
 

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aws-amplify/codegen-ui",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"yup": "^0.32.11"

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "generic component code generation interface definitions",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",

--- a/packages/test-generator/CHANGELOG.md
+++ b/packages/test-generator/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.2.0) (2021-12-07)
+
+
+### Bug Fixes
+
+* dont navigate on each test, and remove unnecessary gets from cypress suite ([#281](https://github.com/aws-amplify/amplify-codegen-ui/issues/281)) ([c72e66c](https://github.com/aws-amplify/amplify-codegen-ui/commit/c72e66cee560d7133650d242e3c36341c0356d98))
+
+
+### Features
+
+* add Expander primitive ([#252](https://github.com/aws-amplify/amplify-codegen-ui/issues/252)) ([91096ce](https://github.com/aws-amplify/amplify-codegen-ui/commit/91096ce8b3e6e7604c6dd63df8be5ef642b08b58))
+* add import mappings to non-dynamic, and correct EscapeHatchProps import type. ([#277](https://github.com/aws-amplify/amplify-codegen-ui/issues/277)) ([16acc35](https://github.com/aws-amplify/amplify-codegen-ui/commit/16acc35303f1fa62b6dbc8c72b4dd2dd22166238))
+* add support for developing on windows ([#276](https://github.com/aws-amplify/amplify-codegen-ui/issues/276)) ([985f576](https://github.com/aws-amplify/amplify-codegen-ui/commit/985f576f1df7251b4890366096326fee097fb7fc))
+* use typescript virtual file server to allow transpilation without requiring a real fs ([#268](https://github.com/aws-amplify/amplify-codegen-ui/issues/268)) ([d8219c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/d8219c50928e33ffd032df3a11b1024b3d7bf982))
+
+
+
+
+
 # [1.1.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v1.0.0...v1.1.0) (2021-12-02)
 
 

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aws-amplify/codegen-ui-test-generator",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-test-generator",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "^15.12.1",

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Test generator with sample JSON files",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -20,8 +20,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@aws-amplify/codegen-ui": "1.1.0",
-    "@aws-amplify/codegen-ui-react": "1.1.0",
+    "@aws-amplify/codegen-ui": "1.2.0",
+    "@aws-amplify/codegen-ui-react": "1.2.0",
     "@types/node": "^15.12.1",
     "loglevel": "^1.7.1",
     "typescript": "^4.2.4"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Release commit to enable the following.

We know EscapeHatchProps will have the wrong import paths when we re-enable. Need to push this release to fix that bug before we go out.

Full set of changes https://github.com/aws-amplify/amplify-codegen-ui/compare/e26ae637f1c36aaa92647af3ceffc7cd3d59b6a9..2f7f80689e03b7aa5ba08db725a9427c602dcdf5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
