### PR TITLE
fix: support synthetic prop mutation, and duplicate mutations on the …

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -5261,6 +5261,115 @@ export default function ColorChangeOnClick(
 }
 `;
 
+exports[`amplify render tests mutations supports multiple actions pointing to the same value 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+  useStateMutationAction,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Button, Flex, FlexProps, Text } from \\"@aws-amplify/ui-react\\";
+
+export type ButtonsToggleStateProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function ButtonsToggleState(
+  props: ButtonsToggleStateProps
+): React.ReactElement {
+  const { overrides, ...rest } = props;
+  const [fooBarValueChildren, setFooBarValueChildren] =
+    useStateMutationAction(\\"Baz\\");
+  const fooButtonClick = () => {
+    setFooBarValueChildren(\\"Foo\\");
+  };
+  const barButtonClick = () => {
+    setFooBarValueChildren(\\"Bar\\");
+  };
+  return (
+    /* @ts-ignore: TS2322 */
+    <Flex {...rest} {...getOverrideProps(overrides, \\"ButtonsToggleState\\")}>
+      <Text
+        children={fooBarValueChildren}
+        {...getOverrideProps(overrides, \\"FooBarValue\\")}
+      ></Text>
+      <Button
+        children=\\"Set to Foo\\"
+        onClick={() => {
+          fooButtonClick();
+        }}
+        {...getOverrideProps(overrides, \\"FooButton\\")}
+      ></Button>
+      <Button
+        children=\\"Set to Bar\\"
+        onClick={() => {
+          barButtonClick();
+        }}
+        {...getOverrideProps(overrides, \\"BarButton\\")}
+      ></Button>
+    </Flex>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
+exports[`amplify render tests mutations supports mutations on synthetic props 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+  useStateMutationAction,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Button, Flex, FlexProps, Text } from \\"@aws-amplify/ui-react\\";
+
+export type MutationWithSyntheticPropProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function MutationWithSyntheticProp(
+  props: MutationWithSyntheticPropProps
+): React.ReactElement {
+  const { overrides, ...rest } = props;
+  const [fooBarValueChildren, setFooBarValueChildren] =
+    useStateMutationAction(\\"Baz\\");
+  const fooButtonClick = () => {
+    setFooBarValueChildren(\\"Foo\\");
+  };
+  return (
+    /* @ts-ignore: TS2322 */
+    <Flex
+      {...rest}
+      {...getOverrideProps(overrides, \\"MutationWithSyntheticProp\\")}
+    >
+      <Text
+        children={fooBarValueChildren}
+        {...getOverrideProps(overrides, \\"FooBarValue\\")}
+      ></Text>
+      <Button
+        children=\\"Set to Foo\\"
+        onClick={() => {
+          fooButtonClick();
+        }}
+        {...getOverrideProps(overrides, \\"FooButton\\")}
+      ></Button>
+    </Flex>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
 exports[`amplify render tests primitives Built-in Iconset 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -337,6 +337,14 @@ describe('amplify render tests', () => {
     it('internal mutation', () => {
       expect(generateWithAmplifyRenderer('workflow/internalMutation')).toMatchSnapshot();
     });
+
+    it('supports mutations on synthetic props', () => {
+      expect(generateWithAmplifyRenderer('workflow/mutationWithSyntheticProp')).toMatchSnapshot();
+    });
+
+    it('supports multiple actions pointing to the same value', () => {
+      expect(generateWithAmplifyRenderer('workflow/buttonsToggleState')).toMatchSnapshot();
+    });
   });
 
   describe('default value', () => {

--- a/packages/codegen-ui-react/lib/__tests__/workflow/mutation.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/workflow/mutation.test.ts
@@ -43,7 +43,7 @@ describe('getComponentStateReferences', () => {
       children: [
         {
           componentType: 'TextField',
-          name: 'UsernameTextField',
+          name: 'UserNameTextField',
           properties: {
             label: {
               value: 'Username',

--- a/packages/codegen-ui-react/lib/__tests__/workflow/utils.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/workflow/utils.test.ts
@@ -1,0 +1,40 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { getChildPropMappingForComponentName } from '../../workflow/utils';
+
+describe('getChildPropMappingForComponentName', () => {
+  const componentNameToTypeMap = {
+    MyFlex: 'Flex',
+    MyButton: 'Button',
+  };
+
+  test('throws on missing name mapping', () => {
+    expect(() => {
+      getChildPropMappingForComponentName(componentNameToTypeMap, 'MissingComponent');
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid definition, found reference to component name MissingComponent which wasn't found in the schema."`,
+    );
+  });
+
+  test('returns mapping for synthetic mapped prop', () => {
+    expect(getChildPropMappingForComponentName(componentNameToTypeMap, 'MyButton')).toEqual('label');
+  });
+
+  test('returns undefined for non-mapped component', () => {
+    expect(getChildPropMappingForComponentName(componentNameToTypeMap, 'MyFlex')).toBeUndefined();
+  });
+});

--- a/packages/codegen-ui-react/lib/workflow/utils.ts
+++ b/packages/codegen-ui-react/lib/workflow/utils.ts
@@ -1,0 +1,31 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { InvalidInputError } from '@aws-amplify/codegen-ui';
+import Primitive, { PrimitiveChildrenPropMapping } from '../primitive';
+
+export const getChildPropMappingForComponentName = (
+  componentNameToTypeMap: Record<string, string>,
+  componentName: string,
+): string | undefined => {
+  const referencedComponentType = componentNameToTypeMap[componentName];
+  if (!referencedComponentType) {
+    throw new InvalidInputError(
+      `Invalid definition, found reference to component name ${componentName} which wasn't found in the schema.`,
+    );
+  }
+  return PrimitiveChildrenPropMapping[Primitive[referencedComponentType as Primitive]];
+};

--- a/packages/codegen-ui/example-schemas/workflow/buttonsToggleState.json
+++ b/packages/codegen-ui/example-schemas/workflow/buttonsToggleState.json
@@ -1,0 +1,64 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Flex",
+  "name": "ButtonsToggleState",
+  "properties": {},
+  "children": [
+    {
+      "componentType": "Text",
+      "name": "FooBarValue",
+      "properties": {
+        "label": {
+          "value": "Baz"
+        }
+      }
+    },
+    {
+      "componentType": "Button",
+      "name": "FooButton",
+      "properties": {
+        "label": {
+          "value": "Set to Foo"
+        }
+      },
+      "events": {
+        "click": {
+          "action": "Amplify.Mutation",
+          "parameters": {
+            "state": {
+              "componentName": "FooBarValue",
+              "property": "children",
+              "set": {
+                "value": "Foo"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "componentType": "Button",
+      "name": "BarButton",
+      "properties": {
+        "label": {
+          "value": "Set to Bar"
+        }
+      },
+      "events": {
+        "click": {
+          "action": "Amplify.Mutation",
+          "parameters": {
+            "state": {
+              "componentName": "FooBarValue",
+              "property": "children",
+              "set": {
+                "value": "Bar"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+  

--- a/packages/codegen-ui/example-schemas/workflow/mutationWithSyntheticProp.json
+++ b/packages/codegen-ui/example-schemas/workflow/mutationWithSyntheticProp.json
@@ -1,0 +1,41 @@
+{
+    "id": "1234-5678-9010",
+    "componentType": "Flex",
+    "name": "MutationWithSyntheticProp",
+    "properties": {},
+    "children": [
+      {
+        "componentType": "Text",
+        "name": "FooBarValue",
+        "properties": {
+          "label": {
+            "value": "Baz"
+          }
+        }
+      },
+      {
+        "componentType": "Button",
+        "name": "FooButton",
+        "properties": {
+          "label": {
+            "value": "Set to Foo"
+          }
+        },
+        "events": {
+          "click": {
+            "action": "Amplify.Mutation",
+            "parameters": {
+              "state": {
+                "componentName": "FooBarValue",
+                "property": "label",
+                "set": {
+                  "value": "Foo"
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+    

--- a/packages/codegen-ui/index.ts
+++ b/packages/codegen-ui/index.ts
@@ -31,3 +31,4 @@ export * from './lib/required-dependency-provider';
 
 export * from './lib/types';
 export * from './lib/errors';
+export * from './lib/utils';

--- a/packages/codegen-ui/lib/__tests__/utils/component-mapping-utils.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/component-mapping-utils.test.ts
@@ -1,0 +1,76 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { StudioComponent } from '../../types';
+import { buildComponentNameToTypeMap } from '../../utils';
+
+describe('buildComponentNameToTypeMap', () => {
+  test('builds for a single component', () => {
+    const component: StudioComponent = {
+      componentType: 'Flex',
+      name: 'SingleFlexComponent',
+      properties: {},
+      bindingProperties: {},
+    };
+    const expectedNameToTypeMapping = {
+      SingleFlexComponent: 'Flex',
+    };
+    expect(buildComponentNameToTypeMap(component)).toEqual(expectedNameToTypeMapping);
+  });
+
+  test('builds for a single component with no name', () => {
+    const component: StudioComponent = {
+      componentType: 'Flex',
+      properties: {},
+      bindingProperties: {},
+    };
+    expect(buildComponentNameToTypeMap(component)).toEqual({});
+  });
+
+  test('builds deeply nested objects', () => {
+    const component: StudioComponent = {
+      componentType: 'Flex',
+      name: 'TopLevelComponent',
+      properties: {},
+      bindingProperties: {},
+      children: [
+        {
+          componentType: 'Flex',
+          name: 'NestedComponent',
+          properties: {},
+          children: [
+            {
+              componentType: 'Button',
+              name: 'NestedButton',
+              properties: {},
+            },
+          ],
+        },
+        {
+          componentType: 'Button',
+          name: 'MyButton',
+          properties: {},
+        },
+      ],
+    };
+    const expectedNameToTypeMapping = {
+      TopLevelComponent: 'Flex',
+      NestedComponent: 'Flex',
+      MyButton: 'Button',
+      NestedButton: 'Button',
+    };
+    expect(buildComponentNameToTypeMap(component)).toEqual(expectedNameToTypeMapping);
+  });
+});

--- a/packages/codegen-ui/lib/utils/component-mapping-utils.ts
+++ b/packages/codegen-ui/lib/utils/component-mapping-utils.ts
@@ -1,0 +1,40 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { StudioComponent, StudioComponentChild } from '../types';
+
+/**
+ * Helper to recurse through the component tree and build the name to type mapping.
+ */
+export const buildComponentNameToTypeMap = (
+  component: StudioComponent | StudioComponentChild,
+): Record<string, string> => {
+  const localMap: Record<string, string> = {};
+  if (component.name) {
+    localMap[component.name] = component.componentType;
+  }
+  if (component.children) {
+    Object.entries(
+      component.children
+        .map((child) => buildComponentNameToTypeMap(child))
+        .reduce((previous, next) => {
+          return { ...previous, ...next };
+        }, {}),
+    ).forEach(([name, componentType]) => {
+      localMap[name] = componentType;
+    });
+  }
+  return localMap;
+};

--- a/packages/codegen-ui/lib/utils/index.ts
+++ b/packages/codegen-ui/lib/utils/index.ts
@@ -1,0 +1,16 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+export * from './component-mapping-utils';


### PR DESCRIPTION
…same property

*Issue #, if available:*
N/A

*Description of changes:*
Fixing two bugs in mutations:
* Mutations on synthetic props get reassigned appropriately.
* Duplicate mutations targeting the same prop get deduped so we don't redeclare useStateMutation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
