### PR TITLE
ci: move style and unit test jobs to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,99 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@4.7
+
+jobs:
+  install:
+    docker:
+      - image: cimg/node:16.10
+    steps:
+      - checkout
+      - restore_node_modules
+      - node/install-packages:
+          pkg-manager: npm
+      - run:
+          name: Lerna Bootstrap
+          command: npx lerna bootstrap
+      - save_cache:
+          key: v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "combined-package-lock.txt" }}-test1
+          paths:
+            - node_modules
+            - packages/codegen-ui/node_modules
+            - packages/codegen-ui-react/node_modules
+            - packages/test-generator/node_modules
+
+  style:
+    docker:
+      - image: cimg/node:16.10
+    steps:
+      - checkout
+      - restore_node_modules
+      - run:
+          name: Prettier
+          command: npm run format:check
+      - run:
+          name: ESLint
+          command: npm run lint
+      - run:
+          name: Commit Message
+          command: |
+            echo `git log --format=%s -n 1 $CIRCLE_SHA1` > commit-message-tmp
+            ./.husky/commit-msg commit-message-tmp
+            rm commit-message-tmp
+
+  build:
+    docker:
+      - image: cimg/node:16.10
+    steps:
+      - checkout
+      - restore_node_modules
+      - run: npm run build
+
+  unit-test:
+    docker:
+      - image: cimg/node:16.10
+    resource_class: large
+    steps:
+      - checkout
+      - restore_node_modules
+      - run:
+          name: Unit Test
+          command: npm run test
+      - run:
+          name: Codecov
+          command: npx codecov
+
+workflows:
+  build-and-test:
+    jobs:
+      - install
+      - style:
+          requires:
+            - install
+      - build:
+          requires:
+            - install
+      - unit-test:
+          requires:
+            - install
+
+commands:
+  create_concatenated_package_lock:
+    description: "Concatenate all package-lock.json files recognized by lerna.js into single file. File is used as checksum source for part of caching key."
+    parameters:
+      filename:
+        type: string
+    steps:
+      - run:
+          name: Combine package-lock.json files to single file
+          command: npx lerna la -a | awk -F packages '{gsub("   \\(PRIVATE\\)", "");printf "\"packages%s/package-lock.json\" ", $2}' | xargs cat > << parameters.filename >>
+
+  restore_node_modules:
+    description: "Restore node_modules cache using concatenated package-lock."
+    steps:
+      - create_concatenated_package_lock:
+          filename: combined-package-lock.txt
+      - restore_cache:
+         keys:
+           - v1-deps-{{ checksum "package-lock.json" }}-{{ checksum "combined-package-lock.txt" }}-test1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,51 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  style:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Studio Codegen
-        uses: actions/checkout@v2
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v2
-        with:
-          node-version: lts/*
-      - name: Install packages
-        run: npm ci
-      - name: Lerna bootstrap
-        run: lerna bootstrap
-      - name: Prettier
-        run: npm run format:check
-      - name: ESLint
-        run: npm run lint
-      - name: Commit message
-        run: |
-          echo "${{ github.event.head_commit.message }}" > commit-message-tmp
-          ./.husky/commit-msg commit-message-tmp
-          rm commit-message-tmp
-
-  unit-test:
-    runs-on: ubuntu-latest
-    env:
-      NODE_ENV: test
-    steps:
-      - name: Checkout Studio Codegen
-        uses: actions/checkout@v2
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v2
-        with:
-          node-version: lts/*
-      - name: Install packages
-        run: npm ci
-      - name: Lerna bootstrap
-        run: lerna bootstrap
-      - name: Build
-        run: npm run build
-      - name: Run tests
-        run: npm run test
-      - name: Codecov
-        uses: codecov/codecov-action@v2
-
   integration-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Style and unit test jobs have been removed from GitHub Actions and moved to circle ci. I'll update the required checks when we are ready to merge.