### PR TITLE
chore: backfill e2e tests for auth bindings, add auth mock utils

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress/integration/action-binding-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/action-binding-spec.ts
@@ -44,8 +44,7 @@ describe('Workflow', () => {
       cy.get('#mutated-value').contains('Conditional Value');
     });
 
-    // Auth Bindings not yet supported in functional tests
-    it.skip('supports auth bindings', () => {
+    it('supports auth bindings', () => {
       cy.get('#mutated-value').contains('Auth Value').should('not.exist');
       cy.contains('Apply Auth Property Mutation').click();
       cy.get('#mutated-value').contains('Auth Value');
@@ -83,8 +82,7 @@ describe('Workflow', () => {
       cy.get('#data-store-value').contains('Conditional Value');
     });
 
-    // Auth Bindings not yet supported in functional tests
-    it.skip('supports auth bindings', () => {
+    it('supports auth bindings', () => {
       cy.get('#data-store-value').contains('Auth Value').should('not.exist');
       cy.contains('Apply Auth Property DataStoreUpdateItemAction').click();
       cy.get('#data-store-value').contains('Auth Value');

--- a/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/generated-components-spec.ts
@@ -133,17 +133,16 @@ describe('Generated Components', () => {
         cy.get('#dataStoreBindingWithPredicateWithOverride').contains('Override Name');
       });
 
-      it('Renders with wired data model', () => {
-        // TODO: Implement me.
-      });
-
       describe('Auth Binding', () => {
         it('Renders if user data is not available', () => {
           cy.get('#authBinding [alt="User Image"]');
         });
 
         it('Renders user data if available', () => {
-          // TODO: Implement me.
+          cy.get('#data-binding').within(() => {
+            cy.contains('TestUser');
+            cy.contains('Mint Chip');
+          });
         });
       });
 
@@ -153,10 +152,6 @@ describe('Generated Components', () => {
         });
       });
     });
-  });
-
-  describe('Action Binding', () => {
-    // TODO: Write Action Binding Cases
   });
 
   describe('Collections', () => {

--- a/packages/test-generator/integration-test-templates/src/ActionBindingTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ActionBindingTests.tsx
@@ -21,6 +21,7 @@ import { useDataStoreBinding } from '@aws-amplify/ui-react/internal';
 import { User, Listing } from './models';
 // eslint-disable-next-line import/extensions
 import { MutationActionBindings, DataStoreActionBindings } from './ui-components';
+import { initializeAuthMockData } from './mock-utils';
 
 export default function ActionBindingTests() {
   const [isInitialized, setInitialized] = useState(false);
@@ -31,6 +32,7 @@ export default function ActionBindingTests() {
       indexedDB.deleteDatabase('amplify-datastore');
       await DataStore.save(new Listing({ title: 'Default Value' }));
       await DataStore.save(new User({ firstName: 'Johnny', lastName: 'Bound Value', age: 45 }));
+      initializeAuthMockData({ email: 'Auth Value' });
       setInitialized(true);
     };
 

--- a/packages/test-generator/integration-test-templates/src/App.tsx
+++ b/packages/test-generator/integration-test-templates/src/App.tsx
@@ -23,10 +23,12 @@ import SnippetTests from './SnippetTests'; // eslint-disable-line import/extensi
 import WorkflowTests from './WorkflowTests';
 import TwoWayBindingTests from './TwoWayBindingTests';
 import ActionBindingTests from './ActionBindingTests';
+import { DATA_STORE_MOCK_EXPORTS, AUTH_MOCK_EXPORTS } from './mock-utils';
 
 // use fake endpoint so useDataStoreBinding does not fail
 Amplify.configure({
-  aws_appsync_graphqlEndpoint: 'https://fake-appsync-endpoint/graphql',
+  ...DATA_STORE_MOCK_EXPORTS,
+  ...AUTH_MOCK_EXPORTS,
 });
 
 const HomePage = () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -59,6 +59,7 @@ import {
   SearchableCollection,
   ComponentWithAuthBinding,
 } from './ui-components'; // eslint-disable-line import/extensions
+import { initializeAuthMockData } from './mock-utils';
 
 const initializeUserTestData = async (): Promise<void> => {
   await DataStore.save(new User({ firstName: 'Real', lastName: 'LUser3', age: 29 }));
@@ -131,6 +132,11 @@ export default function ComponentTests() {
       // DataStore.clear() doesn't appear to reliably work in this scenario.
       indexedDB.deleteDatabase('amplify-datastore');
       await Promise.all([initializeUserTestData(), initializeListingTestData()]);
+      initializeAuthMockData({
+        picture: 'http://media.corporate-ir.net/media_files/IROL/17/176060/Oct18/AWS.png',
+        username: 'TestUser',
+        'custom:favorite_icecream': 'Mint Chip',
+      });
       setInitialized(true);
     };
 

--- a/packages/test-generator/integration-test-templates/src/mock-utils.ts
+++ b/packages/test-generator/integration-test-templates/src/mock-utils.ts
@@ -1,0 +1,58 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { Buffer } from 'buffer';
+
+const TEST_REGION = 'us-west-2';
+const TEST_POOL_NAME = 'testpool';
+const TEST_USER_NAME = 'testuser';
+const MOCK_ENDPOINT = 'https://fake-appsync-endpoint/graphql';
+
+export const DATA_STORE_MOCK_EXPORTS = {
+  aws_appsync_graphqlEndpoint: MOCK_ENDPOINT,
+};
+
+export const AUTH_MOCK_EXPORTS = {
+  aws_user_pools_id: `${TEST_REGION}_${TEST_POOL_NAME}`,
+  aws_user_pools_web_client_id: TEST_POOL_NAME,
+};
+
+export const initializeAuthMockData = (authAttributes: Record<string, string>) => {
+  const buildAuthKey = (key: string) => `CognitoIdentityServiceProvider.${TEST_POOL_NAME}.${TEST_USER_NAME}.${key}`;
+  const generateJwt = (tokenData: any) => `.${Buffer.from(JSON.stringify(tokenData), 'utf8').toString('base64')}`;
+
+  // Set expiry to 24h in the future
+  const expiryTimestamp = Math.floor(Date.now() / 1000) + 86400;
+
+  const userAttributes = Object.entries(authAttributes).map(([attrName, attrValue]) => {
+    return { Name: attrName, Value: attrValue };
+  });
+
+  localStorage.setItem(`CognitoIdentityServiceProvider.${TEST_POOL_NAME}.LastAuthUser`, TEST_USER_NAME);
+  localStorage.setItem(buildAuthKey('userData'), JSON.stringify({ UserAttributes: userAttributes }));
+  localStorage.setItem(
+    buildAuthKey('accessToken'),
+    generateJwt({
+      scope: 'aws.cognito.signin.user.admin',
+      exp: expiryTimestamp,
+    }),
+  );
+  localStorage.setItem(
+    buildAuthKey('idToken'),
+    generateJwt({
+      exp: expiryTimestamp,
+    }),
+  );
+};


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Create auth utils to allow injection of authenticated user data into local storage (mock what the real Authentication category does).
* Add e2e tests for auth behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
