### PR TITLE
feat: adding method to compute component metadata

### DIFF
--- a/packages/codegen-ui/lib/__tests__/utils/component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/component-metadata.test.ts
@@ -1,0 +1,746 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { StudioComponent } from '../../types';
+import { ComponentMetadata, computeComponentMetadata } from '../../utils';
+
+describe('computeComponentMetadata', () => {
+  describe('builds hasAuthBindings', () => {
+    test('returns false for no binding', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    test('builds for top-level auth binding', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {
+          label: {
+            userAttribute: 'email',
+          },
+        },
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: true,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    test('builds for nested auth binding', () => {
+      const component: StudioComponent = {
+        componentType: 'Flex',
+        name: 'Comp',
+        properties: {
+          label: {
+            userAttribute: 'email',
+          },
+        },
+        bindingProperties: {},
+        children: [
+          {
+            componentType: 'Text',
+            name: 'BoundText',
+            properties: {
+              label: {
+                concat: [
+                  {
+                    userAttribute: 'email',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: true,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {
+          BoundText: 'Text',
+          Comp: 'Flex',
+        },
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    test('builds for auth binding in action', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {
+                email: {
+                  userAttribute: 'email',
+                },
+              },
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: true,
+        requiredDataModels: ['User'],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    test('builds for nested auth binding in action', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {
+                title: {
+                  concat: [
+                    {
+                      value: 'The Honorable - ',
+                    },
+                    {
+                      userAttribute: 'firstName',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: true,
+        requiredDataModels: ['User'],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+  });
+
+  describe('builds requiredDataModels', () => {
+    it('returns no required data models if there are no state references', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns models in events', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {},
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns models in binding properties', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {
+          user: {
+            type: 'Data',
+            bindingProperties: {
+              model: 'User',
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns models in collection properties', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+        collectionProperties: {
+          user: {
+            model: 'User',
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns multiple different models', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {
+          user: {
+            type: 'Data',
+            bindingProperties: {
+              model: 'User',
+            },
+          },
+        },
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'Listing',
+              fields: {},
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User', 'Listing'],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('dedupes models', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {
+          user: {
+            type: 'Data',
+            bindingProperties: {
+              model: 'User',
+            },
+          },
+        },
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {},
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+  });
+
+  describe('builds stateReferences', () => {
+    it('returns for no state binding', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns for state binding in prop', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {
+          label: {
+            componentName: 'UserNameField',
+            property: 'value',
+          },
+        },
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns for nested state binding in prop', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {
+          label: {
+            concat: [
+              {
+                componentName: 'UserNameField',
+                property: 'value',
+              },
+            ],
+          },
+        },
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns for state binding in event', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {
+                title: {
+                  componentName: 'UserNameField',
+                  property: 'value',
+                },
+              },
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns for nested state binding in event', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {
+                title: {
+                  concat: [
+                    {
+                      value: 'The Honorable - ',
+                    },
+                    {
+                      componentName: 'UserNameField',
+                      property: 'value',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('returns multiple state bindings', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {
+          label: {
+            componentName: 'NicknameField',
+            property: 'value',
+          },
+        },
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {
+                title: {
+                  concat: [
+                    {
+                      value: 'The Honorable - ',
+                    },
+                    {
+                      componentName: 'UserNameField',
+                      property: 'value',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [
+          { componentName: 'NicknameField', property: 'value' },
+          { componentName: 'UserNameField', property: 'value' },
+        ],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('dedupes state bindings', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {
+          label: {
+            componentName: 'UserNameField',
+            property: 'value',
+          },
+        },
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {
+                title: {
+                  concat: [
+                    {
+                      value: 'The Honorable - ',
+                    },
+                    {
+                      componentName: 'UserNameField',
+                      property: 'value',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    it('mutation events with set dedupe against bindings', () => {
+      const component: StudioComponent = {
+        componentType: 'Text',
+        properties: {},
+        bindingProperties: {},
+        events: {
+          click: {
+            action: 'Amplify.DataStoreCreateItemAction',
+            parameters: {
+              model: 'User',
+              fields: {
+                title: {
+                  componentName: 'UserNameField',
+                  property: 'value',
+                },
+              },
+            },
+          },
+          doubleclick: {
+            action: 'Amplify.Mutation',
+            parameters: {
+              state: {
+                componentName: 'UserNameField',
+                property: 'value',
+                set: {
+                  value: 'Setter',
+                },
+              },
+            },
+          },
+        },
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: ['User'],
+        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+  });
+
+  describe('builds componentNameToTypeMap', () => {
+    test('builds for a single component', () => {
+      const component: StudioComponent = {
+        componentType: 'Flex',
+        name: 'SingleFlexComponent',
+        properties: {},
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {
+          SingleFlexComponent: 'Flex',
+        },
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    test('builds for a single component with no name', () => {
+      const component: StudioComponent = {
+        componentType: 'Flex',
+        properties: {},
+        bindingProperties: {},
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {},
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+
+    test('builds deeply nested objects', () => {
+      const component: StudioComponent = {
+        componentType: 'Flex',
+        name: 'TopLevelComponent',
+        properties: {},
+        bindingProperties: {},
+        children: [
+          {
+            componentType: 'Flex',
+            name: 'NestedComponent',
+            properties: {},
+            children: [
+              {
+                componentType: 'Button',
+                name: 'NestedButton',
+                properties: {},
+              },
+            ],
+          },
+          {
+            componentType: 'Button',
+            name: 'MyButton',
+            properties: {},
+          },
+        ],
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: false,
+        requiredDataModels: [],
+        stateReferences: [],
+        componentNameToTypeMap: {
+          TopLevelComponent: 'Flex',
+          NestedComponent: 'Flex',
+          MyButton: 'Button',
+          NestedButton: 'Button',
+        },
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+  });
+
+  describe('builds for complex cases', () => {
+    it('works for this mess', () => {
+      const component: StudioComponent = {
+        componentType: 'Flex',
+        name: 'TopLevelComponent',
+        properties: {},
+        bindingProperties: {
+          color: {
+            type: 'String',
+          },
+        },
+        collectionProperties: {
+          user: {
+            model: 'User',
+          },
+        },
+        children: [
+          {
+            componentType: 'Flex',
+            name: 'NestedComponent',
+            properties: {},
+            children: [
+              {
+                componentType: 'Button',
+                name: 'NestedButton',
+                properties: {},
+                events: {
+                  click: {
+                    action: 'Amplify.Mutation',
+                    parameters: {
+                      state: {
+                        componentName: 'NestedComponent',
+                        property: 'color',
+                        set: {
+                          bindingProperties: {
+                            property: 'color',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          {
+            componentType: 'TextField',
+            name: 'NicknameField',
+            properties: {
+              label: {
+                value: 'Enter your nickname',
+              },
+            },
+          },
+          {
+            componentType: 'Button',
+            name: 'MyButton',
+            properties: {
+              label: {
+                concat: [
+                  {
+                    value: 'Click Me - ',
+                  },
+                  {
+                    userAttribute: 'firstName',
+                  },
+                ],
+              },
+            },
+            events: {
+              click: {
+                action: 'Amplify.DataStoreCreateItemAction',
+                parameters: {
+                  model: 'Listing',
+                  fields: {
+                    name: {
+                      userAttribute: 'firstName',
+                    },
+                    preferredName: {
+                      condition: {
+                        property: 'color',
+                        operator: 'eq',
+                        operand: 'blue',
+                        then: {
+                          value: 'Nice Color',
+                        },
+                        else: {
+                          componentName: 'NicknameField',
+                          property: 'value',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+      const expectedMetadata: ComponentMetadata = {
+        hasAuthBindings: true,
+        requiredDataModels: ['User', 'Listing'],
+        stateReferences: [
+          { componentName: 'NestedComponent', property: 'color' },
+          { componentName: 'NicknameField', property: 'value' },
+        ],
+        componentNameToTypeMap: {
+          TopLevelComponent: 'Flex',
+          NestedComponent: 'Flex',
+          MyButton: 'Button',
+          NestedButton: 'Button',
+          NicknameField: 'TextField',
+        },
+      };
+      expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
+    });
+  });
+});

--- a/packages/codegen-ui/lib/utils/component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/component-metadata.ts
@@ -1,0 +1,243 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import {
+  StudioComponent,
+  StudioComponentChild,
+  StudioComponentDataConfiguration,
+  StudioComponentEvent,
+  StudioComponentProperty,
+  StudioComponentPropertyBinding,
+  StateStudioComponentProperty,
+} from '../types';
+
+type StateReference = StateStudioComponentProperty;
+
+export type ComponentMetadata = {
+  hasAuthBindings: boolean;
+  requiredDataModels: string[];
+  stateReferences: StateReference[];
+  componentNameToTypeMap: Record<string, string>;
+};
+
+/**
+ * Component Structure Functions
+ */
+
+// Check top-level binding properties, then call helper on the chilren.
+export function computeComponentMetadata(component: StudioComponent): ComponentMetadata {
+  const { bindingProperties, collectionProperties } = component;
+  return dedupeComponentMetadata(
+    reduceComponentMetadata([
+      ...Object.values(bindingProperties).map(computeBindingPropertyMetadata),
+      ...(collectionProperties ? Object.values(collectionProperties).map(computeCollectionPropertyMetadata) : []),
+      computeComponentMetadataHelper(component),
+    ]),
+  );
+}
+
+// Check names, properties, events, and recurse through children.
+function computeComponentMetadataHelper(component: StudioComponent | StudioComponentChild): ComponentMetadata {
+  return reduceComponentMetadata([
+    generateNameMappingMetadata(component.name, component.componentType),
+    ...Object.values(component.properties).map(computePropertyMetadata),
+    ...(component.events ? Object.values(component.events).map(computeEventMetadata) : []),
+    ...(component.children ? component.children.map(computeComponentMetadataHelper) : []),
+  ]);
+}
+
+/**
+ * Utility Functions
+ */
+
+// Because object equality won't catch dupes here, we'll map by component Name, dedupe
+// properties, then unroll to a list.
+function dedupeStateReferences(stateReferences: StateReference[]): StateReference[] {
+  const stateReferenceMap: Record<string, Set<string>> = {};
+  stateReferences.forEach(({ componentName, property }) => {
+    if (!(componentName in stateReferenceMap)) {
+      stateReferenceMap[componentName] = new Set([]);
+    }
+    stateReferenceMap[componentName].add(property);
+  });
+  return Object.entries(stateReferenceMap).flatMap(([componentName, properties]) =>
+    [...properties].map((property) => {
+      return { componentName, property };
+    }),
+  );
+}
+
+function dedupeComponentMetadata(componentMetadata: ComponentMetadata): ComponentMetadata {
+  const { hasAuthBindings, requiredDataModels, stateReferences, componentNameToTypeMap } = componentMetadata;
+  return {
+    hasAuthBindings,
+    requiredDataModels: [...new Set(requiredDataModels)],
+    stateReferences: dedupeStateReferences(stateReferences),
+    componentNameToTypeMap,
+  };
+}
+
+function reduceComponentMetadata(componentMetadata: ComponentMetadata[]): ComponentMetadata {
+  const mergeMetadata = (lhs: ComponentMetadata, rhs: ComponentMetadata) => {
+    return {
+      hasAuthBindings: lhs.hasAuthBindings || rhs.hasAuthBindings,
+      requiredDataModels: [...lhs.requiredDataModels, ...rhs.requiredDataModels],
+      stateReferences: [...lhs.stateReferences, ...rhs.stateReferences],
+      componentNameToTypeMap: { ...lhs.componentNameToTypeMap, ...rhs.componentNameToTypeMap },
+    };
+  };
+  return componentMetadata.reduce(mergeMetadata, generateEmptyMetadata());
+}
+
+function generateEmptyMetadata(): ComponentMetadata {
+  return {
+    hasAuthBindings: false,
+    requiredDataModels: [],
+    stateReferences: [],
+    componentNameToTypeMap: {},
+  };
+}
+
+function generateAuthBindingMetadata(): ComponentMetadata {
+  return {
+    hasAuthBindings: true,
+    requiredDataModels: [],
+    stateReferences: [],
+    componentNameToTypeMap: {},
+  };
+}
+
+function generateModelMetadata(model: string): ComponentMetadata {
+  return {
+    hasAuthBindings: false,
+    requiredDataModels: [model],
+    stateReferences: [],
+    componentNameToTypeMap: {},
+  };
+}
+
+function generateReferenceMetadata(reference: StateReference): ComponentMetadata {
+  // Unpacking the reference, so we don't bring additional values in.
+  const { componentName, property } = reference;
+  return {
+    hasAuthBindings: false,
+    requiredDataModels: [],
+    stateReferences: [{ componentName, property }],
+    componentNameToTypeMap: {},
+  };
+}
+
+function generateNameMappingMetadata(componentName: string | undefined, componentType: string): ComponentMetadata {
+  if (componentName) {
+    return {
+      hasAuthBindings: false,
+      requiredDataModels: [],
+      stateReferences: [],
+      componentNameToTypeMap: { [componentName]: componentType },
+    };
+  }
+  return generateEmptyMetadata();
+}
+
+/**
+ * Binding Property Functions
+ */
+
+function computeCollectionPropertyMetadata(dataConfiguration: StudioComponentDataConfiguration): ComponentMetadata {
+  return generateModelMetadata(dataConfiguration.model);
+}
+
+function computeBindingPropertyMetadata(bindingProperty: StudioComponentPropertyBinding): ComponentMetadata {
+  switch (bindingProperty.type) {
+    case 'Event':
+      return generateEmptyMetadata();
+    case 'Data':
+      return generateModelMetadata(bindingProperty.bindingProperties.model);
+    case 'Storage':
+      return generateEmptyMetadata();
+    default:
+      if ('type' in bindingProperty) {
+        return generateEmptyMetadata();
+      }
+      throw new Error(`Binding Property ${JSON.stringify(bindingProperty)} could not be parsed for Metadata.`);
+  }
+}
+
+/**
+ * Property Functions
+ */
+
+function computePropertyMetadata(property: StudioComponentProperty): ComponentMetadata {
+  return reduceComponentMetadata(
+    ([] as ComponentMetadata[])
+      .concat('concat' in property ? property.concat.map(computePropertyMetadata) : [])
+      .concat('userAttribute' in property ? [generateAuthBindingMetadata()] : [])
+      .concat(
+        'condition' in property && 'then' in property.condition
+          ? [computePropertyMetadata(property.condition.then)]
+          : [],
+      )
+      .concat(
+        'condition' in property && 'else' in property.condition
+          ? [computePropertyMetadata(property.condition.else)]
+          : [],
+      )
+      .concat(
+        'componentName' in property && 'property' in property
+          ? [generateReferenceMetadata(property as StateReference)]
+          : [],
+      ),
+  );
+}
+
+/**
+ * Event Functions
+ */
+
+function computeEventMetadata(event: StudioComponentEvent): ComponentMetadata {
+  if (!('action' in event)) {
+    return generateEmptyMetadata();
+  }
+
+  switch (event.action) {
+    case 'Amplify.Navigation':
+      return reduceComponentMetadata(Object.values(event.parameters).map(computePropertyMetadata));
+    case 'Amplify.AuthSignOut':
+      return reduceComponentMetadata(Object.values(event.parameters).map(computePropertyMetadata));
+    case 'Amplify.DataStoreCreateItemAction':
+      return reduceComponentMetadata([
+        generateModelMetadata(event.parameters.model),
+        ...Object.values(event.parameters.fields).map(computePropertyMetadata),
+      ]);
+    case 'Amplify.DataStoreUpdateItemAction':
+      return reduceComponentMetadata([
+        generateModelMetadata(event.parameters.model),
+        computePropertyMetadata(event.parameters.id),
+        ...Object.values(event.parameters.fields).map(computePropertyMetadata),
+      ]);
+    case 'Amplify.DataStoreDeleteItemAction':
+      return reduceComponentMetadata([
+        generateModelMetadata(event.parameters.model),
+        computePropertyMetadata(event.parameters.id),
+      ]);
+    case 'Amplify.Mutation':
+      return reduceComponentMetadata([
+        generateReferenceMetadata(event.parameters.state),
+        computePropertyMetadata(event.parameters.state.set),
+      ]);
+    default:
+      throw new Error(`Event ${JSON.stringify(event)} could not be parsed for Metadata.`);
+  }
+}

--- a/packages/codegen-ui/lib/utils/index.ts
+++ b/packages/codegen-ui/lib/utils/index.ts
@@ -14,3 +14,4 @@
   limitations under the License.
  */
 export * from './component-mapping-utils';
+export * from './component-metadata';


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Today, we decorate our component tree w/ metadata as we walk it here and there, but have seen bugs where we're missing detection of auth attributes and state references if they're deeply nested. Creating a new utility method which will replace a lot of this logic, and do a comprehensive walk of the component structure, identifying dependent data models, state references, auth attributes, and component name mapping elements so we can use them without recomputing later.

I've separated the logic here form the actual refactor, to keep this PR focused on the functionality described here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
