### PR TITLE
ci: add npm pre-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,12 @@ jobs:
       - run:
           name: NPM Publish
           command: >-
+            # lerna publish docs: https://github.com/lerna/lerna/tree/main/commands/publish
             if [[ `git log --format=%s -n 1` =~ ^chore\(release\):\ v.* ]];
+            # production release
             then npx lerna publish from-git -y;
-            else echo "No publish";
+            # pre-release
+            else npx lerna publish --pre-dist-tag next --canary -y;
             fi
 
 workflows:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,34 @@ Studio UI does not yet consume Codegen UI from NPM and instead the Codegen UI so
 1. Execute the 'update-codegen.sh' script, providing the newly created tag.
 1. Ensure review and merge the CR, after manual verification testing.
 
+### Pre-Release
+
+A pre-release is automatically published to NPM when the following cirteria are met:
+
+- A commit is pushed to then `main` branch.
+- The commit is not a release commit (i.e. `chore(release): v...`).
+- The commit has changes to a leaf package source.
+  - Ex. updating `.circleci/config.yml` will not make a pre-release, but changes `packages/codegen-ui/lib/studio-node.ts` will.
+- Lerna will only look back a single commit. If the HEAD commit does not meet previous cirteria the pre-release will not be published.
+
+The pre-release will increment the patch version of each package and append meta information including the short commit hash.
+These changes will **NOT** be pushed back to the GitHub repo.
+
+Example:
+
+```
+ - @aws-amplify/codegen-ui-react => 1.1.1-alpha.270+2baaca9
+ - @aws-amplify/codegen-ui => 1.1.1-alpha.270+2baaca9
+```
+
+The pre-release will be published under the `next` dist tag.
+
+```
+npm install @aws-amplify/codegen-ui-react@next
+```
+
+See [lerna publish docs](https://github.com/lerna/lerna/tree/main/commands/publish) for further detail.
+
 ### Icons
 
 The built-in iconset is genereted with `packages/scripts/generateBuiltInIconset.js`.


### PR DESCRIPTION
This will help CLI to easily test new changes to codegen without the need for `npm link`.

This change will publish a pre-release to npm for every change pushed to main that is:
* not a production release. (release commit)
* has functional changes to packages recognized by lerna
  * Ex. updating `.circleci/config.yml` will not make a pre-release, but changes `packages/codegen-ui/lib/studio-node.ts` will

The `--canary` option will look back one commit to determine if there are any changes that need to be published as a pre-release. If there are changes it will increase the patch version and append the commit hash to the version number before publishing. These changes are **NOT** kept in git. 

I have not found an easy way to look back further than one commit. This means if we rebase and merge to main and the HEAD commit does not make any changes recognized by lerna the pre-release would not be published. However, in most circumstances we use squash and merge so it is not a concern most of the time.

`--pre-dist-tag next` will publish the pre-release under the `next` tag keeping `latest` (default install) always pointing at production releases.

Example:
```
> lerna publish --pre-dist-tag next --canary -y

info cli using local version of lerna
lerna notice cli v4.0.0
lerna info canary enabled
lerna info Looking for changed packages since 2baaca9^..2baaca9

Found 2 packages to publish:
 - @aws-amplify/codegen-ui-react => 1.1.1-alpha.270+2baaca9
 - @aws-amplify/codegen-ui => 1.1.1-alpha.270+2baaca9
```

See lerna docs: https://github.com/lerna/lerna/tree/main/commands/publish

Note: their documentation is actually incorrect on the functionality of `--canary`. They state it makes a minor bump but that is in contradiction to their examples and my testing.