### PR TITLE
chore: remove run from action bindings per golden updates

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -30,7 +30,7 @@ export default function CreateCustomerButton(
     <Button
       children=\\"Create\\"
       onClick={() => {
-        createCustomerButtonClick.run();
+        createCustomerButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"CreateCustomerButton\\")}
@@ -73,7 +73,7 @@ export default function DeleteCustomerButton(
     <Button
       children=\\"Delete\\"
       onClick={() => {
-        deleteCustomerButtonClick.run();
+        deleteCustomerButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"DeleteCustomerButton\\")}
@@ -117,7 +117,7 @@ export default function UpdateCustomerButton(
     <Button
       children=\\"Update\\"
       onClick={() => {
-        updateCustomerButtonClick.run();
+        updateCustomerButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"UpdateCustomerButton\\")}
@@ -156,7 +156,7 @@ export default function SignOutButton(
     <Button
       children=\\"Sign out\\"
       onClick={() => {
-        signOutButtonClick.run();
+        signOutButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"SignOutButton\\")}
@@ -198,7 +198,7 @@ export default function NavigateButton(
     <Button
       children=\\"Go to About section\\"
       onClick={() => {
-        navigateButtonClick.run();
+        navigateButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"NavigateButton\\")}
@@ -240,7 +240,7 @@ export default function NavigateButton(
     <Button
       children=\\"Go to Amazon.com\\"
       onClick={() => {
-        navigateButtonClick.run();
+        navigateButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"NavigateButton\\")}
@@ -283,7 +283,7 @@ export default function NavigateButton(
     <Button
       children=\\"Go to Amazon.com (Open in new tab)\\"
       onClick={() => {
-        navigateButtonClick.run();
+        navigateButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"NavigateButton\\")}
@@ -322,7 +322,7 @@ export default function ReloadButton(
     <Button
       children=\\"Reload the page.\\"
       onClick={() => {
-        reloadButtonClick.run();
+        reloadButtonClick();
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"ReloadButton\\")}

--- a/packages/codegen-ui-react/lib/workflow/events.ts
+++ b/packages/codegen-ui-react/lib/workflow/events.ts
@@ -67,10 +67,7 @@ export function buildActionEvent(
           [
             factory.createExpressionStatement(
               factory.createCallExpression(
-                factory.createPropertyAccessExpression(
-                  factory.createIdentifier(getActionIdentifier(componentName, eventName)),
-                  factory.createIdentifier('run'),
-                ),
+                factory.createIdentifier(getActionIdentifier(componentName, eventName)),
                 undefined,
                 [],
               ),


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We're planning to return the function directly from the ui helpers, so getting rid of the `run` parameter which was being returned, and invoking directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
