### PR TITLE
ci: move npm publish job to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,25 @@ jobs:
           name: Codecov
           command: npx codecov
 
+  publish:
+    docker:
+      - image: cimg/node:16.10
+    steps:
+      - checkout
+      - restore_node_modules
+      - run:
+          name: NPM Login
+          command: npm set "//registry.npmjs.org/:_authToken" $NPM_ACCESS_TOKEN
+      - run:
+          name: NPM Publish
+          command: >-
+            if [[ `git log --format=%s -n 1` =~ ^chore\(release\):\ v.* ]];
+            then npx lerna publish from-git -y;
+            else echo "No publish";
+            fi
+
 workflows:
-  build-and-test:
+  build:
     jobs:
       - install
       - style:
@@ -77,6 +94,14 @@ workflows:
       - unit-test:
           requires:
             - install
+      - publish:
+          requires:
+            - style
+            - build
+            - unit-test
+          filters:
+            branches:
+              only: main
 
 commands:
   create_concatenated_package_lock:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,22 +33,3 @@ jobs:
           body_path: release_description.md
           draft: false
           prerelease: false
-
-  npm-release:
-    needs: github-release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Setup Node.js LTS
-        uses: actions/setup-node@v2
-        with:
-          node-version: lts/*
-      - name: Install packages
-        run: npm ci
-      - name: Lerna bootstrap
-        run: lerna bootstrap
-      - name: NPM Login
-        run: npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_ACCESS_TOKEN }}
-      - name: NPM Publish
-        run: lerna publish from-git -y


### PR DESCRIPTION
* Move npm publish job from github actions to circleci
* publish job only runs on main branch
* If commit matches release commit style create a full release, else no-op
  * circle ci cannot conditional run jobs based on the commit message unfortunately
  * In the future we will add a pre-release to the else condition
