### PR TITLE
ci: add tagged release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,12 @@ jobs:
       - checkout
       - restore_node_modules
       - run: npm run build
+      - save_cache:
+          key: dist-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - packages/codegen-ui/dist
+            - packages/codegen-ui-react/dist
+            - packages/test-generator/dist
 
   unit-test:
     docker:
@@ -70,16 +76,15 @@ jobs:
     steps:
       - checkout
       - restore_node_modules
+      - restore_cache:
+          keys:
+            - dist-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: NPM Login
           command: npm set "//registry.npmjs.org/:_authToken" $NPM_ACCESS_TOKEN
       - run:
           name: NPM Publish
-          command: >-
-            if [[ `git log --format=%s -n 1` =~ ^chore\(release\):\ v.* ]];
-            then npx lerna publish from-git -y;
-            else npx lerna publish --pre-dist-tag next --canary -y;
-            fi
+          command: bash ./.circleci/publish.sh
 
 workflows:
   build:
@@ -104,6 +109,7 @@ workflows:
               only:
                 - main
                 - develop
+                - /tagged-release\/.*/
 
 commands:
   create_concatenated_package_lock:

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+if [[ `git log --format=%s -n 1` =~ ^chore\(release\):\ v.* ]]; then
+  # production release
+  npx lerna publish from-git --ignore-scripts -y;
+else
+  # pre-release or tagged release
+  # if branch starts with tagged-release/ then do tagged release, else pre-release
+  npx lerna publish --canary --ignore-scripts -y \
+    --preid $([[ $CIRCLE_BRANCH =~ ^tagged-release\/.* ]] \
+      && echo $(echo $CIRCLE_BRANCH | sed 's:.*/::') --no-pre-dist-tag \
+      || echo alpha --pre-dist-tag next);
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,17 @@ npm install @aws-amplify/codegen-ui-react@next
 
 See [lerna publish docs](https://github.com/lerna/lerna/tree/main/commands/publish) for further detail.
 
+### Tagged Release
+
+A tagged release is used to release emergent or prototype changes without merging into `main`.
+To create a tagged release create a pull request or push directly to a branch with the prefix `tagged-release/`.
+(Ex. `tagged-release/fix-properties`).
+The branch name must not contain any additional forward slashes after `tagged-release/`.
+The tagged release will use the same versioning process as the pre-release except:
+
+- the preid will be the branch name with `tagged-release/` removed. (Ex. `1.1.1-fix-properties.270+2baaca9`)
+- the release will not be published under any dist tag
+
 ### Icons
 
 The built-in iconset is genereted with `packages/scripts/generateBuiltInIconset.js`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "lerna run test --stream",
     "test:update": "lerna run test:update --stream",
     "build": "lerna run build --stream",
-    "prepublishOnly": "npm run build && npm run test",
     "setup-dev": "npm install && lerna bootstrap && lerna run build",
     "clean": "lerna run clean && lerna exec npm run rimraf tsconfig.tsbuildinfo && lerna clean --yes && npm run rimraf node_modules",
     "prepare": "husky install",


### PR DESCRIPTION
Merging to main so that tagged releases can be created off of main.

See CONTRIBUTING.md for instructions on how to create a tagged release.

NPM publishing via circle CI now works for prod release, pre-release, and tagged release. 

Successful publish [here](https://app.circleci.com/pipelines/github/aws-amplify/amplify-codegen-ui/111/workflows/b60bd4d9-0669-4465-a203-0b46964233c4/jobs/447).
