### PR TITLE
ci: fix pre-release and tagged release

### DIFF
--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -4,10 +4,36 @@ if [[ `git log --format=%s -n 1` =~ ^chore\(release\):\ v.* ]]; then
   # production release
   npx lerna publish from-git --ignore-scripts -y;
 else
+  SHORT_SHA1=$(echo $CIRCLE_SHA1 | cut -c -7)
+
+  # the commit is not pushed to the repo so user email and name do not matter but need to be set
+  git config user.email "nobody@amazon.com"
+  git config user.name "circleci"
+
   # pre-release or tagged release
   # if branch starts with tagged-release/ then do tagged release, else pre-release
-  npx lerna publish --canary --ignore-scripts -y \
-    --preid $([[ $CIRCLE_BRANCH =~ ^tagged-release\/.* ]] \
-      && echo $(echo $CIRCLE_BRANCH | sed 's:.*/::') --no-pre-dist-tag \
-      || echo alpha --pre-dist-tag next);
+  if [[ $CIRCLE_BRANCH =~ ^tagged-release\/.* ]]; then
+    TAGGED_RELEASE_NAME=$(echo $CIRCLE_BRANCH | sed 's:.*/::')
+    npx lerna version prerelease \
+      --amend \
+      --ignore-scripts \
+      --no-commit-hooks \
+      --preid ${TAGGED_RELEASE_NAME}-${SHORT_SHA1} \
+      -y
+    npx lerna publish from-git \
+      --ignore-scripts \
+      --pre-dist-tag $TAGGED_RELEASE_NAME \
+      -y;
+  else
+    npx lerna version prerelease \
+      --amend \
+      --ignore-scripts \
+      --no-commit-hooks \
+      --preid $SHORT_SHA1 \
+      -y
+    npx lerna publish from-git \
+      --ignore-scripts \
+      --pre-dist-tag next \
+      -y;
+  fi;
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,11 +125,8 @@ Studio UI does not yet consume Codegen UI from NPM and instead the Codegen UI so
 
 A pre-release is automatically published to NPM when the following cirteria are met:
 
-- A commit is pushed to then `main` branch.
+- A commit is pushed to then `main` or `develop` branch.
 - The commit is not a release commit (i.e. `chore(release): v...`).
-- The commit has changes to a leaf package source.
-  - Ex. updating `.circleci/config.yml` will not make a pre-release, but changes `packages/codegen-ui/lib/studio-node.ts` will.
-- Lerna will only look back a single commit. If the HEAD commit does not meet previous cirteria the pre-release will not be published.
 
 The pre-release will increment the patch version of each package and append meta information including the short commit hash.
 These changes will **NOT** be pushed back to the GitHub repo.
@@ -137,8 +134,8 @@ These changes will **NOT** be pushed back to the GitHub repo.
 Example:
 
 ```
- - @aws-amplify/codegen-ui-react => 1.1.1-alpha.270+2baaca9
- - @aws-amplify/codegen-ui => 1.1.1-alpha.270+2baaca9
+ - @aws-amplify/codegen-ui-react => 1.1.1-2baaca9.0
+ - @aws-amplify/codegen-ui => 1.1.1-2baaca9.0
 ```
 
 The pre-release will be published under the `next` dist tag.
@@ -157,8 +154,8 @@ To create a tagged release create a pull request or push directly to a branch wi
 The branch name must not contain any additional forward slashes after `tagged-release/`.
 The tagged release will use the same versioning process as the pre-release except:
 
-- the preid will be the branch name with `tagged-release/` removed. (Ex. `1.1.1-fix-properties.270+2baaca9`)
-- the release will not be published under any dist tag
+- the preid will inlcude the branch name with `tagged-release/` removed. (Ex. `1.1.1-fix-properties-2baaca9.0`)
+- the release will be published with the dist tag as the tagged release name. (Ex. `fix-properties`)
 
 ### Icons
 


### PR DESCRIPTION
Take 2 of #313.

Original job failed because the GitHub user was not set on CircleCI. Added a dummy user because the commit will not be pushed back to the repo.

https://app.circleci.com/pipelines/github/aws-amplify/amplify-codegen-ui/161/workflows/9895e95b-08d2-42a9-be22-e08fe7def449/jobs/656
