### PR TITLE
fix: add override for stepper and slider controlled change events

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -5314,6 +5314,57 @@ export default function TwoWayBindings(
 }
 `;
 
+exports[`amplify render tests mutations supports a controlled stepper primitive 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Flex, FlexProps, StepperField, Text } from \\"@aws-amplify/ui-react\\";
+import { useStateMutationAction } from \\"../mock-helpers\\";
+
+export type StepperControlledElementProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function StepperControlledElement(
+  props: StepperControlledElementProps
+): React.ReactElement {
+  const { overrides, ...rest } = props;
+  const [inputValue, setInputValue] = useStateMutationAction(undefined);
+  return (
+    /* @ts-ignore: TS2322 */
+    <Flex
+      {...rest}
+      {...getOverrideProps(overrides, \\"StepperControlledElement\\")}
+    >
+      <StepperField
+        label=\\"Stepper\\"
+        defaultValue={0}
+        min={0}
+        max={10}
+        step={1}
+        labelHidden={true}
+        value={inputValue}
+        onStepChange={(value: number) => setInputValue(value)}
+        {...getOverrideProps(overrides, \\"Input\\")}
+      ></StepperField>
+      <Text
+        children={inputValue}
+        {...getOverrideProps(overrides, \\"StepperFieldValue\\")}
+      ></Text>
+    </Flex>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
 exports[`amplify render tests mutations supports multiple actions pointing to the same value 1`] = `
 Object {
   "componentText": "/* eslint-disable */
@@ -5875,9 +5926,7 @@ export default function TwoWayBindings(
           step={1}
           labelHidden={true}
           value={sliderFieldInputValue}
-          onChange={(event: SyntheticEvent) => {
-            setSliderFieldInputValue(event.target.value);
-          }}
+          onChange={(value: number) => setSliderFieldInputValue(value)}
           {...getOverrideProps(overrides, \\"SliderFieldInput\\")}
         ></SliderField>
         <Text
@@ -5909,9 +5958,7 @@ export default function TwoWayBindings(
           step={1}
           labelHidden={true}
           value={stepperFieldInputValue}
-          onChange={(event: SyntheticEvent) => {
-            setStepperFieldInputValue(event.target.value);
-          }}
+          onStepChange={(value: number) => setStepperFieldInputValue(value)}
           {...getOverrideProps(overrides, \\"StepperFieldInput\\")}
         ></StepperField>
         <Text

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -358,6 +358,10 @@ describe('amplify render tests', () => {
       expect(generateWithAmplifyRenderer('workflow/twoWayBindings')).toMatchSnapshot();
     });
 
+    it('supports a controlled stepper primitive', () => {
+      expect(generateWithAmplifyRenderer('workflow/stepperControlledElement')).toMatchSnapshot();
+    });
+
     it('modifies text in component on input change', () => {
       expect(generateWithAmplifyRenderer('workflow/inputToTextChange')).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/primitive.ts
+++ b/packages/codegen-ui-react/lib/primitive.ts
@@ -16,6 +16,10 @@
 import { factory, SyntaxKind, TypeParameterDeclaration, TypeNode } from 'typescript';
 import iconset from './iconset';
 
+export type PrimitiveLevelPropConfiguration<ConfigType> = {
+  [componentType: string]: { [eventType: string]: ConfigType };
+};
+
 enum Primitive {
   Alert = 'Alert',
   Badge = 'Badge',

--- a/packages/codegen-ui-react/lib/react-component-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-renderer.ts
@@ -87,13 +87,14 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
       });
 
     const eventAttributes = Object.entries(this.component.events || {}).map(([key, value]) =>
-      buildOpeningElementEvents(value, key, this.component.name),
+      buildOpeningElementEvents(this.component.componentType, value, key, this.component.name),
     );
 
     const controlEventAttributes = Object.entries(localStateReferences)
       .filter(([, references]) => references.some(({ addControlEvent }) => addControlEvent))
       .map(([key]) =>
         buildOpeningElementControlEvents(
+          this.component.componentType,
           getSetStateName({ componentName: this.component.name || '', property: key }),
           'change',
         ),

--- a/packages/codegen-ui-react/lib/react-component-with-children-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-with-children-renderer.ts
@@ -85,7 +85,7 @@ export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithCh
       });
 
     const eventAttributes = Object.entries(this.component.events || {}).map(([key, value]) =>
-      buildOpeningElementEvents(value, key, this.component.name),
+      buildOpeningElementEvents(this.component.componentType, value, key, this.component.name),
     );
 
     // TODO: Should we always control form elements?
@@ -93,6 +93,7 @@ export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithCh
       .filter(([, references]) => references.some(({ addControlEvent }) => addControlEvent))
       .map(([key]) =>
         buildOpeningElementControlEvents(
+          this.component.componentType,
           getSetStateName({ componentName: this.component.name || '', property: key }),
           'change',
         ),

--- a/packages/codegen-ui-react/lib/workflow/mutation.ts
+++ b/packages/codegen-ui-react/lib/workflow/mutation.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import ts, { Statement, factory, JsxAttribute } from 'typescript';
+import ts, { Statement, factory, JsxAttribute, JsxExpression } from 'typescript';
 import {
   StudioComponent,
   StudioComponentChild,
@@ -34,6 +34,14 @@ import {
 import { ImportCollection, ImportValue } from '../imports';
 import { mapGenericEventToReact } from './events';
 import { getChildPropMappingForComponentName } from './utils';
+import Primitive, { PrimitiveLevelPropConfiguration } from '../primitive';
+
+type EventHandlerBuilder = (stateName: string) => JsxExpression;
+
+const genericEventToReactEventImplementationOverrides: PrimitiveLevelPropConfiguration<EventHandlerBuilder> = {
+  [Primitive.StepperField]: { [StudioGenericEvent.change]: numericValueCallbackGenerator },
+  [Primitive.SliderField]: { [StudioGenericEvent.change]: numericValueCallbackGenerator },
+};
 
 export function getComponentStateReferences(component: StudioComponent) {
   const stateReferences = getComponentStateReferencesHelper(component);
@@ -99,45 +107,83 @@ export function getActionStateParameters(action: ActionStudioComponentEvent): St
   return [];
 }
 
-export function buildOpeningElementControlEvents(stateName: string, event: string): JsxAttribute {
-  return factory.createJsxAttribute(
-    factory.createIdentifier(mapGenericEventToReact(event as StudioGenericEvent)),
-    factory.createJsxExpression(
+function syntheticEventTargetValueCallbackGenerator(stateName: string): JsxExpression {
+  return factory.createJsxExpression(
+    undefined,
+    factory.createArrowFunction(
       undefined,
-      factory.createArrowFunction(
-        undefined,
-        undefined,
+      undefined,
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          undefined,
+          factory.createIdentifier('event'),
+          undefined,
+          factory.createTypeReferenceNode(factory.createIdentifier('SyntheticEvent'), undefined),
+          undefined,
+        ),
+      ],
+      undefined,
+      factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+      factory.createBlock(
         [
-          factory.createParameterDeclaration(
-            undefined,
-            undefined,
-            undefined,
-            factory.createIdentifier('event'),
-            undefined,
-            factory.createTypeReferenceNode(factory.createIdentifier('SyntheticEvent'), undefined),
-            undefined,
+          factory.createExpressionStatement(
+            factory.createCallExpression(factory.createIdentifier(stateName), undefined, [
+              factory.createPropertyAccessExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('event'),
+                  factory.createIdentifier('target'),
+                ),
+                factory.createIdentifier('value'),
+              ),
+            ]),
           ),
         ],
-        undefined,
-        factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-        factory.createBlock(
-          [
-            factory.createExpressionStatement(
-              factory.createCallExpression(factory.createIdentifier(stateName), undefined, [
-                factory.createPropertyAccessExpression(
-                  factory.createPropertyAccessExpression(
-                    factory.createIdentifier('event'),
-                    factory.createIdentifier('target'),
-                  ),
-                  factory.createIdentifier('value'),
-                ),
-              ]),
-            ),
-          ],
-          false,
-        ),
+        false,
       ),
     ),
+  );
+}
+
+function numericValueCallbackGenerator(stateName: string): JsxExpression {
+  return factory.createJsxExpression(
+    undefined,
+    factory.createArrowFunction(
+      undefined,
+      undefined,
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          undefined,
+          factory.createIdentifier('value'),
+          undefined,
+          factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+          undefined,
+        ),
+      ],
+      undefined,
+      factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+      factory.createCallExpression(factory.createIdentifier(stateName), undefined, [factory.createIdentifier('value')]),
+    ),
+  );
+}
+
+// TODO: Update in here so we can support customer `change` events for form elements.
+export function buildOpeningElementControlEvents(
+  componentType: string,
+  stateName: string,
+  event: string,
+): JsxAttribute {
+  const implementationOverrides = genericEventToReactEventImplementationOverrides[componentType];
+  const controlEventBuilder =
+    implementationOverrides && implementationOverrides[event]
+      ? implementationOverrides[event]
+      : syntheticEventTargetValueCallbackGenerator;
+  return factory.createJsxAttribute(
+    factory.createIdentifier(mapGenericEventToReact(componentType as Primitive, event as StudioGenericEvent)),
+    controlEventBuilder(stateName),
   );
 }
 

--- a/packages/codegen-ui/example-schemas/workflow/stepperControlledElement.json
+++ b/packages/codegen-ui/example-schemas/workflow/stepperControlledElement.json
@@ -1,0 +1,43 @@
+{
+    "id": "1234-5678-9010",
+    "componentType": "Flex",
+    "name": "StepperControlledElement",
+    "properties": {},
+    "children": [
+      {
+        "componentType": "StepperField",
+        "name": "Input",
+        "properties": {
+          "label": {
+            "value": "Stepper"
+          },
+          "defaultValue": {
+            "value": 0
+          },
+          "min": {
+            "value": 0
+          },
+          "max": {
+            "value": 10
+          },
+          "step": {
+            "value": 1
+          },
+          "labelHidden": {
+            "value": true
+          }
+        }
+      },
+      {
+        "componentType": "Text",
+        "name": "StepperFieldValue",
+        "properties": {
+          "label": {
+            "componentName": "Input",
+            "property": "value"
+          }
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Stepper primitive takes an onStepChange callback, rather than onChange, and issues a raw number rather than a full SyntheticEvent, adding support for synthetic event names, as well as implementations which are based on the primitive type.

Also updated the SliderField to use the numeric callback, though w/ the name onChange per UI docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
