### PR TITLE
chore: add running datastore tests using current stubs from ui

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress/integration/workflow-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/workflow-spec.ts
@@ -166,7 +166,7 @@ describe('Workflow', () => {
       });
     });
 
-    describe.skip('DataStore', () => {
+    describe('DataStore', () => {
       it('supports creating a datastore item', () => {
         cy.get('#user-collection').contains('Din Djarin').should('not.exist');
         cy.get('#create-item').click();
@@ -195,11 +195,11 @@ describe('Workflow', () => {
         cy.get('#color-changing-box').should('have.css', 'background-color', 'rgb(0, 0, 255)');
       });
 
-      it.skip('supports controlled components for a form', () => {
-        cy.get('#user-collection').contains('viszla123').should('not.exist');
+      it('supports controlled components for a form', () => {
+        cy.get('#user-collection').contains('vizsla123').should('not.exist');
         cy.get('#username-entry').type('123');
         cy.get('#submit-user-form').click();
-        cy.get('#user-collection').contains('viszla123');
+        cy.get('#user-collection').contains('vizsla123');
       });
 
       it('supports synthetic props', () => {

--- a/packages/test-generator/integration-test-templates/src/WorkflowTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/WorkflowTests.tsx
@@ -56,10 +56,12 @@ export default function ComplexTests() {
   const [idToUpdate, setIdToUpdate] = useState('');
   const [hasDisappeared, setDisappeared] = useState(false);
   const [authState, setAuthState] = useState<AuthState>('LoggedIn');
+  const [formIdToUpdate, setFormIdToUpdate] = useState('');
 
   const initializeUserTestData = async (): Promise<void> => {
     await DataStore.save(new User({ firstName: 'DeleteMe', lastName: 'Me' }));
     await DataStore.save(new User({ firstName: 'UpdateMe', lastName: 'Me' }));
+    await DataStore.save(new User({ firstName: 'FormUpdate', lastName: 'Me' }));
   };
 
   const initializeAuthListener = () => {
@@ -89,6 +91,10 @@ export default function ComplexTests() {
       setIdToDelete(queriedIdToDelete);
       const queriedIdToUpdate = (await DataStore.query(User, (criteria) => criteria.firstName('eq', 'UpdateMe')))[0].id;
       setIdToUpdate(queriedIdToUpdate);
+      const queriedFormIdToUpdate = (
+        await DataStore.query(User, (criteria) => criteria.firstName('eq', 'FormUpdate'))
+      )[0].id;
+      setFormIdToUpdate(queriedFormIdToUpdate);
       initializeAuthListener();
       setInitialized(true);
     };
@@ -201,7 +207,7 @@ export default function ComplexTests() {
       <Divider />
       <View id="state">
         <Heading>State Actions</Heading>
-        <FormWithState />
+        <FormWithState idToUpdate={formIdToUpdate} />
       </View>
       <Divider />
       <View id="mutation">

--- a/packages/test-generator/integration-test-templates/src/mock-helpers.js
+++ b/packages/test-generator/integration-test-templates/src/mock-helpers.js
@@ -13,14 +13,30 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-/* eslint-disable no-undef */
-
 import { useState } from 'react';
-
-const mockedAction = () => () => {};
-
-export const useDataStoreCreateAction = mockedAction;
-export const useDataStoreUpdateAction = mockedAction;
-export const useDataStoreDeleteAction = mockedAction;
+import { DataStore } from '@aws-amplify/datastore';
 
 export const useStateMutationAction = useState;
+
+export const useDataStoreCreateAction =
+  ({ model: Model, fields }) =>
+  async () => {
+    await DataStore.save(new Model(fields));
+  };
+
+export const useDataStoreDeleteAction =
+  ({ model: Model, id }) =>
+  async () => {
+    await DataStore.delete(Model, id);
+  };
+
+export const useDataStoreUpdateAction =
+  ({ model: Model, id, fields }) =>
+  async () => {
+    const original = await DataStore.query(Model, id);
+    await DataStore.save(
+      Model.copyOf(original, (updated) => {
+        Object.assign(updated, fields);
+      }),
+    );
+  };

--- a/packages/test-generator/lib/components/workflow/formWithState.json
+++ b/packages/test-generator/lib/components/workflow/formWithState.json
@@ -2,6 +2,11 @@
   "id": "1234-5678-9010",
   "componentType": "Flex",
   "name": "FormWithState",
+  "bindingProperties": {
+    "idToUpdate": {
+      "type": "String"
+    }
+  },
   "properties": {},
   "children": [
     {
@@ -28,7 +33,9 @@
           "parameters": {
             "model": "User",
             "id": {
-              "value": "d9887268-47dd-4899-9568-db5809218751"
+              "bindingProperties": {
+                "property": "idToUpdate"
+              }
             },
             "fields": {
               "firstName": {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Now that we have a mock to use for testing, enabling the datastore related action tests. Outstanding action is to remove the stubs and flip back to ui once released.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
