### PR TITLE
fix: proper use of type from ui builder backend

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
@@ -12,6 +12,8 @@ exports[`react-component-render-helper buildFixedJsxExpression parsed null 1`] =
 
 exports[`react-component-render-helper buildFixedJsxExpression parsed number 1`] = `"{400}"`;
 
+exports[`react-component-render-helper buildFixedJsxExpression parsed number 2`] = `"{400}"`;
+
 exports[`react-component-render-helper buildFixedJsxExpression parsed object 1`] = `"{{ \\"transponder\\": \\"rocinante\\" }}"`;
 
 exports[`react-component-render-helper buildFixedJsxExpression string 1`] = `"\\"some text\\""`;

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -76,6 +76,7 @@ export default function CustomButton(
     <Button
       color=\\"#ff0000\\"
       width={20}
+      isDisabled={true}
       {...rest}
       {...getOverrideProps(overrides, \\"Button\\")}
     ></Button>

--- a/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
@@ -108,6 +108,7 @@ describe('react-component-render-helper', () => {
 
     test('parsed number', () => {
       assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '400', type: 'Number' }));
+      assertASTMatchesSnapshot(buildFixedJsxExpression({ value: '400', type: 'number' }));
     });
 
     test('boolean', () => {
@@ -144,6 +145,16 @@ describe('react-component-render-helper', () => {
 
     test('parsed null', () => {
       assertASTMatchesSnapshot(buildFixedJsxExpression({ value: 'null', type: 'Object' }));
+    });
+
+    test('type mismatch error', () => {
+      expect(() => buildFixedJsxExpression({ value: 'true', type: 'number' })).toThrow(
+        'Parsed value type "boolean" and specified type "number" mismatch',
+      );
+    });
+
+    test('json parse error', () => {
+      expect(() => buildFixedJsxExpression({ value: '⭐', type: 'number' })).toThrow('Failed to parse value "⭐"');
     });
   });
 });

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-json/buttonGolden.json
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-json/buttonGolden.json
@@ -9,6 +9,10 @@
     "width": {
       "type": "Number",
       "value": "20"
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "value": "true"
     }
   }
 }


### PR DESCRIPTION
*Description of changes:*
JS types specified in the type prop is in lowercase, and all of the values pulled from the backend are string literals. Updating the function to take those into account
