### PR TITLE
feat: add default initial value for form component state

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -5223,7 +5223,7 @@ export default function InputMutationOnClick(
   props: InputMutationOnClickProps
 ): React.ReactElement {
   const { overrides, ...rest } = props;
-  const [myInputValue, setMyInputValue] = useStateMutationAction(undefined);
+  const [myInputValue, setMyInputValue] = useStateMutationAction(\\"\\");
   const setInputButtonClick = () => {
     setMyInputValue(\\"Razor Crest\\");
   };
@@ -5376,7 +5376,7 @@ export default function TwoWayBindings(
 ): React.ReactElement {
   const { overrides, ...rest } = props;
   const [textFieldInputValue, setTextFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(\\"\\");
   return (
     /* @ts-ignore: TS2322 */
     <Flex
@@ -5426,7 +5426,7 @@ export default function CheckboxControlledElement(
   props: CheckboxControlledElementProps
 ): React.ReactElement {
   const { overrides, ...rest } = props;
-  const [inputChecked, setInputChecked] = useStateMutationAction(undefined);
+  const [inputChecked, setInputChecked] = useStateMutationAction(false);
   return (
     /* @ts-ignore: TS2322 */
     <Flex
@@ -5524,7 +5524,7 @@ export default function SwitchControlledElement(
   props: SwitchControlledElementProps
 ): React.ReactElement {
   const { overrides, ...rest } = props;
-  const [inputIsChecked, setInputIsChecked] = useStateMutationAction(undefined);
+  const [inputIsChecked, setInputIsChecked] = useStateMutationAction(false);
   return (
     /* @ts-ignore: TS2322 */
     <Flex {...rest} {...getOverrideProps(overrides, \\"SwitchControlledElement\\")}>
@@ -5815,15 +5815,15 @@ export default function TwoWayBindings(
 ): React.ReactElement {
   const { overrides, ...rest } = props;
   const [checkboxFieldInputChecked, setCheckboxFieldInputChecked] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(false);
   const [passwordFieldInputValue, setPasswordFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(\\"\\");
   const [phoneNumberFieldInputValue, setPhoneNumberFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(\\"\\");
   const [radioGroupFieldInputValue, setRadioGroupFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(\\"html\\");
   const [searchFieldInputValue, setSearchFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(\\"\\");
   const [selectFieldInputValue, setSelectFieldInputValue] =
     useStateMutationAction(undefined);
   const [sliderFieldInputValue, setSliderFieldInputValue] =
@@ -5831,9 +5831,9 @@ export default function TwoWayBindings(
   const [stepperFieldInputValue, setStepperFieldInputValue] =
     useStateMutationAction(undefined);
   const [switchFieldInputIsChecked, setSwitchFieldInputIsChecked] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(false);
   const [textFieldInputValue, setTextFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(\\"\\");
   const setCheckboxFieldValueClick = () => {
     setCheckboxFieldInputChecked(false);
   };

--- a/packages/codegen-ui-react/lib/primitive.ts
+++ b/packages/codegen-ui-react/lib/primitive.ts
@@ -130,9 +130,7 @@ export const PrimitivesWithChangeEvent: Set<Primitive> = new Set([
   Primitive.TextField,
 ]);
 
-export const PrimitiveDefaultPropertyValue: Partial<
-  Record<Primitive, { [property: string]: FixedStudioComponentProperty }>
-> = {
+export const PrimitiveDefaultPropertyValue: PrimitiveLevelPropConfiguration<FixedStudioComponentProperty> = {
   [Primitive.CheckboxField]: {
     checked: { value: false, type: 'boolean' },
   },

--- a/packages/codegen-ui-react/lib/primitive.ts
+++ b/packages/codegen-ui-react/lib/primitive.ts
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+import { FixedStudioComponentProperty } from '@aws-amplify/codegen-ui';
 import { factory, SyntaxKind, TypeParameterDeclaration, TypeNode } from 'typescript';
 import iconset from './iconset';
 
@@ -128,3 +129,29 @@ export const PrimitivesWithChangeEvent: Set<Primitive> = new Set([
   Primitive.SwitchField,
   Primitive.TextField,
 ]);
+
+export const PrimitiveDefaultPropertyValue: Partial<
+  Record<Primitive, { [property: string]: FixedStudioComponentProperty }>
+> = {
+  [Primitive.CheckboxField]: {
+    checked: { value: false, type: 'boolean' },
+  },
+  [Primitive.PasswordField]: {
+    value: { value: '', type: 'string' },
+  },
+  [Primitive.PhoneNumberField]: {
+    value: { value: '', type: 'string' },
+  },
+  [Primitive.RadioGroupField]: {
+    value: { value: '', type: 'string' },
+  },
+  [Primitive.SearchField]: {
+    value: { value: '', type: 'string' },
+  },
+  [Primitive.SwitchField]: {
+    isChecked: { value: false, type: 'boolean' },
+  },
+  [Primitive.TextField]: {
+    value: { value: '', type: 'string' },
+  },
+};


### PR DESCRIPTION
*Description of changes:*

Set default initial state value for form components. 

List was determined by interacting with TwoWayBinding tests on integration app and adding default initial values for components that gave a warning.

Todo in another change:
If a `defaultValue` is set by the customer and the component becomes controlled the defaultValue needs to be removed because the form components cannot have both `defaultValue` and `value`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
