### PR TITLE
fix: remove defaultValue if value is added to component

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -9,8 +9,8 @@ import {
   getOverrideProps,
   useDataStoreCreateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 import { Customer } from \\"../models\\";
+import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type CreateCustomerButtonProps = React.PropsWithChildren<
   Partial<ButtonProps> & {
@@ -52,8 +52,8 @@ import {
   getOverrideProps,
   useDataStoreDeleteAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 import { Customer } from \\"../models\\";
+import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type DeleteCustomerButtonProps = React.PropsWithChildren<
   Partial<ButtonProps> & {
@@ -95,8 +95,8 @@ import {
   getOverrideProps,
   useDataStoreUpdateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 import { Customer } from \\"../models\\";
+import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type UpdateCustomerButtonProps = React.PropsWithChildren<
   Partial<ButtonProps> & {
@@ -339,7 +339,6 @@ exports[`amplify render tests actions with conditional in parameters 1`] = `
 Object {
   "componentText": "/* eslint-disable */
 import React from \\"react\\";
-import { User } from \\"../models\\";
 import {
   EscapeHatchProps,
   createDataStorePredicate,
@@ -347,6 +346,7 @@ import {
   useDataStoreBinding,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
+import { User } from \\"../models\\";
 import { Button, Flex, FlexProps, Text } from \\"@aws-amplify/ui-react\\";
 
 export type ConditionalInMutationProps = React.PropsWithChildren<
@@ -502,8 +502,8 @@ import {
   useAuth,
   useDataStoreCreateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 import { Customer } from \\"../models\\";
+import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type ComponentWithAuthEventBindingProps = React.PropsWithChildren<
   Partial<ButtonProps> & {
@@ -540,6 +540,12 @@ export default function ComponentWithAuthEventBinding(
 exports[`amplify render tests collection should render collection with data binding 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  createDataStorePredicate,
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
 import { User, UserPreferences } from \\"../models\\";
 import {
   Button,
@@ -547,12 +553,6 @@ import {
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
-import {
-  EscapeHatchProps,
-  createDataStorePredicate,
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -641,13 +641,6 @@ exports[`amplify render tests collection should render collection with data bind
 Object {
   "componentText": "/* eslint-disable */
 import React from \\"react\\";
-import { User, UserPreferences } from \\"../models\\";
-import {
-  Button,
-  Collection,
-  CollectionProps,
-  Flex,
-} from \\"@aws-amplify/ui-react\\";
 import {
   EscapeHatchProps,
   createDataStorePredicate,
@@ -655,6 +648,13 @@ import {
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { SortDirection, SortPredicate } from \\"@aws-amplify/datastore\\";
+import { User, UserPreferences } from \\"../models\\";
+import {
+  Button,
+  Collection,
+  CollectionProps,
+  Flex,
+} from \\"@aws-amplify/ui-react\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -750,6 +750,12 @@ export default function CollectionOfCustomButtons(
 exports[`amplify render tests collection should render collection with data binding if binding name is items 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  createDataStorePredicate,
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
 import { User, UserPreferences } from \\"../models\\";
 import {
   Button,
@@ -757,12 +763,6 @@ import {
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
-import {
-  EscapeHatchProps,
-  createDataStorePredicate,
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -850,14 +850,14 @@ export default function CollectionOfCustomButtons(
 exports[`amplify render tests collection should render collection with data binding with no predicate 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import ListingCard from \\"./ListingCard\\";
+import { UntitledModel } from \\"../models\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
+import ListingCard from \\"./ListingCard\\";
 import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
-import { UntitledModel } from \\"../models\\";
 
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -4845,13 +4845,13 @@ exports[`amplify render tests default value should render collection default val
 Object {
   "componentText": "/* eslint-disable */
 import React from \\"react\\";
-import { Collection, CollectionProps, Text } from \\"@aws-amplify/ui-react\\";
+import { User } from \\"../models\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { User } from \\"../models\\";
+import { Collection, CollectionProps, Text } from \\"@aws-amplify/ui-react\\";
 
 export type CollectionDefaultValueProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -4881,8 +4881,8 @@ export default function CollectionDefaultValue(
     >
       {(item, index) => (
         <Text
-          key={item.id}
           children={item.username || \\"Collection Default Value\\"}
+          key={item.id}
           {...(overrideItems && overrideItems({ item, index }))}
         ></Text>
       )}
@@ -5330,8 +5330,8 @@ import {
   useDataStoreUpdateAction,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Button, Flex, FlexProps, TextField } from \\"@aws-amplify/ui-react\\";
 import { Customer } from \\"../models\\";
+import { Button, Flex, FlexProps, TextField } from \\"@aws-amplify/ui-react\\";
 
 export type MyFormProps = React.PropsWithChildren<
   Partial<FlexProps> & {
@@ -5540,7 +5540,7 @@ export default function StepperControlledElement(
   props: StepperControlledElementProps
 ): React.ReactElement {
   const { overrides, ...rest } = props;
-  const [inputValue, setInputValue] = useStateMutationAction(undefined);
+  const [inputValue, setInputValue] = useStateMutationAction(0);
   return (
     /* @ts-ignore: TS2322 */
     <Flex
@@ -5549,7 +5549,6 @@ export default function StepperControlledElement(
     >
       <StepperField
         label=\\"Stepper\\"
-        defaultValue={0}
         min={0}
         max={10}
         step={1}
@@ -5991,9 +5990,9 @@ export default function TwoWayBindings(
   const [selectFieldInputValue, setSelectFieldInputValue] =
     useStateMutationAction(undefined);
   const [sliderFieldInputValue, setSliderFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(50);
   const [stepperFieldInputValue, setStepperFieldInputValue] =
-    useStateMutationAction(undefined);
+    useStateMutationAction(0);
   const [switchFieldInputIsChecked, setSwitchFieldInputIsChecked] =
     useStateMutationAction(false);
   const [textFieldInputValue, setTextFieldInputValue] =
@@ -6143,7 +6142,6 @@ export default function TwoWayBindings(
         <RadioGroupField
           label=\\"Language\\"
           name=\\"language\\"
-          defaultValue=\\"html\\"
           value={radioGroupFieldInputValue}
           onChange={(event: SyntheticEvent) => {
             setRadioGroupFieldInputValue(event.target.value);
@@ -6265,7 +6263,6 @@ export default function TwoWayBindings(
         ></Heading>
         <SliderField
           label=\\"Slider\\"
-          defaultValue={50}
           min={0}
           max={100}
           step={1}
@@ -6297,7 +6294,6 @@ export default function TwoWayBindings(
         ></Heading>
         <StepperField
           label=\\"Stepper\\"
-          defaultValue={0}
           min={0}
           max={10}
           step={1}

--- a/packages/codegen-ui-react/lib/react-component-with-children-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-with-children-renderer.ts
@@ -33,7 +33,6 @@ import {
   buildOpeningElementEvents,
   filterStateReferencesForComponent,
 } from './workflow';
-import Primitive, { PrimitiveChildrenPropMapping } from './primitive';
 
 export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithChildrenRendererBase<
   TPropIn,
@@ -47,7 +46,6 @@ export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithCh
     protected parent?: StudioNode,
   ) {
     super(component, parent);
-    this.mapSyntheticProps();
     addBindingPropertiesImports(component, importCollection);
   }
 
@@ -193,27 +191,5 @@ export class ReactComponentWithChildrenRenderer<TPropIn> extends ComponentWithCh
     );
 
     attributes.push(attr);
-  }
-
-  /* Some additional props are added to Amplify primitives in Studio. These "sythetic" props are mapped to real props
-   * on the primitives.
-   *
-   * Example: Text prop label is mapped to to Text prop Children
-   *
-   * This is done so that nonadvanced users of Studio do not need to interact with props that might confuse them.
-   */
-  private mapSyntheticProps() {
-    // properties.children will take precedent over mapped children prop
-    if (this.component.properties.children === undefined) {
-      const childrenPropMapping = PrimitiveChildrenPropMapping[Primitive[this.component.componentType as Primitive]];
-
-      if (childrenPropMapping !== undefined) {
-        const mappedChildrenProp = this.component.properties[childrenPropMapping];
-        if (mappedChildrenProp !== undefined) {
-          this.component.properties.children = mappedChildrenProp;
-          delete this.component.properties[childrenPropMapping];
-        }
-      }
-    }
   }
 }

--- a/packages/codegen-ui-react/lib/react-index-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-index-studio-template-renderer.ts
@@ -93,4 +93,7 @@ export class ReactIndexStudioTemplateRenderer extends StudioTemplateRenderer<
         );
       }) as ExportDeclaration[];
   }
+
+  // no-op
+  validateSchema() {}
 }

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -31,6 +31,7 @@ import {
   handleCodegenErrors,
   ComponentMetadata,
   computeComponentMetadata,
+  validateComponentSchema,
 } from '@aws-amplify/codegen-ui';
 import { EOL } from 'os';
 import ts, {
@@ -1176,6 +1177,10 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     }
 
     mapSyntheticPropsForComponent(this.component);
+  }
+
+  validateSchema(component: StudioComponent) {
+    validateComponentSchema(component);
   }
 
   abstract renderJsx(component: StudioComponent): JsxElement | JsxFragment | JsxSelfClosingElement;

--- a/packages/codegen-ui-react/lib/react-theme-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-theme-studio-template-renderer.ts
@@ -60,7 +60,6 @@ export class ReactThemeStudioTemplateRenderer extends StudioTemplateRenderer<
 
   constructor(theme: StudioTheme, renderConfig: ReactRenderConfig) {
     super(theme, new ReactOutputManager(), renderConfig);
-    validateThemeSchema(theme);
     this.renderConfig = {
       ...defaultRenderConfig,
       ...renderConfig,
@@ -193,5 +192,9 @@ export class ReactThemeStudioTemplateRenderer extends StudioTemplateRenderer<
         false,
       ),
     );
+  }
+
+  validateSchema(theme: StudioTheme) {
+    validateThemeSchema(theme);
   }
 }

--- a/packages/codegen-ui/lib/__tests__/__utils__/mock-classes.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/mock-classes.ts
@@ -39,4 +39,6 @@ export class MockTemplateRenderer extends StudioTemplateRenderer<
       renderComponentToFilesystem: jest.fn(),
     };
   }
+
+  validateSchema() {}
 }

--- a/packages/codegen-ui/lib/common-component-renderer.ts
+++ b/packages/codegen-ui/lib/common-component-renderer.ts
@@ -15,7 +15,6 @@
  */
 import { StudioComponent, StudioComponentChild, WrappedComponentProperties } from './types';
 import { StudioNode } from './studio-node';
-import { validateComponentSchema } from './validation-helper';
 
 /**
  * Shared class for rendering components.
@@ -27,10 +26,6 @@ export abstract class CommonComponentRenderer<TPropIn> {
   protected node: StudioNode;
 
   constructor(protected component: StudioComponent | StudioComponentChild, protected parent?: StudioNode) {
-    // Run schema validation on the top-level component.
-    if (this.parent === undefined) {
-      validateComponentSchema(this.component as StudioComponent);
-    }
     const flattenedProps = Object.entries(component.properties).map((prop) => {
       return [prop[0], prop[1]];
     });

--- a/packages/codegen-ui/lib/studio-template-renderer.ts
+++ b/packages/codegen-ui/lib/studio-template-renderer.ts
@@ -33,7 +33,9 @@ export abstract class StudioTemplateRenderer<
     protected component: TStudioType,
     protected outputManager: TOutputManager,
     protected renderConfig: FrameworkRenderConfig,
-  ) {}
+  ) {
+    this.validateSchema(component);
+  }
 
   /**
    * Renders the entire first order component. It returns the
@@ -50,4 +52,6 @@ export abstract class StudioTemplateRenderer<
     return (fileName: string) => (outputPath: string) =>
       this.outputManager.writeComponent(componentContent, path.join(outputPath, fileName));
   }
+
+  protected abstract validateSchema(component: TStudioType): void;
 }


### PR DESCRIPTION
In the case that a component becomes controlled due to state reference, but the customer has added a `defaultValue` prop the `defaultValue` prop should be removed to avoid react warnings.

This change modified the order of some functions so the import order has changed as a result.
