### PR TITLE
fix: do not swallow prettier.format errors

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-studio-template-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-studio-template-renderer-helper.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`react-studio-template-renderer-helper formatCode does not swallow prettier errors 1`] = `"Failed to format"`;
+
 exports[`react-studio-template-renderer-helper formatCode formats code when prettier is installed 1`] = `
 "const foo = 1;
 const bar = false;

--- a/packages/codegen-ui-react/lib/__tests__/react-studio-template-renderer-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-studio-template-renderer-helper.test.ts
@@ -114,5 +114,15 @@ describe('react-studio-template-renderer-helper', () => {
 
       expect(formatCode(code)).toEqual(code);
     });
+
+    it('does not swallow prettier errors', () => {
+      jest.mock('prettier', () => ({
+        format: jest.fn(() => {
+          throw new Error('Failed to format');
+        }),
+      }));
+
+      expect(() => formatCode(code)).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
@@ -187,16 +187,19 @@ export function bindingPropertyUsesHook(
 
 // optional import prettier
 export function formatCode(code: string): string {
+  let prettier = null;
+  let parserTypescript = null;
+
   try {
     // eslint-disable-next-line global-require, import/no-extraneous-dependencies, @typescript-eslint/no-var-requires
-    const prettier = require('prettier');
+    prettier = require('prettier');
     // eslint-disable-next-line global-require, import/no-extraneous-dependencies, @typescript-eslint/no-var-requires
-    const parserTypescript = require('prettier/parser-typescript');
-
-    if (prettier && parserTypescript) {
-      return prettier.format(code, { parser: 'typescript', plugins: [parserTypescript] });
-    }
+    parserTypescript = require('prettier/parser-typescript');
   } catch {} // eslint-disable-line no-empty
+
+  if (prettier && parserTypescript) {
+    return prettier.format(code, { parser: 'typescript', plugins: [parserTypescript] });
+  }
 
   return code;
 }


### PR DESCRIPTION
Swallowing prettier errors resulted in code not being formatted in cases where the generated code had invalid syntax. I'm not aware any occurrence in production yet.

The error will now bubble up if prettier fails to format.
