### PR TITLE
chore: add datastore e2e tests

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -7,9 +7,9 @@ import React from \\"react\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
-  useDataStoreCreateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
+import { useDataStoreCreateAction } from \\"../mock-helpers\\";
 import { Customer } from \\"../models\\";
 
 export type CreateCustomerButtonProps = React.PropsWithChildren<
@@ -50,9 +50,9 @@ import React from \\"react\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
-  useDataStoreDeleteAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
+import { useDataStoreDeleteAction } from \\"../mock-helpers\\";
 import { Customer } from \\"../models\\";
 
 export type DeleteCustomerButtonProps = React.PropsWithChildren<
@@ -93,9 +93,9 @@ import React from \\"react\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
-  useDataStoreUpdateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
+import { useDataStoreUpdateAction } from \\"../mock-helpers\\";
 import { Customer } from \\"../models\\";
 
 export type UpdateCustomerButtonProps = React.PropsWithChildren<
@@ -5166,10 +5166,12 @@ import React from \\"react\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
-  useDataStoreUpdateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, Flex, FlexProps, TextField } from \\"@aws-amplify/ui-react\\";
-import { useStateMutationAction } from \\"../mock-helpers\\";
+import {
+  useDataStoreUpdateAction,
+  useStateMutationAction,
+} from \\"../mock-helpers\\";
 import { Customer } from \\"../models\\";
 
 export type MyFormProps = React.PropsWithChildren<

--- a/packages/codegen-ui-react/lib/imports/import-mapping.ts
+++ b/packages/codegen-ui-react/lib/imports/import-mapping.ts
@@ -55,9 +55,9 @@ export const ImportMapping: Record<ImportValue, ImportSource> = {
   [ImportValue.SORT_PREDICATE]: ImportSource.AMPLIFY_DATASTORE,
   [ImportValue.MERGE_VARIANTS_OVERRIDES]: ImportSource.UI_REACT_INTERNAL,
   [ImportValue.USE_NAVIGATE_ACTION]: ImportSource.UI_REACT_INTERNAL,
-  [ImportValue.USE_DATA_STORE_CREATE_ACTION]: ImportSource.UI_REACT_INTERNAL,
-  [ImportValue.USE_DATA_STORE_UPDATE_ACTION]: ImportSource.UI_REACT_INTERNAL,
-  [ImportValue.USE_DATA_STORE_DELETE_ACTION]: ImportSource.UI_REACT_INTERNAL,
+  [ImportValue.USE_DATA_STORE_CREATE_ACTION]: ImportSource.MOCK_HELPERS,
+  [ImportValue.USE_DATA_STORE_UPDATE_ACTION]: ImportSource.MOCK_HELPERS,
+  [ImportValue.USE_DATA_STORE_DELETE_ACTION]: ImportSource.MOCK_HELPERS,
   [ImportValue.USE_AUTH_SIGN_OUT_ACTION]: ImportSource.UI_REACT_INTERNAL,
   [ImportValue.USE_STATE_MUTATION_ACTION]: ImportSource.MOCK_HELPERS,
 };

--- a/packages/test-generator/integration-test-templates/cypress/integration/generate-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generate-spec.ts
@@ -139,6 +139,9 @@ const EXPECTED_SUCCESSFUL_CASES = new Set([
   'MutationWithSyntheticProp',
   'SetStateWithoutInitialValue',
   'UpdateVisibility',
+  'DataStoreActions',
+  'FormWithState',
+  'InternalMutation',
 ]);
 const EXPECTED_INVALID_INPUT_CASES = new Set([
   'ComponentMissingProperties',

--- a/packages/test-generator/integration-test-templates/src/mock-helpers.js
+++ b/packages/test-generator/integration-test-templates/src/mock-helpers.js
@@ -17,4 +17,10 @@
 
 import { useState } from 'react';
 
+const mockedAction = () => () => {};
+
+export const useDataStoreCreateAction = mockedAction;
+export const useDataStoreUpdateAction = mockedAction;
+export const useDataStoreDeleteAction = mockedAction;
+
 export const useStateMutationAction = useState;

--- a/packages/test-generator/lib/components/workflow/dataStoreActions.json
+++ b/packages/test-generator/lib/components/workflow/dataStoreActions.json
@@ -1,0 +1,101 @@
+{
+  "componentType": "Flex",
+  "name": "DataStoreActions",
+  "bindingProperties": {
+    "idToDelete": {
+      "type": "String"
+    },
+    "idToUpdate": {
+      "type": "String"
+    }
+  },
+  "properties": {},
+  "children": [
+    {
+      "componentType": "Button",
+      "name": "CreateItem",
+      "properties": {
+        "id": {
+          "value": "create-item"
+        },
+        "label": {
+          "value": "Create Item"
+        }
+      },
+      "events": {
+        "click": {
+          "action": "Amplify.DataStoreCreateItem",
+          "parameters": {
+            "model": "User",
+            "fields": {
+              "firstName": {
+                "value": "Din"
+              },
+              "lastName": {
+                "value": "Djarin"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "componentType": "Button",
+      "name": "UpdateItem",
+      "properties": {
+        "id": {
+          "value": "update-item"
+        },
+        "label": {
+          "value": "Update Item"
+        }
+      },
+      "events": {
+        "click": {
+          "action": "Amplify.DataStoreUpdateItem",
+          "parameters": {
+            "model": "User",
+            "id": {
+              "bindingProperties": {
+                "property": "idToUpdate"
+              }
+            },
+            "fields": {
+              "firstName": {
+                "value": "Moff"
+              },
+              "lastName": {
+                "value": "Gideon"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "componentType": "Button",
+      "name": "DeleteItem",
+      "properties": {
+        "id": {
+          "value": "delete-item"
+        },
+        "label": {
+          "value": "Delete Item"
+        }
+      },
+      "events": {
+        "click": {
+          "action": "Amplify.DataStoreDeleteItem",
+          "parameters": {
+            "model": "User",
+            "id": {
+              "bindingProperties": {
+                "property": "idToDelete"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/test-generator/lib/components/workflow/formWithState.json
+++ b/packages/test-generator/lib/components/workflow/formWithState.json
@@ -1,0 +1,52 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Flex",
+  "name": "FormWithState",
+  "properties": {},
+  "children": [
+    {
+      "componentType": "TextField",
+      "name": "UsernameTextField",
+      "properties": {
+        "id": {
+          "value": "username-entry"
+        },
+        "label": {
+          "value": "Username"
+        },
+        "value": {
+          "value": "vizsla"
+        }
+      }
+    },
+    {
+      "componentType": "Button",
+      "name": "SubmitButton",
+      "events": {
+        "click": {
+          "action": "Amplify.DataStoreUpdateItem",
+          "parameters": {
+            "model": "User",
+            "id": {
+              "value": "d9887268-47dd-4899-9568-db5809218751"
+            },
+            "fields": {
+              "firstName": {
+                "componentName": "UsernameTextField",
+                "property": "value"
+              }
+            }
+          }
+        }
+      },
+      "properties": {
+        "id": {
+          "value": "submit-user-form"
+        },
+        "children": {
+          "value": "Submit"
+        }
+      }
+    }
+  ]
+}

--- a/packages/test-generator/lib/components/workflow/index.ts
+++ b/packages/test-generator/lib/components/workflow/index.ts
@@ -21,3 +21,5 @@ export { default as ButtonsToggleState } from './buttonsToggleState.json';
 export { default as MutationWithSyntheticProp } from './mutationWithSyntheticProp.json';
 export { default as SetStateWithoutInitialValue } from './setStateWithoutInitialValue.json';
 export { default as UpdateVisibility } from './updateVisibility.json';
+export { default as DataStoreActions } from './dataStoreActions.json';
+export { default as FormWithState } from './formWithState.json';


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Setting up e2e tests for the new actions. These are still wip, but I'd like to get them committed, and un-skipped as the hooks become available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
