### PR TITLE
feat: adding support for  prop on collection components

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -151,17 +151,17 @@ exports[`amplify render tests collection should render collection with data bind
 import React from \\"react\\";
 import { User, UserPreferences } from \\"../models\\";
 import {
-  EscapeHatchProps,
-  createDataStorePredicate,
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
-import {
   Button,
   Collection,
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  EscapeHatchProps,
+  createDataStorePredicate,
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -169,6 +169,7 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
+    overrideItems?: ({ item: any, index: number }) => EscapeHatchProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -181,6 +182,7 @@ export default function CollectionOfCustomButtons(
     backgroundColor,
     buttonColor: buttonColorProp,
     items,
+    overrideItems,
     overrides: overridesProp,
     ...rest
   } = props;
@@ -228,14 +230,14 @@ export default function CollectionOfCustomButtons(
       {(item, index) => (
         <Flex
           key={item.id}
-          {...getOverrideProps(overrides, \\"Collection.Flex[0]\\")}
+          {...(overrideItems && overrideItems({ item, index }))}
         >
           <Button
             labelWidth={width}
             backgroundColor={buttonColor?.favoriteColor}
             disabled={isDisabled}
             children={item.username || \\"hspain@gmail.com\\"}
-            {...getOverrideProps(overrides, \\"Collection.Flex[0].Button[0]\\")}
+            {...(overrideItems && overrideItems({ item, index }))}
           ></Button>
         </Flex>
       )}
@@ -251,17 +253,17 @@ Object {
 import React from \\"react\\";
 import { User, UserPreferences } from \\"../models\\";
 import {
-  EscapeHatchProps,
-  createDataStorePredicate,
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
-import {
   Button,
   Collection,
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  EscapeHatchProps,
+  createDataStorePredicate,
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
 import { SortDirection, SortPredicate } from \\"@aws-amplify/datastore\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
@@ -270,6 +272,7 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
+    overrideItems?: ({ item: any, index: number }) => EscapeHatchProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -282,6 +285,7 @@ export default function CollectionOfCustomButtons(
     backgroundColor,
     buttonColor: buttonColorProp,
     items,
+    overrideItems,
     overrides: overridesProp,
     ...rest
   } = props;
@@ -334,14 +338,14 @@ export default function CollectionOfCustomButtons(
       {(item, index) => (
         <Flex
           key={item.id}
-          {...getOverrideProps(overrides, \\"Collection.Flex[0]\\")}
+          {...(overrideItems && overrideItems({ item, index }))}
         >
           <Button
             labelWidth={width}
             backgroundColor={buttonColor?.favoriteColor}
             disabled={isDisabled}
             children={item.username || \\"hspain@gmail.com\\"}
-            {...getOverrideProps(overrides, \\"Collection.Flex[0].Button[0]\\")}
+            {...(overrideItems && overrideItems({ item, index }))}
           ></Button>
         </Flex>
       )}
@@ -359,17 +363,17 @@ exports[`amplify render tests collection should render collection with data bind
 import React from \\"react\\";
 import { User, UserPreferences } from \\"../models\\";
 import {
-  EscapeHatchProps,
-  createDataStorePredicate,
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
-import {
   Button,
   Collection,
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  EscapeHatchProps,
+  createDataStorePredicate,
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -377,6 +381,7 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
+    overrideItems?: ({ item: any, index: number }) => EscapeHatchProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -389,6 +394,7 @@ export default function CollectionOfCustomButtons(
     backgroundColor,
     buttonColor: buttonColorProp,
     items: itemsProp,
+    overrideItems,
     overrides: overridesProp,
     ...rest
   } = props;
@@ -436,14 +442,14 @@ export default function CollectionOfCustomButtons(
       {(item, index) => (
         <Flex
           key={item.id}
-          {...getOverrideProps(overrides, \\"Collection.Flex[0]\\")}
+          {...(overrideItems && overrideItems({ item, index }))}
         >
           <Button
             labelWidth={width}
             backgroundColor={buttonColor?.favoriteColor}
             disabled={isDisabled}
             children={item.username || \\"hspain@gmail.com\\"}
-            {...getOverrideProps(overrides, \\"Collection.Flex[0].Button[0]\\")}
+            {...(overrideItems && overrideItems({ item, index }))}
           ></Button>
         </Flex>
       )}
@@ -456,18 +462,19 @@ export default function CollectionOfCustomButtons(
 exports[`amplify render tests collection should render collection with data binding with no predicate 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
+import ListingCard from \\"./ListingCard\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
-import ListingCard from \\"./ListingCard\\";
 import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
 import { UntitledModel } from \\"../models\\";
 
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
+    overrideItems?: ({ item: any, index: number }) => EscapeHatchProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -475,7 +482,7 @@ export type ListingCardCollectionProps = React.PropsWithChildren<
 export default function ListingCardCollection(
   props: ListingCardCollectionProps
 ): React.ReactElement {
-  const { items, overrides: overridesProp, ...rest } = props;
+  const { items, overrideItems, overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
   const bananas =
     items !== undefined
@@ -503,7 +510,7 @@ export default function ListingCardCollection(
           marginTop=\\"0\\"
           marginLeft=\\"0\\"
           key={item.id}
-          {...getOverrideProps(overrides, \\"Collection.ListingCard[0]\\")}
+          {...(overrideItems && overrideItems({ item, index }))}
         ></ListingCard>
       )}
     </Collection>
@@ -515,16 +522,17 @@ export default function ListingCardCollection(
 exports[`amplify render tests collection should render collection without data binding 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
+import ListingCard from \\"./ListingCard\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
 } from \\"@aws-amplify/ui-react/internal\\";
-import ListingCard from \\"./ListingCard\\";
 import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
 
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
+    overrideItems?: ({ item: any, index: number }) => EscapeHatchProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -532,7 +540,7 @@ export type ListingCardCollectionProps = React.PropsWithChildren<
 export default function ListingCardCollection(
   props: ListingCardCollectionProps
 ): React.ReactElement {
-  const { items, overrides: overridesProp, ...rest } = props;
+  const { items, overrideItems, overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
   return (
     /* @ts-ignore: TS2322 */
@@ -546,7 +554,7 @@ export default function ListingCardCollection(
       {(item, index) => (
         <ListingCard
           key={item.id}
-          {...getOverrideProps(overrides, \\"Collection.ListingCard[0]\\")}
+          {...(overrideItems && overrideItems({ item, index }))}
         ></ListingCard>
       )}
     </Collection>
@@ -4692,23 +4700,26 @@ exports[`amplify render tests default value should render collection default val
 Object {
   "componentText": "/* eslint-disable */
 import React from \\"react\\";
+import { Collection, CollectionProps, Text } from \\"@aws-amplify/ui-react\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Collection, CollectionProps, Text } from \\"@aws-amplify/ui-react\\";
 import { User } from \\"../models\\";
 
 export type CollectionDefaultValueProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
+    items?: any[];
+    overrideItems?: ({ item: any, index: number }) => EscapeHatchProps;
+  } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
 >;
 export default function CollectionDefaultValue(
   props: CollectionDefaultValueProps
 ): React.ReactElement {
-  const { items, overrides: overridesProp, ...rest } = props;
+  const { items, overrideItems, overrides: overridesProp, ...rest } = props;
   const overrides = { ...overridesProp };
   const user =
     items !== undefined
@@ -4728,7 +4739,7 @@ export default function CollectionDefaultValue(
         <Text
           key={item.id}
           children={item.username || \\"Collection Default Value\\"}
-          {...getOverrideProps(overrides, \\"Collection.Text[0]\\")}
+          {...(overrideItems && overrideItems({ item, index }))}
         ></Text>
       )}
     </Collection>

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
@@ -15,8 +15,9 @@
  */
 import { BaseComponentProps } from '@aws-amplify/ui-react';
 import { isStudioComponentWithCollectionProperties, StudioComponentChild } from '@aws-amplify/codegen-ui';
-import { factory, JsxChild, JsxElement, JsxExpression, SyntaxKind } from 'typescript';
+import { factory, JsxChild, JsxElement, JsxExpression, JsxOpeningElement, SyntaxKind } from 'typescript';
 import { ReactComponentWithChildrenRenderer } from '../react-component-with-children-renderer';
+import { buildOpeningElementAttributes } from '../react-component-render-helper';
 
 export default class CollectionRenderer extends ReactComponentWithChildrenRenderer<BaseComponentProps> {
   renderElement(renderChildren: (children: StudioComponentChild[]) => JsxChild[]): JsxElement {
@@ -34,6 +35,33 @@ export default class CollectionRenderer extends ReactComponentWithChildrenRender
     this.importCollection.addImport('@aws-amplify/ui-react', this.component.componentType);
 
     return element;
+  }
+
+  private renderCollectionOpeningElement(itemsVariableName?: string): JsxOpeningElement {
+    const propsArray = Object.entries(this.component.properties).map(([key, value]) =>
+      buildOpeningElementAttributes(value, key),
+    );
+
+    const itemsAttribute = factory.createJsxAttribute(
+      factory.createIdentifier('items'),
+      factory.createJsxExpression(
+        undefined,
+        factory.createBinaryExpression(
+          factory.createIdentifier(itemsVariableName || 'items'),
+          factory.createToken(SyntaxKind.BarBarToken),
+          factory.createArrayLiteralExpression([], false),
+        ),
+      ),
+    );
+    propsArray.push(itemsAttribute);
+
+    this.addPropsSpreadAttributes(propsArray);
+
+    return factory.createJsxOpeningElement(
+      factory.createIdentifier(this.component.componentType),
+      undefined,
+      factory.createJsxAttributes(propsArray),
+    );
   }
 
   private addKeyPropertyToChildren(children: StudioComponentChild[]) {

--- a/packages/codegen-ui/lib/__tests__/studio-node.test.ts
+++ b/packages/codegen-ui/lib/__tests__/studio-node.test.ts
@@ -62,6 +62,134 @@ describe('StudioNode', () => {
     });
   });
 
+  describe('hasAncestorOfType', () => {
+    test('it returns false with no parent', () => {
+      const node = new StudioNode({
+        componentType: 'View',
+        name: 'Node',
+        properties: {},
+      });
+      expect(node.hasAncestorOfType('Collection')).toBeFalsy();
+    });
+
+    test('it returns false with node is of type, but not parent', () => {
+      const parent = new StudioNode({
+        componentType: 'View',
+        name: 'Parent Node',
+        properties: {},
+      });
+      const node = new StudioNode(
+        {
+          componentType: 'Collection',
+          name: 'Node',
+          properties: {},
+        },
+        parent,
+      );
+      expect(node.hasAncestorOfType('Collection')).toBeFalsy();
+    });
+
+    test('it returns true if immediate parent is of type', () => {
+      const parent = new StudioNode({
+        componentType: 'Collection',
+        name: 'Parent Node',
+        properties: {},
+      });
+      const node = new StudioNode(
+        {
+          componentType: 'View',
+          name: 'Node',
+          properties: {},
+        },
+        parent,
+      );
+      expect(node.hasAncestorOfType('Collection')).toBeTruthy();
+    });
+
+    test('it returns true if ancestor is of type', () => {
+      const greatGrandParent = new StudioNode({
+        componentType: 'View',
+        name: 'Great GrandParent Node',
+        properties: {},
+      });
+      const grandParent = new StudioNode(
+        {
+          componentType: 'Collection',
+          name: 'GrandParent Node',
+          properties: {},
+        },
+        greatGrandParent,
+      );
+      const parent = new StudioNode(
+        {
+          componentType: 'View',
+          name: 'Parent Node',
+          properties: {},
+        },
+        grandParent,
+      );
+      const node = new StudioNode(
+        {
+          componentType: 'View',
+          name: 'Node',
+          properties: {},
+        },
+        parent,
+      );
+      expect(node.hasAncestorOfType('Collection')).toBeTruthy();
+    });
+
+    test('it returns true if top-level ancestor is of type', () => {
+      const grandParent = new StudioNode({
+        componentType: 'Collection',
+        name: 'GrandParent Node',
+        properties: {},
+      });
+      const parent = new StudioNode(
+        {
+          componentType: 'View',
+          name: 'Parent Node',
+          properties: {},
+        },
+        grandParent,
+      );
+      const node = new StudioNode(
+        {
+          componentType: 'View',
+          name: 'Node',
+          properties: {},
+        },
+        parent,
+      );
+      expect(node.hasAncestorOfType('Collection')).toBeTruthy();
+    });
+
+    test('it false if no ancestor of type exists', () => {
+      const grandParent = new StudioNode({
+        componentType: 'view',
+        name: 'GrandParent Node',
+        properties: {},
+      });
+      const parent = new StudioNode(
+        {
+          componentType: 'View',
+          name: 'Parent Node',
+          properties: {},
+        },
+        grandParent,
+      );
+      const node = new StudioNode(
+        {
+          componentType: 'View',
+          name: 'Node',
+          properties: {},
+        },
+        parent,
+      );
+      expect(node.hasAncestorOfType('Collection')).toBeFalsy();
+    });
+  });
+
   describe('getOverrideKey', () => {
     test('returns for parent', () => {
       const rootComponent = createStudioNodeOfType('Flex', createStudioNodeOfType('Button'));

--- a/packages/codegen-ui/lib/studio-node.ts
+++ b/packages/codegen-ui/lib/studio-node.ts
@@ -36,6 +36,16 @@ export class StudioNode {
     return [this];
   }
 
+  /**
+   * Return true if any ancestor node of the current node has type `componentType`.
+   */
+  hasAncestorOfType(componentType: string): boolean {
+    const ancestorComponentTypes = this.getComponentPathToRoot().map((node) => node.component.componentType);
+    // We don't want to check if the current node has type, so shift that element out.
+    ancestorComponentTypes.shift();
+    return ancestorComponentTypes.some((ancestorComponentType) => ancestorComponentType === componentType);
+  }
+
   getOverrideIndex(): number {
     if (this.parent === undefined || this.parent.component.children === undefined) {
       return -1;

--- a/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.ts
@@ -194,6 +194,11 @@ describe('Generated Components', () => {
       cy.get('[aria-label="Go to page 2"]').click();
       cy.get('#paginatedCollection').contains('Beachside Cottage - $1000');
     });
+
+    it('Supports overrideItems with context injection', () => {
+      cy.get('#collectionWithOverrideItems').contains('0 - Doodle, Yankee');
+      cy.get('#collectionWithOverrideItems').contains('1 - Cap, Feather');
+    });
   });
 
   describe('Default Value', () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -303,6 +303,26 @@ export default function ComponentTests() {
           ]}
         />
         <PaginatedCollection id="paginatedCollection" />
+        <CollectionWithBinding
+          id="collectionWithOverrideItems"
+          items={[
+            {
+              id: '1',
+              firstName: 'Yankee',
+              lastName: 'Doodle',
+            },
+            {
+              id: '2',
+              firstName: 'Feather',
+              lastName: 'Cap',
+            },
+          ]}
+          overrideItems={({ item, index }: { item: any; index: number }) => {
+            return {
+              children: `${index} - ${item.lastName}, ${item.firstName}`,
+            };
+          }}
+        />
       </div>
       <div id="default-value">
         <h2>Default Value</h2>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Replace the use of existing getOverrideProps with calls to an injected overrItems callback provided by the user. This allows the user to access item and index information in their overrides.

This is the first of two major updates to overrides which we'll be rolling out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
