### PR TITLE
ci: pin react-scripts@4.0.3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: amplify-cli/packages/amplify-util-uibuilder
         run: npm test
       - name: Create a test react app
-        run: npx create-react-app e2e-test-app
+        run: npx create-react-app e2e-test-app --scripts-version 4.0.3
       - name: Install test app dependencies
         working-directory: e2e-test-app
         run: |

--- a/scripts/integ-setup.bat
+++ b/scripts/integ-setup.bat
@@ -4,7 +4,7 @@ call npm run build
 
 :: create
 chdir packages
-call npx create-react-app integration-test --use-npm --template typescript
+call npx create-react-app integration-test --use-npm --template typescript --scripts-version 4.0.3
 chdir ..
 
 :: add files

--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -4,7 +4,7 @@ npm run integ:clean
 npm run build
 
 # create
-(cd packages && npx create-react-app integration-test --use-npm --template typescript)
+(cd packages && npx create-react-app integration-test --use-npm --template typescript --scripts-version 4.0.3)
 
 # add files
 npm run integ:templates


### PR DESCRIPTION
Create React App release a new version 5.0.0 this morning: https://github.com/facebook/create-react-app/releases/tag/v5.0.0

The new version of Create React App upgrades to Webpack 5. There is an existing [issue with Webpack 5 and graphql](https://github.com/graphql/graphql-js/issues/2721) that is causing newly created CRA apps to fail compilation.

This change will pin the react-scripts to 4.0.3 so that Webpack 4 is still used.