### PR TITLE
chore: enable cypress artifact publish for help debugging remote failure

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress.json
+++ b/packages/test-generator/integration-test-templates/cypress.json
@@ -1,3 +1,4 @@
 {
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "projectId": "eg7gax"
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We have a flaky e2e test that only seems to fail in the GH action, adding cypress dashboard to help debug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
