### PR TITLE
fix: append Model to local model imports

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -148,7 +148,10 @@ export default function Test(props: TestProps): React.ReactElement {
 exports[`amplify render tests collection should render collection with data binding 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { User, UserPreferences } from \\"../models\\";
+import {
+  User as UserModel,
+  UserPreferences as UserPreferencesModel,
+} from \\"../models\\";
 import {
   EscapeHatchProps,
   createDataStorePredicate,
@@ -166,7 +169,7 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     width?: Number;
     backgroundColor?: String;
-    buttonColor?: UserPreferences;
+    buttonColor?: UserPreferencesModel;
     items?: any[];
   } & {
     overrides?: EscapeHatchProps | undefined | null;
@@ -196,7 +199,7 @@ export default function CollectionOfCustomButtons(
       ? items
       : useDataStoreBinding({
           type: \\"collection\\",
-          model: User,
+          model: UserModel,
           criteria: buttonUserFilter,
         }).items;
   const buttonColorFilterObj = {
@@ -205,10 +208,10 @@ export default function CollectionOfCustomButtons(
     operator: \\"eq\\",
   };
   const buttonColorFilter =
-    createDataStorePredicate<UserPreferences>(buttonColorFilterObj);
+    createDataStorePredicate<UserPreferencesModel>(buttonColorFilterObj);
   const buttonColorDataStore = useDataStoreBinding({
     type: \\"collection\\",
-    model: UserPreferences,
+    model: UserPreferencesModel,
     criteria: buttonColorFilter,
   }).items[0];
   const buttonColor =
@@ -248,7 +251,10 @@ exports[`amplify render tests collection should render collection with data bind
 Object {
   "componentText": "/* eslint-disable */
 import React from \\"react\\";
-import { User, UserPreferences } from \\"../models\\";
+import {
+  User as UserModel,
+  UserPreferences as UserPreferencesModel,
+} from \\"../models\\";
 import {
   EscapeHatchProps,
   createDataStorePredicate,
@@ -267,7 +273,7 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     width?: Number;
     backgroundColor?: String;
-    buttonColor?: UserPreferences;
+    buttonColor?: UserPreferencesModel;
     items?: any[];
   } & {
     overrides?: EscapeHatchProps | undefined | null;
@@ -301,7 +307,7 @@ export default function CollectionOfCustomButtons(
       ? items
       : useDataStoreBinding({
           type: \\"collection\\",
-          model: User,
+          model: UserModel,
           criteria: buttonUserFilter,
           pagination: buttonUserPagination,
         }).items;
@@ -311,10 +317,10 @@ export default function CollectionOfCustomButtons(
     operator: \\"eq\\",
   };
   const buttonColorFilter =
-    createDataStorePredicate<UserPreferences>(buttonColorFilterObj);
+    createDataStorePredicate<UserPreferencesModel>(buttonColorFilterObj);
   const buttonColorDataStore = useDataStoreBinding({
     type: \\"collection\\",
-    model: UserPreferences,
+    model: UserPreferencesModel,
     criteria: buttonColorFilter,
   }).items[0];
   const buttonColor =
@@ -356,7 +362,10 @@ export default function CollectionOfCustomButtons(
 exports[`amplify render tests collection should render collection with data binding if binding name is items 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { User, UserPreferences } from \\"../models\\";
+import {
+  User as UserModel,
+  UserPreferences as UserPreferencesModel,
+} from \\"../models\\";
 import {
   EscapeHatchProps,
   createDataStorePredicate,
@@ -374,7 +383,7 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     width?: Number;
     backgroundColor?: String;
-    buttonColor?: UserPreferences;
+    buttonColor?: UserPreferencesModel;
     items?: any[];
   } & {
     overrides?: EscapeHatchProps | undefined | null;
@@ -404,7 +413,7 @@ export default function CollectionOfCustomButtons(
       ? itemsProp
       : useDataStoreBinding({
           type: \\"collection\\",
-          model: User,
+          model: UserModel,
           criteria: itemsFilter,
         }).items;
   const buttonColorFilterObj = {
@@ -413,10 +422,10 @@ export default function CollectionOfCustomButtons(
     operator: \\"eq\\",
   };
   const buttonColorFilter =
-    createDataStorePredicate<UserPreferences>(buttonColorFilterObj);
+    createDataStorePredicate<UserPreferencesModel>(buttonColorFilterObj);
   const buttonColorDataStore = useDataStoreBinding({
     type: \\"collection\\",
-    model: UserPreferences,
+    model: UserPreferencesModel,
     criteria: buttonColorFilter,
   }).items[0];
   const buttonColor =
@@ -462,7 +471,7 @@ import {
 } from \\"@aws-amplify/ui-react/internal\\";
 import ListingCard from \\"./ListingCard\\";
 import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
-import { UntitledModel } from \\"../models\\";
+import { UntitledModel as UntitledModelModel } from \\"../models\\";
 
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -481,7 +490,7 @@ export default function ListingCardCollection(
       ? items
       : useDataStoreBinding({
           type: \\"collection\\",
-          model: UntitledModel,
+          model: UntitledModelModel,
         }).items;
   return (
     /* @ts-ignore: TS2322 */
@@ -3627,7 +3636,7 @@ export default function TextWithDataBinding(
 exports[`amplify render tests component with data binding should add model imports 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { User } from \\"../models\\";
+import { User as UserModel } from \\"../models\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
@@ -3638,7 +3647,7 @@ export type ComponentWithDataBindingProps = React.PropsWithChildren<
   Partial<ButtonProps> & {
     width?: Number;
     isDisabled?: Boolean;
-    buttonUser?: User;
+    buttonUser?: UserModel;
     buttonColor?: String;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
@@ -3670,10 +3679,56 @@ export default function ComponentWithDataBinding(
 "
 `;
 
+exports[`amplify render tests component with data binding should allow binding with same name as model 1`] = `
+"/* eslint-disable */
+import React from \\"react\\";
+import { User as UserModel } from \\"../models\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
+
+export type ComponentWithDataBindingProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    width?: Number;
+    isDisabled?: Boolean;
+    User?: UserModel;
+    buttonColor?: String;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function ComponentWithDataBinding(
+  props: ComponentWithDataBindingProps
+): React.ReactElement {
+  const {
+    width,
+    isDisabled,
+    User,
+    buttonColor,
+    overrides: overridesProp,
+    ...rest
+  } = props;
+  const overrides = { ...overridesProp };
+  return (
+    /* @ts-ignore: TS2322 */
+    <Button
+      labelWidth={width}
+      disabled={isDisabled}
+      children={User?.username || \\"hspain@gmail.com\\"}
+      {...rest}
+      {...getOverrideProps(overrides, \\"Button\\")}
+    ></Button>
+  );
+}
+"
+`;
+
 exports[`amplify render tests component with data binding should not have useDataStoreBinding when there is no predicate 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { UntitledModel } from \\"../models\\";
+import { UntitledModel as UntitledModelModel } from \\"../models\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
@@ -3682,7 +3737,7 @@ import { Flex, FlexProps, Text } from \\"@aws-amplify/ui-react\\";
 
 export type SectionHeadingProps = React.PropsWithChildren<
   Partial<FlexProps> & {
-    newProp6fd1?: UntitledModel;
+    newProp6fd1?: UntitledModelModel;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -4017,7 +4072,7 @@ export default function ChildComponentWithStaticConcatenation(
 exports[`amplify render tests concat and conditional transform should render component with concatenation prop 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { User } from \\"../models\\";
+import { User as UserModel } from \\"../models\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
@@ -4027,7 +4082,7 @@ import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 export type CustomButtonProps = React.PropsWithChildren<
   Partial<ButtonProps> & {
     width?: Number;
-    buttonUser?: User;
+    buttonUser?: UserModel;
     buttonColor?: String;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
@@ -4062,7 +4117,7 @@ export default function CustomButton(
 exports[`amplify render tests concat and conditional transform should render component with conditional data binding prop 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { User } from \\"../models\\";
+import { User as UserModel } from \\"../models\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
@@ -4072,7 +4127,7 @@ import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 export type CustomButtonProps = React.PropsWithChildren<
   Partial<ButtonProps> & {
     width?: Number;
-    buttonUser?: User;
+    buttonUser?: UserModel;
     buttonColor?: String;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
@@ -4120,7 +4175,7 @@ export default function CustomButton(
 exports[`amplify render tests concat and conditional transform should render component with conditional data binding prop from a bug 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import { Student } from \\"../models\\";
+import { Student as StudentModel } from \\"../models\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
@@ -4129,7 +4184,7 @@ import { Button, Flex, FlexProps, Text } from \\"@aws-amplify/ui-react\\";
 
 export type ConditionalComponentWithDataBindingProps = React.PropsWithChildren<
   Partial<FlexProps> & {
-    student?: Student;
+    student?: StudentModel;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -4697,7 +4752,7 @@ import {
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Collection, CollectionProps, Text } from \\"@aws-amplify/ui-react\\";
-import { User } from \\"../models\\";
+import { User as UserModel } from \\"../models\\";
 
 export type CollectionDefaultValueProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -4714,7 +4769,7 @@ export default function CollectionDefaultValue(
       ? items
       : useDataStoreBinding({
           type: \\"collection\\",
-          model: User,
+          model: UserModel,
         }).items;
   return (
     /* @ts-ignore: TS2322 */

--- a/packages/codegen-ui-react/lib/__tests__/imports/__snapshots__/import-collection.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/imports/__snapshots__/import-collection.test.ts.snap
@@ -26,6 +26,16 @@ exports[`ImportCollection addImport one relative import 1`] = `
 import { User } from \\"../models\\";"
 `;
 
+exports[`ImportCollection addImport one renamed import 1`] = `
+"import React from \\"react\\";
+import { Text, getOverrideProps as renamed } from \\"@aws-amplify/ui-react\\";"
+`;
+
+exports[`ImportCollection addImport renamed and original import 1`] = `
+"import React from \\"react\\";
+import { getOverrideProps, getOverrideProps as renamed } from \\"@aws-amplify/ui-react\\";"
+`;
+
 exports[`ImportCollection buildImportStatements multiple imports 1`] = `
 "import React from \\"react\\";
 import { Button, getOverrideProps } from \\"@aws-amplify/ui-react\\";

--- a/packages/codegen-ui-react/lib/__tests__/imports/import-collection.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/imports/import-collection.test.ts
@@ -69,6 +69,20 @@ describe('ImportCollection', () => {
       importCollection.addImport('@aws-amplify/ui-react', 'getOverrideProps');
       assertImportCollectionMatchesSnapshot(importCollection);
     });
+
+    test('one renamed import', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('@aws-amplify/ui-react', 'getOverrideProps', 'renamed');
+      importCollection.addImport('@aws-amplify/ui-react', 'Text');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
+
+    test('renamed and original import', () => {
+      const importCollection = new ImportCollection();
+      importCollection.addImport('@aws-amplify/ui-react', 'getOverrideProps', 'renamed');
+      importCollection.addImport('@aws-amplify/ui-react', 'getOverrideProps');
+      assertImportCollectionMatchesSnapshot(importCollection);
+    });
   });
 
   test('mergeCollections', () => {

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -115,6 +115,11 @@ describe('amplify render tests', () => {
       expect(generatedCode.componentText).toMatchSnapshot();
     });
 
+    it('should allow binding with same name as model', () => {
+      const generatedCode = generateWithAmplifyRenderer('bindingWithSameNameAsModel');
+      expect(generatedCode.componentText).toMatchSnapshot();
+    });
+
     it('should not have useDataStoreBinding when there is no predicate', () => {
       const generatedCode = generateWithAmplifyRenderer('dataBindingWithoutPredicate');
       expect(generatedCode.componentText).toMatchSnapshot();

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-json/bindingWithSameNameAsModel.json
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-json/bindingWithSameNameAsModel.json
@@ -1,0 +1,41 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Button",
+  "name": "ComponentWithDataBinding",
+  "bindingProperties": {
+    "width": {
+      "type": "Number"
+    },
+    "isDisabled": {
+      "type": "Boolean"
+    },
+    "User": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "User"
+      }
+    },
+    "buttonColor": {
+      "type": "String"
+    }
+  },
+  "properties": {
+    "label": {
+      "bindingProperties": {
+        "property": "User",
+        "field": "username"
+      },
+      "defaultValue": "hspain@gmail.com"
+    },
+    "labelWidth": {
+      "bindingProperties": {
+        "property": "width"
+      }
+    },
+    "disabled": {
+      "bindingProperties": {
+        "property": "isDisabled"
+      }
+    }
+  }
+}

--- a/packages/codegen-ui-react/lib/react-component-render-helper.ts
+++ b/packages/codegen-ui-react/lib/react-component-render-helper.ts
@@ -52,6 +52,10 @@ export function getComponentPropName(componentName?: string): string {
   return 'ComponentWithoutNameProps';
 }
 
+export function getModelImportName(modelName: string): string {
+  return `${modelName}Model`;
+}
+
 export type ComponentPropertyValueTypes =
   | ConcatenatedStudioComponentProperty
   | ConditionalStudioComponentProperty
@@ -457,7 +461,11 @@ export function addBindingPropertiesImports(
   if ('bindingProperties' in component) {
     Object.entries(component.bindingProperties).forEach(([, binding]) => {
       if ('bindingProperties' in binding && 'model' in binding.bindingProperties) {
-        importCollection.addImport(ImportSource.LOCAL_MODELS, binding.bindingProperties.model);
+        importCollection.addImport(
+          ImportSource.LOCAL_MODELS,
+          binding.bindingProperties.model,
+          getModelImportName(binding.bindingProperties.model),
+        );
       }
     });
   }

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -62,7 +62,7 @@ import { ImportCollection, ImportSource, ImportValue } from './imports';
 import { ReactOutputManager } from './react-output-manager';
 import { ReactRenderConfig, ScriptKind, scriptKindToFileExtension } from './react-render-config';
 import SampleCodeRenderer from './amplify-ui-renderers/sampleCodeRenderer';
-import { getComponentPropName } from './react-component-render-helper';
+import { getComponentPropName, getModelImportName } from './react-component-render-helper';
 import {
   transpile,
   buildPrinter,
@@ -421,7 +421,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
           undefined,
           propName,
           factory.createToken(SyntaxKind.QuestionToken),
-          factory.createTypeReferenceNode(binding.bindingProperties.model, undefined),
+          factory.createTypeReferenceNode(getModelImportName(binding.bindingProperties.model), undefined),
         );
         propSignatures.push(propSignature);
       }
@@ -698,7 +698,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
           this.importCollection.addMappedImport(ImportValue.SORT_PREDICATE);
           statements.push(this.buildPaginationStatement(propName, model, sort));
         }
-        this.importCollection.addImport(ImportSource.LOCAL_MODELS, model);
+        this.importCollection.addImport(ImportSource.LOCAL_MODELS, model, getModelImportName(model));
         statements.push(
           this.buildPropPrecedentStatement(
             propName,
@@ -760,9 +760,9 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
              * }
              */
             statements.push(this.buildPredicateDeclaration(propName, bindingProperties.predicate));
-            statements.push(this.buildCreateDataStorePredicateCall(bindingProperties.model, propName));
+            statements.push(this.buildCreateDataStorePredicateCall(`${bindingProperties.model}Model`, propName));
             const { model } = bindingProperties;
-            this.importCollection.addImport(ImportSource.LOCAL_MODELS, model);
+            this.importCollection.addImport(ImportSource.LOCAL_MODELS, model, getModelImportName(model));
 
             /* const buttonColorDataStore = useDataStoreBinding({
              *   type: "collection"
@@ -978,7 +978,10 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     const objectProperties = [
       factory.createPropertyAssignment(factory.createIdentifier('type'), factory.createStringLiteral(callType)),
-      factory.createPropertyAssignment(factory.createIdentifier('model'), factory.createIdentifier(bindingModel)),
+      factory.createPropertyAssignment(
+        factory.createIdentifier('model'),
+        factory.createIdentifier(getModelImportName(bindingModel)),
+      ),
     ]
       .concat(
         criteriaName

--- a/packages/test-generator/integration-test-templates/cypress/integration/generate-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generate-spec.ts
@@ -129,6 +129,7 @@ const EXPECTED_SUCCESSFUL_CASES = new Set([
   'GoldenComponentWithTypedProp',
   'GoldenComponentWithVariants',
   'GoldenTheme',
+  'BindingWithSameNameAsModel',
 ]);
 const EXPECTED_INVALID_INPUT_CASES = new Set([
   'ComponentMissingProperties',

--- a/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.ts
@@ -114,6 +114,10 @@ describe('Generated Components', () => {
   });
 
   describe('Data Binding', () => {
+    it('Renders DataStore binding with same name as model', () => {
+      cy.get('#sameNameAsModel').contains('No name!');
+    });
+
     describe('Simple Property Binding', () => {
       it('Renders the Bound property', () => {
         cy.get('#simplePropIsDisabled').get('[disabled]');

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -46,6 +46,7 @@ import {
   ComponentWithDataBindingWithoutPredicate,
   ComponentWithDataBindingWithPredicate,
   ComponentWithMultipleDataBindingsWithPredicate,
+  BindingWithSameNameAsModel,
   CollectionWithBinding,
   CollectionWithSort,
   ParsedFixedValues,
@@ -266,6 +267,7 @@ export default function ComponentTests() {
             priceUSD: 2200,
           }}
         />
+        <BindingWithSameNameAsModel id="sameNameAsModel" />
       </div>
       <div id="collections">
         <h2>Collections</h2>

--- a/packages/test-generator/lib/components/property-binding/bindingWithSameNameAsModel.json
+++ b/packages/test-generator/lib/components/property-binding/bindingWithSameNameAsModel.json
@@ -1,0 +1,41 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Button",
+  "name": "BindingWithSameNameAsModel",
+  "bindingProperties": {
+    "width": {
+      "type": "Number"
+    },
+    "isDisabled": {
+      "type": "Boolean"
+    },
+    "User": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "User"
+      }
+    },
+    "buttonColor": {
+      "type": "String"
+    }
+  },
+  "properties": {
+    "label": {
+      "bindingProperties": {
+        "property": "User",
+        "field": "firstName"
+      },
+      "defaultValue": "No name!"
+    },
+    "labelWidth": {
+      "bindingProperties": {
+        "property": "width"
+      }
+    },
+    "disabled": {
+      "bindingProperties": {
+        "property": "isDisabled"
+      }
+    }
+  }
+}

--- a/packages/test-generator/lib/components/property-binding/index.ts
+++ b/packages/test-generator/lib/components/property-binding/index.ts
@@ -18,3 +18,4 @@ export { default as ComponentWithDataBindingWithoutPredicate } from './component
 export { default as ComponentWithSimplePropertyBinding } from './componentWithSimplePropertyBinding.json';
 export { default as ComponentWithAuthBinding } from './componentWithAuthBinding.json';
 export { default as CompWithMultipleBindingsWithPred } from './componentWithMultipleDataBindingsWithPredicate.json';
+export { default as BindingWithSameNameAsModel } from './bindingWithSameNameAsModel.json';


### PR DESCRIPTION
In the case where a model shared the name with a prop the generated code would be invalid. Solve this issue by appending `Model` to model import names.

This is only really the first step to a full solution. The customer could still create a prop that is named something like `UserModel` and there would be a name collision. Long term we need to devise a way to prevent name collisions in generated components.