### PR TITLE
ci: fix pre-release and tagged release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,11 +125,8 @@ Studio UI does not yet consume Codegen UI from NPM and instead the Codegen UI so
 
 A pre-release is automatically published to NPM when the following cirteria are met:
 
-- A commit is pushed to then `main` branch.
+- A commit is pushed to then `main` or `develop` branch.
 - The commit is not a release commit (i.e. `chore(release): v...`).
-- The commit has changes to a leaf package source.
-  - Ex. updating `.circleci/config.yml` will not make a pre-release, but changes `packages/codegen-ui/lib/studio-node.ts` will.
-- Lerna will only look back a single commit. If the HEAD commit does not meet previous cirteria the pre-release will not be published.
 
 The pre-release will increment the patch version of each package and append meta information including the short commit hash.
 These changes will **NOT** be pushed back to the GitHub repo.
@@ -137,8 +134,8 @@ These changes will **NOT** be pushed back to the GitHub repo.
 Example:
 
 ```
- - @aws-amplify/codegen-ui-react => 1.1.1-alpha.270+2baaca9
- - @aws-amplify/codegen-ui => 1.1.1-alpha.270+2baaca9
+ - @aws-amplify/codegen-ui-react => 1.1.1-2baaca9.0
+ - @aws-amplify/codegen-ui => 1.1.1-2baaca9.0
 ```
 
 The pre-release will be published under the `next` dist tag.
@@ -157,8 +154,8 @@ To create a tagged release create a pull request or push directly to a branch wi
 The branch name must not contain any additional forward slashes after `tagged-release/`.
 The tagged release will use the same versioning process as the pre-release except:
 
-- the preid will be the branch name with `tagged-release/` removed. (Ex. `1.1.1-fix-properties.270+2baaca9`)
-- the release will not be published under any dist tag
+- the preid will inlcude the branch name with `tagged-release/` removed. (Ex. `1.1.1-fix-properties-2baaca9.0`)
+- the release will be published with the dist tag as the tagged release name. (Ex. `fix-properties`)
 
 ### Icons
 


### PR DESCRIPTION
No longer use the [canary option](https://github.com/lerna/lerna/tree/main/commands/publish#--canary) because [it is broken](https://github.com/lerna/lerna/issues/2622). 

Now manually create a pre-release version number and then use `lerna publish from-git`.

Other changes:
* Will always publish a new pre-release (even if there are no changes to source).
* Change pre-release `alpha` preid to short commit hash.
* Use tagged release name as dist tag 
* Add short commit hash to tagged release preid.

Tested locally when unauthenticated.

### Pre-release
```
> export CIRCLE_BRANCH = test-pre-relase
> bash -x .circleci/publish.sh 
++ git log --format=%s -n 1
+ [[ feat: something =~ ^chore\(release\): v.* ]]
++ echo adc94308d775618e29c84a8fbd2380bb5dfd181b
++ cut -c -7
+ SHORT_SHA1=adc9430
+ [[ fix-prerelease =~ ^tagged-release/.* ]]
+ npx lerna version prerelease --amend --ignore-scripts --no-commit-hooks --preid adc9430 -y
lerna notice cli v4.0.0
lerna info current version 1.2.0
lerna info Looking for changed packages since @amzn/amplify-ui-codegen-schema@0.1.0
lerna WARN version Skipping working tree validation, proceed at your own risk

Changes:
 - @aws-amplify/codegen-ui-react: 1.2.0 => 1.2.1-adc9430.0
 - @aws-amplify/codegen-ui: 1.2.0 => 1.2.1-adc9430.0
 - @aws-amplify/codegen-ui-test-generator: 1.2.0 => 1.2.1-adc9430.0 (private)

lerna info auto-confirmed 
lerna info execute Skipping git push
lerna info execute Skipping releases

You need a passphrase to unlock the secret key for
user: "Dane Pilcher <dppilche@amazon.com>"
4096-bit RSA key, ID D729AEB7, created 2021-08-23

lerna success version finished
+ npx lerna publish from-git --ignore-scripts --pre-dist-tag next -y
lerna notice cli v4.0.0

Found 2 packages to publish:
 - @aws-amplify/codegen-ui-react => 1.2.1-adc9430.0
 - @aws-amplify/codegen-ui => 1.2.1-adc9430.0

lerna info auto-confirmed 
lerna info publish Publishing packages to npm...
lerna info Verifying npm credentials
lerna http fetch GET 401 https://registry.npmjs.org/-/npm/v1/user 84ms
401 Unauthorized - GET https://registry.npmjs.org/-/npm/v1/user
lerna ERR! EWHOAMI Authentication error. Use `npm whoami` to troubleshoot.
```

### Tagged Release
```
> export CIRCLE_BRANCH = tagged-release/test-tagged
> bash -x .circleci/publish.sh 
++ git log --format=%s -n 1
+ [[ feat: something =~ ^chore\(release\): v.* ]]
++ echo adc94308d775618e29c84a8fbd2380bb5dfd181b
++ cut -c -7
+ SHORT_SHA1=adc9430
+ [[ tagged-release/test-tagged =~ ^tagged-release/.* ]]
++ echo tagged-release/test-tagged
++ sed 's:.*/::'
+ TAGGED_RELEASE_NAME=test-tagged
+ npx lerna version prerelease --amend --ignore-scripts --no-commit-hooks --preid test-tagged-adc9430 -y
lerna notice cli v4.0.0
lerna info current version 1.2.0
lerna info Looking for changed packages since @amzn/amplify-ui-codegen-schema@0.1.0
lerna WARN version Skipping working tree validation, proceed at your own risk

Changes:
 - @aws-amplify/codegen-ui-react: 1.2.0 => 1.2.1-test-tagged-adc9430.0
 - @aws-amplify/codegen-ui: 1.2.0 => 1.2.1-test-tagged-adc9430.0
 - @aws-amplify/codegen-ui-test-generator: 1.2.0 => 1.2.1-test-tagged-adc9430.0 (private)

lerna info auto-confirmed 
lerna info execute Skipping git push
lerna info execute Skipping releases

You need a passphrase to unlock the secret key for
user: "Dane Pilcher <dppilche@amazon.com>"
4096-bit RSA key, ID D729AEB7, created 2021-08-23

lerna success version finished
+ npx lerna publish from-git --ignore-scripts --pre-dist-tag test-tagged -y
lerna notice cli v4.0.0

Found 2 packages to publish:
 - @aws-amplify/codegen-ui-react => 1.2.1-test-tagged-adc9430.0
 - @aws-amplify/codegen-ui => 1.2.1-test-tagged-adc9430.0

lerna info auto-confirmed 
lerna info publish Publishing packages to npm...
lerna info Verifying npm credentials
lerna http fetch GET 401 https://registry.npmjs.org/-/npm/v1/user 106ms
401 Unauthorized - GET https://registry.npmjs.org/-/npm/v1/user
lerna ERR! EWHOAMI Authentication error. Use `npm whoami` to troubleshoot.
```