### PR TITLE
feat: poc for useEffect to manage state dependencies

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -6033,6 +6033,259 @@ export default function InitialValueBindings(
 }
 `;
 
+exports[`amplify render tests mutations supports invalid statement names for mutation targets 1`] = `
+Object {
+  "componentText": "/* eslint-disable */
+import React from \\"react\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+  useStateMutationAction,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Listing } from \\"../models\\";
+import { Flex, FlexProps, Image, Text } from \\"@aws-amplify/ui-react\\";
+
+export type CardAProps = React.PropsWithChildren<
+  Partial<FlexProps> & {
+    listing?: Listing;
+  } & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function CardA(props: CardAProps): React.ReactElement {
+  const { listing, overrides, ...rest } = props;
+  const [classicLongSleeveTShirtChildren, setClassicLongSleeveTShirtChildren] =
+    useStateMutationAction(\\"Classic Long Sleeve T-Shirt\\");
+  const Click = () => {
+    setClassicLongSleeveTShirtChildren(listing?.titl);
+  };
+  return (
+    /* @ts-ignore: TS2322 */
+    <Flex
+      gap=\\"16px\\"
+      direction=\\"column\\"
+      justifyContent=\\"center\\"
+      position=\\"relative\\"
+      padding=\\"0px 0px 0px 0px\\"
+      backgroundColor=\\"rgba(255,255,255,1)\\"
+      {...rest}
+      {...getOverrideProps(overrides, \\"CardA\\")}
+    >
+      <Image
+        height=\\"400px\\"
+        shrink=\\"0\\"
+        alignSelf=\\"stretch\\"
+        position=\\"relative\\"
+        padding=\\"0px 0px 0px 0px\\"
+        {...getOverrideProps(overrides, \\"image\\")}
+      ></Image>
+      <Flex
+        gap=\\"8px\\"
+        direction=\\"column\\"
+        shrink=\\"0\\"
+        alignSelf=\\"stretch\\"
+        position=\\"relative\\"
+        padding=\\"0px 0px 0px 0px\\"
+        {...getOverrideProps(overrides, \\"Text Grouping\\")}
+      >
+        <Text
+          fontFamily=\\"Inter\\"
+          fontSize=\\"16px\\"
+          fontWeight=\\"400\\"
+          color=\\"rgba(0,0,0,1)\\"
+          lineHeight=\\"24px\\"
+          textAlign=\\"left\\"
+          display=\\"flex\\"
+          direction=\\"column\\"
+          justifyContent=\\"flex-start\\"
+          letterSpacing=\\"0.01px\\"
+          shrink=\\"0\\"
+          alignSelf=\\"stretch\\"
+          position=\\"relative\\"
+          padding=\\"0px 0px 0px 0px\\"
+          whiteSpace=\\"pre-wrap\\"
+          children={classicLongSleeveTShirtChildren}
+          {...getOverrideProps(overrides, \\"Classic Long Sleeve T-Shirt\\")}
+        ></Text>
+        <Text
+          fontFamily=\\"Inter\\"
+          fontSize=\\"14px\\"
+          fontWeight=\\"400\\"
+          color=\\"rgba(43,51,59,1)\\"
+          lineHeight=\\"24px\\"
+          textAlign=\\"left\\"
+          display=\\"flex\\"
+          direction=\\"column\\"
+          justifyContent=\\"flex-start\\"
+          shrink=\\"0\\"
+          alignSelf=\\"stretch\\"
+          position=\\"relative\\"
+          padding=\\"0px 0px 0px 0px\\"
+          whiteSpace=\\"pre-wrap\\"
+          children=\\"$99\\"
+          onClick={() => {
+            Click();
+          }}
+          {...getOverrideProps(overrides, \\"$99\\")}
+        ></Text>
+      </Flex>
+    </Flex>
+  );
+}
+",
+  "declaration": undefined,
+  "renderComponentToFilesystem": [Function],
+}
+`;
+
+exports[`amplify render tests mutations supports invalid statement names for mutation targets with ES5 1`] = `
+"var __assign =
+  (this && this.__assign) ||
+  function () {
+    __assign =
+      Object.assign ||
+      function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s)
+            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+      };
+    return __assign.apply(this, arguments);
+  };
+var __rest =
+  (this && this.__rest) ||
+  function (s, e) {
+    var t = {};
+    for (var p in s)
+      if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === \\"function\\")
+      for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+        if (
+          e.indexOf(p[i]) < 0 &&
+          Object.prototype.propertyIsEnumerable.call(s, p[i])
+        )
+          t[p[i]] = s[p[i]];
+      }
+    return t;
+  };
+/* eslint-disable */
+import React from \\"react\\";
+import {
+  getOverrideProps,
+  useStateMutationAction,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Flex, Image, Text } from \\"@aws-amplify/ui-react\\";
+export default function CardA(props) {
+  var listing = props.listing,
+    overrides = props.overrides,
+    rest = __rest(props, [\\"listing\\", \\"overrides\\"]);
+  var _a = useStateMutationAction(\\"Classic Long Sleeve T-Shirt\\"),
+    classicLongSleeveTShirtChildren = _a[0],
+    setClassicLongSleeveTShirtChildren = _a[1];
+  var Click = function () {
+    setClassicLongSleeveTShirtChildren(
+      listing === null || listing === void 0 ? void 0 : listing.titl
+    );
+  };
+  return React.createElement(
+    Flex,
+    __assign(
+      {
+        gap: \\"16px\\",
+        direction: \\"column\\",
+        justifyContent: \\"center\\",
+        position: \\"relative\\",
+        padding: \\"0px 0px 0px 0px\\",
+        backgroundColor: \\"rgba(255,255,255,1)\\",
+      },
+      rest,
+      getOverrideProps(overrides, \\"CardA\\")
+    ),
+    React.createElement(
+      Image,
+      __assign(
+        {
+          height: \\"400px\\",
+          shrink: \\"0\\",
+          alignSelf: \\"stretch\\",
+          position: \\"relative\\",
+          padding: \\"0px 0px 0px 0px\\",
+        },
+        getOverrideProps(overrides, \\"image\\")
+      )
+    ),
+    React.createElement(
+      Flex,
+      __assign(
+        {
+          gap: \\"8px\\",
+          direction: \\"column\\",
+          shrink: \\"0\\",
+          alignSelf: \\"stretch\\",
+          position: \\"relative\\",
+          padding: \\"0px 0px 0px 0px\\",
+        },
+        getOverrideProps(overrides, \\"Text Grouping\\")
+      ),
+      React.createElement(
+        Text,
+        __assign(
+          {
+            fontFamily: \\"Inter\\",
+            fontSize: \\"16px\\",
+            fontWeight: \\"400\\",
+            color: \\"rgba(0,0,0,1)\\",
+            lineHeight: \\"24px\\",
+            textAlign: \\"left\\",
+            display: \\"flex\\",
+            direction: \\"column\\",
+            justifyContent: \\"flex-start\\",
+            letterSpacing: \\"0.01px\\",
+            shrink: \\"0\\",
+            alignSelf: \\"stretch\\",
+            position: \\"relative\\",
+            padding: \\"0px 0px 0px 0px\\",
+            whiteSpace: \\"pre-wrap\\",
+            children: classicLongSleeveTShirtChildren,
+          },
+          getOverrideProps(overrides, \\"Classic Long Sleeve T-Shirt\\")
+        )
+      ),
+      React.createElement(
+        Text,
+        __assign(
+          {
+            fontFamily: \\"Inter\\",
+            fontSize: \\"14px\\",
+            fontWeight: \\"400\\",
+            color: \\"rgba(43,51,59,1)\\",
+            lineHeight: \\"24px\\",
+            textAlign: \\"left\\",
+            display: \\"flex\\",
+            direction: \\"column\\",
+            justifyContent: \\"flex-start\\",
+            shrink: \\"0\\",
+            alignSelf: \\"stretch\\",
+            position: \\"relative\\",
+            padding: \\"0px 0px 0px 0px\\",
+            whiteSpace: \\"pre-wrap\\",
+            children: \\"$99\\",
+            onClick: function () {
+              Click();
+            },
+          },
+          getOverrideProps(overrides, \\"$99\\")
+        )
+      )
+    )
+  );
+}
+"
+`;
+
 exports[`amplify render tests mutations supports multiple actions pointing to the same value 1`] = `
 Object {
   "componentText": "/* eslint-disable */

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -5745,7 +5745,14 @@ import {
 } from \\"@aws-amplify/ui-react/internal\\";
 import { User } from \\"../models\\";
 import { useEffect } from \\"react\\";
-import { Button, Flex, FlexProps, Heading, Text } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  Flex,
+  FlexProps,
+  Heading,
+  Text,
+  TextField,
+} from \\"@aws-amplify/ui-react\\";
 
 export type InitialValueBindingsProps = React.PropsWithChildren<
   Partial<FlexProps> & {
@@ -5776,21 +5783,19 @@ export default function InitialValueBindings(
   const [fixedValueContentsChildren, setFixedValueContentsChildren] =
     useStateMutationAction(\\"Fixed Value\\");
   const [boundValueContentsChildren, setBoundValueContentsChildren] =
-    useStateMutationAction(user?.lastName);
+    useStateMutationAction(undefined);
   const [concatValueContentsChildren, setConcatValueContentsChildren] =
     useStateMutationAction(\`\${\\"Concat\\"}\${\\" \\"}\${\\"Value\\"}\`);
   const [
     conditionalValueContentsChildren,
     setConditionalValueContentsChildren,
-  ] = useStateMutationAction(
-    user?.lastName && user?.lastName == \\"Bound Value\\"
-      ? \\"Conditional Value\\"
-      : \\"Unconditional Value\\"
-  );
+  ] = useStateMutationAction(undefined);
   const [authValueContentsChildren, setAuthValueContentsChildren] =
-    useStateMutationAction(authAttributes[\\"email\\"]);
+    useStateMutationAction(undefined);
   const [stateValueContentsChildren, setStateValueContentsChildren] =
     useStateMutationAction(stateSourceChildren);
+  const [textFieldValueContentsValue, setTextFieldValueContentsValue] =
+    useStateMutationAction(\\"\\");
   const fixedValueMutationClick = () => {
     setFixedValueContentsChildren(\\"Mutated Value\\");
   };
@@ -5809,6 +5814,9 @@ export default function InitialValueBindings(
   const stateValueMutationClick = () => {
     setStateValueContentsChildren(\\"Mutated Value\\");
   };
+  const textFieldValueMutationClick = () => {
+    setTextFieldValueContentsValue(\\"Mutated Value\\");
+  };
   useEffect(() => {
     setBoundValueContentsChildren(user?.lastName);
   }, [user]);
@@ -5821,6 +5829,9 @@ export default function InitialValueBindings(
   }, [user]);
   useEffect(() => {
     setAuthValueContentsChildren(authAttributes[\\"email\\"]);
+  }, [authAttributes]);
+  useEffect(() => {
+    setTextFieldValueContentsValue(authAttributes[\\"email\\"]);
   }, [authAttributes]);
   return (
     /* @ts-ignore: TS2322 */
@@ -5966,6 +5977,30 @@ export default function InitialValueBindings(
           children={stateSourceChildren}
           {...getOverrideProps(overrides, \\"StateSource\\")}
         ></Text>
+      </Flex>
+      <Flex
+        direction=\\"row\\"
+        {...getOverrideProps(overrides, \\"TextFieldValueInitialBindingSection\\")}
+      >
+        <Heading
+          level={5}
+          children=\\"Text Field Initial Value\\"
+          {...getOverrideProps(overrides, \\"TextFieldValueHeading\\")}
+        ></Heading>
+        <TextField
+          value={textFieldValueContentsValue}
+          onChange={(event: SyntheticEvent) => {
+            setTextFieldValueContentsValue(event.target.value);
+          }}
+          {...getOverrideProps(overrides, \\"TextFieldValueContents\\")}
+        ></TextField>
+        <Button
+          children=\\"Mutate\\"
+          onClick={() => {
+            textFieldValueMutationClick();
+          }}
+          {...getOverrideProps(overrides, \\"TextFieldValueMutation\\")}
+        ></Button>
       </Flex>
     </Flex>
   );

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -5731,100 +5731,240 @@ export default function SwitchControlledElement(
 }
 `;
 
-exports[`amplify render tests mutations supports invalid statement names for mutation targets 1`] = `
+exports[`amplify render tests mutations supports all initial value binding types 1`] = `
 Object {
   "componentText": "/* eslint-disable */
 import React from \\"react\\";
 import {
   EscapeHatchProps,
+  createDataStorePredicate,
   getOverrideProps,
+  useAuth,
+  useDataStoreBinding,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Listing } from \\"../models\\";
-import { Flex, FlexProps, Image, Text } from \\"@aws-amplify/ui-react\\";
+import { User } from \\"../models\\";
+import { useEffect } from \\"react\\";
+import { Button, Flex, FlexProps, Heading, Text } from \\"@aws-amplify/ui-react\\";
 
-export type CardAProps = React.PropsWithChildren<
+export type InitialValueBindingsProps = React.PropsWithChildren<
   Partial<FlexProps> & {
-    listing?: Listing;
+    user?: User;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
 >;
-export default function CardA(props: CardAProps): React.ReactElement {
-  const { listing, overrides, ...rest } = props;
-  const [classicLongSleeveTShirtChildren, setClassicLongSleeveTShirtChildren] =
-    useStateMutationAction(\\"Classic Long Sleeve T-Shirt\\");
-  const Click = () => {
-    setClassicLongSleeveTShirtChildren(listing?.titl);
+export default function InitialValueBindings(
+  props: InitialValueBindingsProps
+): React.ReactElement {
+  const { user: userProp, overrides, ...rest } = props;
+  const authAttributes = useAuth().user?.attributes ?? {};
+  const userFilterObj = {
+    field: \\"firstName\\",
+    operand: \\"Johnny\\",
+    operator: \\"eq\\",
   };
+  const userFilter = createDataStorePredicate<User>(userFilterObj);
+  const userDataStore = useDataStoreBinding({
+    type: \\"collection\\",
+    model: User,
+    criteria: userFilter,
+  }).items[0];
+  const user = userProp !== undefined ? userProp : userDataStore;
+  const [stateSourceChildren, setStateSourceChildren] =
+    useStateMutationAction(\\"State Value\\");
+  const [fixedValueContentsChildren, setFixedValueContentsChildren] =
+    useStateMutationAction(\\"Fixed Value\\");
+  const [boundValueContentsChildren, setBoundValueContentsChildren] =
+    useStateMutationAction(user?.lastName);
+  const [concatValueContentsChildren, setConcatValueContentsChildren] =
+    useStateMutationAction(\`\${\\"Concat\\"}\${\\" \\"}\${\\"Value\\"}\`);
+  const [
+    conditionalValueContentsChildren,
+    setConditionalValueContentsChildren,
+  ] = useStateMutationAction(
+    user?.lastName && user?.lastName == \\"Bound Value\\"
+      ? \\"Conditional Value\\"
+      : \\"Unconditional Value\\"
+  );
+  const [authValueContentsChildren, setAuthValueContentsChildren] =
+    useStateMutationAction(authAttributes[\\"email\\"]);
+  const [stateValueContentsChildren, setStateValueContentsChildren] =
+    useStateMutationAction(stateSourceChildren);
+  const fixedValueMutationClick = () => {
+    setFixedValueContentsChildren(\\"Mutated Value\\");
+  };
+  const boundValueMutationClick = () => {
+    setBoundValueContentsChildren(\\"Mutated Value\\");
+  };
+  const concatValueMutationClick = () => {
+    setConcatValueContentsChildren(\\"Mutated Value\\");
+  };
+  const conditionalValueMutationClick = () => {
+    setConditionalValueContentsChildren(\\"Mutated Value\\");
+  };
+  const authValueMutationClick = () => {
+    setAuthValueContentsChildren(\\"Mutated Value\\");
+  };
+  const stateValueMutationClick = () => {
+    setStateValueContentsChildren(\\"Mutated Value\\");
+  };
+  useEffect(() => {
+    setBoundValueContentsChildren(user?.lastName);
+  }, [user]);
+  useEffect(() => {
+    setConditionalValueContentsChildren(
+      user?.lastName && user?.lastName == \\"Bound Value\\"
+        ? \\"Conditional Value\\"
+        : \\"Unconditional Value\\"
+    );
+  }, [user]);
+  useEffect(() => {
+    setAuthValueContentsChildren(authAttributes[\\"email\\"]);
+  }, [authAttributes]);
   return (
     /* @ts-ignore: TS2322 */
     <Flex
-      gap=\\"16px\\"
       direction=\\"column\\"
-      justifyContent=\\"center\\"
-      position=\\"relative\\"
-      padding=\\"0px 0px 0px 0px\\"
-      backgroundColor=\\"rgba(255,255,255,1)\\"
       {...rest}
-      {...getOverrideProps(overrides, \\"CardA\\")}
+      {...getOverrideProps(overrides, \\"InitialValueBindings\\")}
     >
-      <Image
-        height=\\"400px\\"
-        shrink=\\"0\\"
-        alignSelf=\\"stretch\\"
-        position=\\"relative\\"
-        padding=\\"0px 0px 0px 0px\\"
-        {...getOverrideProps(overrides, \\"image\\")}
-      ></Image>
+      <Heading
+        level={3}
+        children=\\"Mutation Initial Value Bindings\\"
+        {...getOverrideProps(overrides, \\"Heading\\")}
+      ></Heading>
       <Flex
-        gap=\\"8px\\"
-        direction=\\"column\\"
-        shrink=\\"0\\"
-        alignSelf=\\"stretch\\"
-        position=\\"relative\\"
-        padding=\\"0px 0px 0px 0px\\"
-        {...getOverrideProps(overrides, \\"Text Grouping\\")}
+        direction=\\"row\\"
+        {...getOverrideProps(overrides, \\"FixedValueInitialBindingSection\\")}
       >
+        <Heading
+          level={5}
+          children=\\"Fixed Initial Value\\"
+          {...getOverrideProps(overrides, \\"FixedValueHeading\\")}
+        ></Heading>
         <Text
-          fontFamily=\\"Inter\\"
-          fontSize=\\"16px\\"
-          fontWeight=\\"400\\"
-          color=\\"rgba(0,0,0,1)\\"
-          lineHeight=\\"24px\\"
-          textAlign=\\"left\\"
-          display=\\"flex\\"
-          direction=\\"column\\"
-          justifyContent=\\"flex-start\\"
-          letterSpacing=\\"0.01px\\"
-          shrink=\\"0\\"
-          alignSelf=\\"stretch\\"
-          position=\\"relative\\"
-          padding=\\"0px 0px 0px 0px\\"
-          whiteSpace=\\"pre-wrap\\"
-          children={classicLongSleeveTShirtChildren}
-          {...getOverrideProps(overrides, \\"Classic Long Sleeve T-Shirt\\")}
+          children={fixedValueContentsChildren}
+          {...getOverrideProps(overrides, \\"FixedValueContents\\")}
         ></Text>
-        <Text
-          fontFamily=\\"Inter\\"
-          fontSize=\\"14px\\"
-          fontWeight=\\"400\\"
-          color=\\"rgba(43,51,59,1)\\"
-          lineHeight=\\"24px\\"
-          textAlign=\\"left\\"
-          display=\\"flex\\"
-          direction=\\"column\\"
-          justifyContent=\\"flex-start\\"
-          shrink=\\"0\\"
-          alignSelf=\\"stretch\\"
-          position=\\"relative\\"
-          padding=\\"0px 0px 0px 0px\\"
-          whiteSpace=\\"pre-wrap\\"
-          children=\\"$99\\"
+        <Button
+          children=\\"Mutate\\"
           onClick={() => {
-            Click();
+            fixedValueMutationClick();
           }}
-          {...getOverrideProps(overrides, \\"$99\\")}
+          {...getOverrideProps(overrides, \\"FixedValueMutation\\")}
+        ></Button>
+      </Flex>
+      <Flex
+        direction=\\"row\\"
+        {...getOverrideProps(overrides, \\"BoundValueInitialBindingSection\\")}
+      >
+        <Heading
+          level={5}
+          children=\\"Bound Initial Value\\"
+          {...getOverrideProps(overrides, \\"BoundValueHeading\\")}
+        ></Heading>
+        <Text
+          children={boundValueContentsChildren}
+          {...getOverrideProps(overrides, \\"BoundValueContents\\")}
+        ></Text>
+        <Button
+          children=\\"Mutate\\"
+          onClick={() => {
+            boundValueMutationClick();
+          }}
+          {...getOverrideProps(overrides, \\"BoundValueMutation\\")}
+        ></Button>
+      </Flex>
+      <Flex
+        direction=\\"row\\"
+        {...getOverrideProps(overrides, \\"ConcatValueInitialBindingSection\\")}
+      >
+        <Heading
+          level={5}
+          children=\\"Concat Initial Value\\"
+          {...getOverrideProps(overrides, \\"ConcatValueHeading\\")}
+        ></Heading>
+        <Text
+          children={concatValueContentsChildren}
+          {...getOverrideProps(overrides, \\"ConcatValueContents\\")}
+        ></Text>
+        <Button
+          children=\\"Mutate\\"
+          onClick={() => {
+            concatValueMutationClick();
+          }}
+          {...getOverrideProps(overrides, \\"ConcatValueMutation\\")}
+        ></Button>
+      </Flex>
+      <Flex
+        direction=\\"row\\"
+        {...getOverrideProps(
+          overrides,
+          \\"ConditionalValueInitialBindingSection\\"
+        )}
+      >
+        <Heading
+          level={5}
+          children=\\"Conditional Initial Value\\"
+          {...getOverrideProps(overrides, \\"ConditionalValueHeading\\")}
+        ></Heading>
+        <Text
+          children={conditionalValueContentsChildren}
+          {...getOverrideProps(overrides, \\"ConditionalValueContents\\")}
+        ></Text>
+        <Button
+          children=\\"Mutate\\"
+          onClick={() => {
+            conditionalValueMutationClick();
+          }}
+          {...getOverrideProps(overrides, \\"ConditionalValueMutation\\")}
+        ></Button>
+      </Flex>
+      <Flex
+        direction=\\"row\\"
+        {...getOverrideProps(overrides, \\"AuthValueInitialBindingSection\\")}
+      >
+        <Heading
+          level={5}
+          children=\\"Auth Initial Value\\"
+          {...getOverrideProps(overrides, \\"AuthValueHeading\\")}
+        ></Heading>
+        <Text
+          children={authValueContentsChildren}
+          {...getOverrideProps(overrides, \\"AuthValueContents\\")}
+        ></Text>
+        <Button
+          children=\\"Mutate\\"
+          onClick={() => {
+            authValueMutationClick();
+          }}
+          {...getOverrideProps(overrides, \\"AuthValueMutation\\")}
+        ></Button>
+      </Flex>
+      <Flex
+        direction=\\"row\\"
+        {...getOverrideProps(overrides, \\"StateValueInitialBindingSection\\")}
+      >
+        <Heading
+          level={5}
+          children=\\"State Initial Value\\"
+          {...getOverrideProps(overrides, \\"StateValueHeading\\")}
+        ></Heading>
+        <Text
+          children={stateValueContentsChildren}
+          {...getOverrideProps(overrides, \\"StateValueContents\\")}
+        ></Text>
+        <Button
+          children=\\"Mutate\\"
+          onClick={() => {
+            stateValueMutationClick();
+          }}
+          {...getOverrideProps(overrides, \\"StateValueMutation\\")}
+        ></Button>
+        <Text
+          children={stateSourceChildren}
+          {...getOverrideProps(overrides, \\"StateSource\\")}
         ></Text>
       </Flex>
     </Flex>
@@ -5834,154 +5974,6 @@ export default function CardA(props: CardAProps): React.ReactElement {
   "declaration": undefined,
   "renderComponentToFilesystem": [Function],
 }
-`;
-
-exports[`amplify render tests mutations supports invalid statement names for mutation targets with ES5 1`] = `
-"var __assign =
-  (this && this.__assign) ||
-  function () {
-    __assign =
-      Object.assign ||
-      function (t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-          s = arguments[i];
-          for (var p in s)
-            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
-        }
-        return t;
-      };
-    return __assign.apply(this, arguments);
-  };
-var __rest =
-  (this && this.__rest) ||
-  function (s, e) {
-    var t = {};
-    for (var p in s)
-      if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
-        t[p] = s[p];
-    if (s != null && typeof Object.getOwnPropertySymbols === \\"function\\")
-      for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
-        if (
-          e.indexOf(p[i]) < 0 &&
-          Object.prototype.propertyIsEnumerable.call(s, p[i])
-        )
-          t[p[i]] = s[p[i]];
-      }
-    return t;
-  };
-/* eslint-disable */
-import React from \\"react\\";
-import {
-  getOverrideProps,
-  useStateMutationAction,
-} from \\"@aws-amplify/ui-react/internal\\";
-import { Flex, Image, Text } from \\"@aws-amplify/ui-react\\";
-export default function CardA(props) {
-  var listing = props.listing,
-    overrides = props.overrides,
-    rest = __rest(props, [\\"listing\\", \\"overrides\\"]);
-  var _a = useStateMutationAction(\\"Classic Long Sleeve T-Shirt\\"),
-    classicLongSleeveTShirtChildren = _a[0],
-    setClassicLongSleeveTShirtChildren = _a[1];
-  var Click = function () {
-    setClassicLongSleeveTShirtChildren(
-      listing === null || listing === void 0 ? void 0 : listing.titl
-    );
-  };
-  return React.createElement(
-    Flex,
-    __assign(
-      {
-        gap: \\"16px\\",
-        direction: \\"column\\",
-        justifyContent: \\"center\\",
-        position: \\"relative\\",
-        padding: \\"0px 0px 0px 0px\\",
-        backgroundColor: \\"rgba(255,255,255,1)\\",
-      },
-      rest,
-      getOverrideProps(overrides, \\"CardA\\")
-    ),
-    React.createElement(
-      Image,
-      __assign(
-        {
-          height: \\"400px\\",
-          shrink: \\"0\\",
-          alignSelf: \\"stretch\\",
-          position: \\"relative\\",
-          padding: \\"0px 0px 0px 0px\\",
-        },
-        getOverrideProps(overrides, \\"image\\")
-      )
-    ),
-    React.createElement(
-      Flex,
-      __assign(
-        {
-          gap: \\"8px\\",
-          direction: \\"column\\",
-          shrink: \\"0\\",
-          alignSelf: \\"stretch\\",
-          position: \\"relative\\",
-          padding: \\"0px 0px 0px 0px\\",
-        },
-        getOverrideProps(overrides, \\"Text Grouping\\")
-      ),
-      React.createElement(
-        Text,
-        __assign(
-          {
-            fontFamily: \\"Inter\\",
-            fontSize: \\"16px\\",
-            fontWeight: \\"400\\",
-            color: \\"rgba(0,0,0,1)\\",
-            lineHeight: \\"24px\\",
-            textAlign: \\"left\\",
-            display: \\"flex\\",
-            direction: \\"column\\",
-            justifyContent: \\"flex-start\\",
-            letterSpacing: \\"0.01px\\",
-            shrink: \\"0\\",
-            alignSelf: \\"stretch\\",
-            position: \\"relative\\",
-            padding: \\"0px 0px 0px 0px\\",
-            whiteSpace: \\"pre-wrap\\",
-            children: classicLongSleeveTShirtChildren,
-          },
-          getOverrideProps(overrides, \\"Classic Long Sleeve T-Shirt\\")
-        )
-      ),
-      React.createElement(
-        Text,
-        __assign(
-          {
-            fontFamily: \\"Inter\\",
-            fontSize: \\"14px\\",
-            fontWeight: \\"400\\",
-            color: \\"rgba(43,51,59,1)\\",
-            lineHeight: \\"24px\\",
-            textAlign: \\"left\\",
-            display: \\"flex\\",
-            direction: \\"column\\",
-            justifyContent: \\"flex-start\\",
-            shrink: \\"0\\",
-            alignSelf: \\"stretch\\",
-            position: \\"relative\\",
-            padding: \\"0px 0px 0px 0px\\",
-            whiteSpace: \\"pre-wrap\\",
-            children: \\"$99\\",
-            onClick: function () {
-              Click();
-            },
-          },
-          getOverrideProps(overrides, \\"$99\\")
-        )
-      )
-    )
-  );
-}
-"
 `;
 
 exports[`amplify render tests mutations supports multiple actions pointing to the same value 1`] = `

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -5818,20 +5818,42 @@ export default function InitialValueBindings(
     setTextFieldValueContentsValue(\\"Mutated Value\\");
   };
   useEffect(() => {
-    setBoundValueContentsChildren(user?.lastName);
+    if (
+      boundValueContentsChildren === undefined &&
+      user !== undefined &&
+      user?.lastName !== undefined
+    )
+      setBoundValueContentsChildren(user?.lastName);
   }, [user]);
   useEffect(() => {
-    setConditionalValueContentsChildren(
-      user?.lastName && user?.lastName == \\"Bound Value\\"
+    if (
+      conditionalValueContentsChildren === undefined &&
+      user !== undefined &&
+      (user?.lastName && user?.lastName == \\"Bound Value\\"
         ? \\"Conditional Value\\"
-        : \\"Unconditional Value\\"
-    );
+        : \\"Unconditional Value\\") !== undefined
+    )
+      setConditionalValueContentsChildren(
+        user?.lastName && user?.lastName == \\"Bound Value\\"
+          ? \\"Conditional Value\\"
+          : \\"Unconditional Value\\"
+      );
   }, [user]);
   useEffect(() => {
-    setAuthValueContentsChildren(authAttributes[\\"email\\"]);
+    if (
+      authValueContentsChildren === undefined &&
+      authAttributes !== undefined &&
+      authAttributes[\\"email\\"] !== undefined
+    )
+      setAuthValueContentsChildren(authAttributes[\\"email\\"]);
   }, [authAttributes]);
   useEffect(() => {
-    setTextFieldValueContentsValue(authAttributes[\\"email\\"]);
+    if (
+      textFieldValueContentsValue === \\"\\" &&
+      authAttributes !== undefined &&
+      authAttributes[\\"email\\"] !== undefined
+    )
+      setTextFieldValueContentsValue(authAttributes[\\"email\\"]);
   }, [authAttributes]);
   return (
     /* @ts-ignore: TS2322 */

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -406,6 +406,8 @@ describe('amplify render tests', () => {
           script: ScriptKind.JS,
         }).componentText,
       ).toMatchSnapshot();
+    });
+
     it('supports all initial value binding types', () => {
       expect(generateWithAmplifyRenderer('workflow/initialValueBindings')).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -406,6 +406,8 @@ describe('amplify render tests', () => {
           script: ScriptKind.JS,
         }).componentText,
       ).toMatchSnapshot();
+    it('supports all initial value binding types', () => {
+      expect(generateWithAmplifyRenderer('workflow/initialValueBindings')).toMatchSnapshot();
     });
   });
 

--- a/packages/codegen-ui-react/lib/__tests__/workflow/__snapshots__/mutation.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/workflow/__snapshots__/mutation.test.ts.snap
@@ -15,8 +15,11 @@ Array [
 exports[`mapSyntheticStateReferences basic 1`] = `
 Array [
   Object {
-    "componentName": "UserNameTextField",
-    "property": "value",
+    "dataDependencies": Array [],
+    "reference": Object {
+      "componentName": "UserNameTextField",
+      "property": "value",
+    },
   },
 ]
 `;

--- a/packages/codegen-ui-react/lib/__tests__/workflow/mutation.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/workflow/mutation.test.ts
@@ -21,7 +21,7 @@ describe('mapSyntheticStateReferences', () => {
     const componentMetadata: ComponentMetadata = {
       hasAuthBindings: false,
       requiredDataModels: [],
-      stateReferences: [{ componentName: 'UserNameTextField', property: 'value' }],
+      stateReferences: [{ reference: { componentName: 'UserNameTextField', property: 'value' }, dataDependencies: [] }],
       componentNameToTypeMap: { UserNameTextField: 'TextField' },
     };
     expect(mapSyntheticStateReferences(componentMetadata)).toMatchSnapshot();

--- a/packages/codegen-ui-react/lib/imports/import-mapping.ts
+++ b/packages/codegen-ui-react/lib/imports/import-mapping.ts
@@ -14,6 +14,7 @@
   limitations under the License.
  */
 export enum ImportSource {
+  REACT = 'react',
   UI_REACT = '@aws-amplify/ui-react',
   UI_REACT_INTERNAL = '@aws-amplify/ui-react/internal',
   AMPLIFY_DATASTORE = '@aws-amplify/datastore',
@@ -38,6 +39,7 @@ export enum ImportValue {
   USE_DATA_STORE_DELETE_ACTION = 'useDataStoreDeleteAction',
   USE_AUTH_SIGN_OUT_ACTION = 'useAuthSignOutAction',
   USE_STATE_MUTATION_ACTION = 'useStateMutationAction',
+  USE_EFFECT = 'useEffect',
 }
 
 export const ImportMapping: Record<ImportValue, ImportSource> = {
@@ -58,4 +60,5 @@ export const ImportMapping: Record<ImportValue, ImportSource> = {
   [ImportValue.USE_DATA_STORE_DELETE_ACTION]: ImportSource.UI_REACT_INTERNAL,
   [ImportValue.USE_AUTH_SIGN_OUT_ACTION]: ImportSource.UI_REACT_INTERNAL,
   [ImportValue.USE_STATE_MUTATION_ACTION]: ImportSource.UI_REACT_INTERNAL,
+  [ImportValue.USE_EFFECT]: ImportSource.REACT,
 };

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -77,6 +77,7 @@ import {
   buildUseActionStatement,
   mapSyntheticStateReferences,
   buildStateStatements,
+  buildUseEffectStatements,
 } from './workflow';
 
 export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer<
@@ -602,6 +603,12 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     const useActionStatements = this.buildUseActionStatements();
     useActionStatements.forEach((entry) => {
+      statements.push(entry);
+    });
+
+    const useEffectStatements = buildUseEffectStatements(component, this.componentMetadata);
+    useEffectStatements.forEach((entry) => {
+      this.importCollection.addMappedImport(ImportValue.USE_EFFECT);
       statements.push(entry);
     });
 

--- a/packages/codegen-ui-react/lib/workflow/mutation.ts
+++ b/packages/codegen-ui-react/lib/workflow/mutation.ts
@@ -88,7 +88,7 @@ export function buildUseEffectStatements(
             factory.createBlock([
               factory.createExpressionStatement(
                 factory.createCallExpression(factory.createIdentifier(getSetStateName(reference)), undefined, [
-                  getStateInitialValue(component, componentMetadata, reference),
+                  getStateInitialValue(component, componentMetadata, { reference, dataDependencies: [] }),
                 ]),
               ),
             ]),
@@ -283,7 +283,7 @@ export function buildStateStatements(
             undefined,
             undefined,
             factory.createCallExpression(factory.createIdentifier('useStateMutationAction'), undefined, [
-              getStateInitialValue(component, componentMetadata, stateReference.reference),
+              getStateInitialValue(component, componentMetadata, stateReference),
             ]),
           ),
         ],
@@ -296,13 +296,16 @@ export function buildStateStatements(
 export function getStateInitialValue(
   component: StudioComponent,
   componentMetadata: ComponentMetadata,
-  stateReference: StateStudioComponentProperty,
+  stateReference: StateReferenceMetadata,
 ) {
-  const { componentName, property } = stateReference;
+  const {
+    reference: { componentName, property },
+    dataDependencies,
+  } = stateReference;
   const referencedComponent = getComponentFromComponentTree(component, componentName);
   const componentProperty = referencedComponent.properties[property];
 
-  if (componentProperty === undefined) {
+  if (componentProperty === undefined || dataDependencies.length > 0) {
     const defaultPropMapping = PrimitiveDefaultValuePropMapping[referencedComponent.componentType as Primitive];
     if (property in defaultPropMapping && referencedComponent.properties[defaultPropMapping[property]]) {
       const defaultProp = referencedComponent.properties[defaultPropMapping[property]];

--- a/packages/codegen-ui/example-schemas/workflow/initialValueBindings.json
+++ b/packages/codegen-ui/example-schemas/workflow/initialValueBindings.json
@@ -396,6 +396,61 @@
           }
         }
       ]
+    },
+    {
+      "componentType": "Flex",
+      "name": "TextFieldValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "TextFieldValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "Text Field Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "TextField",
+          "name": "TextFieldValueContents",
+          "properties": {
+            "value": {
+              "userAttribute": "email"
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "TextFieldValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "TextFieldValueContents",
+                  "property": "value",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        }
+      ]
     }
   ],
   "schemaVersion": "1.0"

--- a/packages/codegen-ui/example-schemas/workflow/initialValueBindings.json
+++ b/packages/codegen-ui/example-schemas/workflow/initialValueBindings.json
@@ -1,0 +1,402 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Flex",
+  "name": "InitialValueBindings",
+  "properties": {
+    "direction": {
+      "value": "column"
+    }
+  },
+  "bindingProperties": {
+    "user": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "User",
+        "predicate": {
+          "field": "firstName",
+          "operand": "Johnny",
+          "operator": "eq"
+        }
+      }
+    }
+  },
+  "children": [
+    {
+      "componentType": "Heading",
+      "name": "Heading",
+      "properties": {
+        "level": {
+          "value": 3
+        },
+        "label": {
+          "value": "Mutation Initial Value Bindings"
+        }
+      }
+    },
+    {
+      "componentType": "Flex",
+      "name": "FixedValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "FixedValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "Fixed Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "Text",
+          "name": "FixedValueContents",
+          "properties": {
+            "label": {
+              "value": "Fixed Value"
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "FixedValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "FixedValueContents",
+                  "property": "label",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentType": "Flex",
+      "name": "BoundValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "BoundValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "Bound Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "Text",
+          "name": "BoundValueContents",
+          "properties": {
+            "label": {
+              "bindingProperties": {
+                "property": "user",
+                "field": "lastName"
+              }
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "BoundValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "BoundValueContents",
+                  "property": "label",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentType": "Flex",
+      "name": "ConcatValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "ConcatValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "Concat Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "Text",
+          "name": "ConcatValueContents",
+          "properties": {
+            "label": {
+              "concat": [
+                {
+                  "value": "Concat"
+                },
+                {
+                  "value": " "
+                },
+                {
+                  "value": "Value"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "ConcatValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "ConcatValueContents",
+                  "property": "label",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentType": "Flex",
+      "name": "ConditionalValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "ConditionalValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "Conditional Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "Text",
+          "name": "ConditionalValueContents",
+          "properties": {
+            "label": {
+              "condition": {
+                "property": "user",
+                "field": "lastName",
+                "operator": "eq",
+                "operand": "Bound Value",
+                "then": {
+                  "value": "Conditional Value"
+                },
+                "else": {
+                  "value": "Unconditional Value"
+                }
+              }
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "ConditionalValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "ConditionalValueContents",
+                  "property": "label",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentType": "Flex",
+      "name": "AuthValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "AuthValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "Auth Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "Text",
+          "name": "AuthValueContents",
+          "properties": {
+            "label": {
+              "userAttribute": "email"
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "AuthValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "AuthValueContents",
+                  "property": "label",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentType": "Flex",
+      "name": "StateValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "StateValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "State Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "Text",
+          "name": "StateValueContents",
+          "properties": {
+            "label": {
+              "componentName": "StateSource",
+              "property": "label"
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "StateValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "StateValueContents",
+                  "property": "label",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        },
+        {
+          "componentType": "Text",
+          "name": "StateSource",
+          "properties": {
+            "label": {
+              "value": "State Value"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "schemaVersion": "1.0"
+}

--- a/packages/codegen-ui/lib/__tests__/utils/component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/component-metadata.test.ts
@@ -359,13 +359,25 @@ describe('computeComponentMetadata', () => {
           },
         },
         bindingProperties: {},
+        children: [
+          {
+            componentType: 'TextField',
+            name: 'UserNameField',
+            properties: {
+              value: {
+                value: 'username',
+              },
+            },
+          },
+        ],
       };
       const expectedMetadata: ComponentMetadata = {
         hasAuthBindings: false,
         requiredDataModels: [],
-        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        stateReferences: [{ reference: { componentName: 'UserNameField', property: 'value' }, dataDependencies: [] }],
         componentNameToTypeMap: {
           MyText: 'Text',
+          UserNameField: 'TextField',
         },
       };
       expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
@@ -386,13 +398,25 @@ describe('computeComponentMetadata', () => {
           },
         },
         bindingProperties: {},
+        children: [
+          {
+            componentType: 'TextField',
+            name: 'UserNameField',
+            properties: {
+              value: {
+                value: 'username',
+              },
+            },
+          },
+        ],
       };
       const expectedMetadata: ComponentMetadata = {
         hasAuthBindings: false,
         requiredDataModels: [],
-        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        stateReferences: [{ reference: { componentName: 'UserNameField', property: 'value' }, dataDependencies: [] }],
         componentNameToTypeMap: {
           MyText: 'Text',
+          UserNameField: 'TextField',
         },
       };
       expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
@@ -418,13 +442,25 @@ describe('computeComponentMetadata', () => {
             },
           },
         },
+        children: [
+          {
+            componentType: 'TextField',
+            name: 'UserNameField',
+            properties: {
+              value: {
+                value: 'username',
+              },
+            },
+          },
+        ],
       };
       const expectedMetadata: ComponentMetadata = {
         hasAuthBindings: false,
         requiredDataModels: ['User'],
-        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        stateReferences: [{ reference: { componentName: 'UserNameField', property: 'value' }, dataDependencies: [] }],
         componentNameToTypeMap: {
           MyText: 'Text',
+          UserNameField: 'TextField',
         },
       };
       expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
@@ -457,13 +493,25 @@ describe('computeComponentMetadata', () => {
             },
           },
         },
+        children: [
+          {
+            componentType: 'TextField',
+            name: 'UserNameField',
+            properties: {
+              value: {
+                value: 'username',
+              },
+            },
+          },
+        ],
       };
       const expectedMetadata: ComponentMetadata = {
         hasAuthBindings: false,
         requiredDataModels: ['User'],
-        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        stateReferences: [{ reference: { componentName: 'UserNameField', property: 'value' }, dataDependencies: [] }],
         componentNameToTypeMap: {
           MyText: 'Text',
+          UserNameField: 'TextField',
         },
       };
       expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
@@ -501,16 +549,38 @@ describe('computeComponentMetadata', () => {
             },
           },
         },
+        children: [
+          {
+            componentType: 'TextField',
+            name: 'UserNameField',
+            properties: {
+              value: {
+                value: 'username',
+              },
+            },
+          },
+          {
+            componentType: 'TextField',
+            name: 'NicknameField',
+            properties: {
+              value: {
+                value: 'nickname',
+              },
+            },
+          },
+        ],
       };
       const expectedMetadata: ComponentMetadata = {
         hasAuthBindings: false,
         requiredDataModels: ['User'],
         stateReferences: [
-          { componentName: 'NicknameField', property: 'value' },
-          { componentName: 'UserNameField', property: 'value' },
+          { reference: { componentName: 'NicknameField', property: 'value' }, dataDependencies: [] },
+          { reference: { componentName: 'UserNameField', property: 'value' }, dataDependencies: [] },
         ],
         componentNameToTypeMap: {
           MyText: 'Text',
+          UserNameField: 'TextField',
+          NicknameField: 'TextField',
         },
       };
       expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
@@ -548,13 +618,25 @@ describe('computeComponentMetadata', () => {
             },
           },
         },
+        children: [
+          {
+            componentType: 'TextField',
+            name: 'UserNameField',
+            properties: {
+              value: {
+                value: 'username',
+              },
+            },
+          },
+        ],
       };
       const expectedMetadata: ComponentMetadata = {
         hasAuthBindings: false,
         requiredDataModels: ['User'],
-        stateReferences: [{ componentName: 'UserNameField', property: 'value' }],
+        stateReferences: [{ reference: { componentName: 'UserNameField', property: 'value' }, dataDependencies: [] }],
         componentNameToTypeMap: {
           MyText: 'Text',
+          UserNameField: 'TextField',
         },
       };
       expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
@@ -592,16 +674,31 @@ describe('computeComponentMetadata', () => {
             },
           },
         },
+        children: [
+          {
+            componentType: 'TextField',
+            name: 'UserNameField',
+            properties: {
+              value: {
+                value: 'username',
+              },
+            },
+          },
+        ],
       };
       const expectedMetadata: ComponentMetadata = {
         hasAuthBindings: false,
         requiredDataModels: ['User'],
         stateReferences: [
-          { componentName: 'UserNameField', property: 'value' },
-          { componentName: 'UserNameField', property: 'value', set: { value: 'Setter' } },
+          { reference: { componentName: 'UserNameField', property: 'value' }, dataDependencies: [] },
+          {
+            reference: { componentName: 'UserNameField', property: 'value', set: { value: 'Setter' } },
+            dataDependencies: [],
+          },
         ],
         componentNameToTypeMap: {
           MyText: 'Text',
+          UserNameField: 'TextField',
         },
       };
       expect(computeComponentMetadata(component)).toEqual(expectedMetadata);
@@ -789,8 +886,15 @@ describe('computeComponentMetadata', () => {
         hasAuthBindings: true,
         requiredDataModels: ['User', 'Listing'],
         stateReferences: [
-          { componentName: 'NicknameField', property: 'value' },
-          { componentName: 'NestedComponent', property: 'color', set: { bindingProperties: { property: 'color' } } },
+          { reference: { componentName: 'NicknameField', property: 'value' }, dataDependencies: [] },
+          {
+            reference: {
+              componentName: 'NestedComponent',
+              property: 'color',
+              set: { bindingProperties: { property: 'color' } },
+            },
+            dataDependencies: [],
+          },
         ],
         componentNameToTypeMap: {
           TopLevelComponent: 'Flex',
@@ -907,8 +1011,15 @@ describe('computeComponentMetadata', () => {
         hasAuthBindings: true,
         requiredDataModels: ['User', 'Listing'],
         stateReferences: [
-          { componentName: 'NicknameField', property: 'value' },
-          { componentName: 'NestedComponent', property: 'color', set: { bindingProperties: { property: 'color' } } },
+          { reference: { componentName: 'NicknameField', property: 'value' }, dataDependencies: [] },
+          {
+            reference: {
+              componentName: 'NestedComponent',
+              property: 'color',
+              set: { bindingProperties: { property: 'color' } },
+            },
+            dataDependencies: [],
+          },
         ],
         componentNameToTypeMap: {
           TopLevelComponent: 'Flex',

--- a/packages/codegen-ui/lib/__tests__/utils/state-reference-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/state-reference-metadata.test.ts
@@ -1,0 +1,266 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { StudioComponent, RelationalOperator, StateReference } from '../../types';
+import { computeDataDependenciesForStudioComponentProperty, computeStateReferenceMetadata } from '../../utils';
+
+describe('state-reference-metadata', () => {
+  describe('computeDataDependenciesForStudioComponentProperty', () => {
+    test('concat', () => {
+      const property = {
+        concat: [
+          {
+            userAttribute: 'username',
+          },
+          {
+            bindingProperties: {
+              property: 'value',
+            },
+          },
+        ],
+      };
+      expect(computeDataDependenciesForStudioComponentProperty(property)).toEqual(['authAttributes', 'value']);
+    });
+
+    test('user auth attribute', () => {
+      const property = {
+        userAttribute: 'username',
+      };
+      expect(computeDataDependenciesForStudioComponentProperty(property)).toEqual(['authAttributes']);
+    });
+
+    test('binding properties', () => {
+      const property = {
+        bindingProperties: {
+          property: 'value',
+        },
+      };
+      expect(computeDataDependenciesForStudioComponentProperty(property)).toEqual(['value']);
+    });
+
+    test('collection binding properties', () => {
+      const property = {
+        collectionBindingProperties: {
+          property: 'value',
+        },
+      };
+      expect(computeDataDependenciesForStudioComponentProperty(property)).toEqual(['items']);
+    });
+
+    test('conditional', () => {
+      const property = {
+        condition: {
+          operator: 'gt' as RelationalOperator,
+          operand: 'prop',
+          then: {
+            userAttribute: 'username',
+          },
+          else: {
+            bindingProperties: {
+              property: 'value',
+            },
+          },
+          property: 'id',
+        },
+      };
+      expect(computeDataDependenciesForStudioComponentProperty(property)).toEqual(['id', 'authAttributes', 'value']);
+    });
+
+    test('removes duplicates', () => {
+      const property = {
+        concat: [
+          {
+            userAttribute: 'username',
+          },
+          {
+            userAttribute: 'username',
+          },
+        ],
+      };
+      expect(computeDataDependenciesForStudioComponentProperty(property)).toEqual(['authAttributes']);
+    });
+  });
+
+  describe('computeStateReferenceMetadata', () => {
+    test('no state reference', () => {
+      const component = {
+        id: '1234-5678-9010',
+        componentType: 'Flex',
+        name: 'InitialValueBindings',
+        properties: {},
+        bindingProperties: {},
+        children: [],
+        schemaVersion: '1.0',
+      };
+      const stateReferences: StateReference[] = [];
+      expect(computeStateReferenceMetadata(component, stateReferences)).toEqual([]);
+    });
+
+    test('state reference with auth attribute', () => {
+      const component: StudioComponent = {
+        id: '1234-5678-9010',
+        componentType: 'Flex',
+        name: 'InitialValueBindings',
+        properties: {},
+        bindingProperties: {},
+        children: [
+          {
+            componentType: 'Text',
+            name: 'AuthValueContents',
+            properties: {
+              label: {
+                userAttribute: 'email',
+              },
+            },
+          },
+          {
+            componentType: 'Button',
+            name: 'AuthValueMutation',
+            properties: {},
+            events: {
+              click: {
+                action: 'Amplify.Mutation',
+                parameters: {
+                  state: {
+                    componentName: 'AuthValueContents',
+                    property: 'label',
+                    set: {
+                      value: 'Mutated Value',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        schemaVersion: '1.0',
+      };
+      const stateReferences: StateReference[] = [
+        {
+          componentName: 'AuthValueContents',
+          property: 'label',
+          set: { value: 'Mutated Value' },
+        },
+      ];
+      expect(computeStateReferenceMetadata(component, stateReferences)).toEqual([
+        {
+          dataDependencies: ['authAttributes'],
+          reference: {
+            componentName: 'AuthValueContents',
+            property: 'label',
+            set: {
+              value: 'Mutated Value',
+            },
+          },
+        },
+      ]);
+    });
+
+    test('state reference with data store', () => {
+      const component: StudioComponent = {
+        id: '1234-5678-9010',
+        componentType: 'Flex',
+        name: 'InitialValueBindings',
+        properties: {},
+        bindingProperties: {
+          user: {
+            type: 'Data',
+            bindingProperties: {
+              model: 'User',
+              predicate: {
+                field: 'firstName',
+                operand: 'Johnny',
+                operator: 'eq',
+              },
+            },
+          },
+        },
+        children: [
+          {
+            componentType: 'Text',
+            name: 'BoundValueContents',
+            properties: {
+              label: {
+                bindingProperties: {
+                  property: 'user',
+                  field: 'lastName',
+                },
+              },
+            },
+          },
+          {
+            componentType: 'Button',
+            name: 'BoundValueMutation',
+            events: {
+              click: {
+                action: 'Amplify.Mutation',
+                parameters: {
+                  state: {
+                    componentName: 'BoundValueContents',
+                    property: 'label',
+                    set: {
+                      value: 'Mutated Value',
+                    },
+                  },
+                },
+              },
+            },
+            properties: {},
+          },
+        ],
+        schemaVersion: '1.0',
+      };
+      const stateReferences: StateReference[] = [
+        {
+          componentName: 'BoundValueContents',
+          property: 'label',
+          set: { value: 'Mutated Value' },
+        },
+      ];
+      expect(computeStateReferenceMetadata(component, stateReferences)).toEqual([
+        {
+          dataDependencies: ['user'],
+          reference: {
+            componentName: 'BoundValueContents',
+            property: 'label',
+            set: {
+              value: 'Mutated Value',
+            },
+          },
+        },
+      ]);
+    });
+
+    test('invalid state reference', () => {
+      const component = {
+        id: '1234-5678-9010',
+        componentType: 'Flex',
+        name: 'InitialValueBindings',
+        properties: {},
+        bindingProperties: {},
+        children: [],
+        schemaVersion: '1.0',
+      };
+      const stateReferences: StateReference[] = [
+        {
+          componentName: 'BoundValueContents',
+          property: 'label',
+          set: { value: 'Mutated Value' },
+        },
+      ];
+      expect(() => computeStateReferenceMetadata(component, stateReferences)).toThrowError();
+    });
+  });
+});

--- a/packages/codegen-ui/lib/utils/index.ts
+++ b/packages/codegen-ui/lib/utils/index.ts
@@ -15,3 +15,4 @@
  */
 export * from './component-metadata';
 export * from './component-tree';
+export * from './state-reference-metadata';

--- a/packages/codegen-ui/lib/utils/state-reference-metadata.ts
+++ b/packages/codegen-ui/lib/utils/state-reference-metadata.ts
@@ -16,10 +16,6 @@
 import { StudioComponent, StudioComponentProperty, StateReference } from '../types';
 import { getComponentFromComponentTree } from './component-tree';
 
-/**
- * TODO: UNIT TESTS ON ME
- */
-
 export type StateReferenceMetadata = {
   reference: StateReference;
   dataDependencies: string[];
@@ -47,7 +43,7 @@ function reduceDataDependencies(dataDependencies: string[]): string[] {
  * Property Functions
  */
 
-function computeDataDependenciesForStudioComponentProperty(property: StudioComponentProperty): string[] {
+export function computeDataDependenciesForStudioComponentProperty(property: StudioComponentProperty): string[] {
   return reduceDataDependencies(
     ([] as string[])
       .concat(

--- a/packages/codegen-ui/lib/utils/state-reference-metadata.ts
+++ b/packages/codegen-ui/lib/utils/state-reference-metadata.ts
@@ -21,7 +21,7 @@ import { getComponentFromComponentTree } from './component-tree';
  */
 
 export type StateReferenceMetadata = {
-  stateReference: StateReference;
+  reference: StateReference;
   dataDependencies: string[];
 };
 
@@ -33,31 +33,10 @@ export function computeStateReferenceMetadata(
   component: StudioComponent,
   stateReferences: StateReference[],
 ): StateReferenceMetadata[] {
-  return dedupeStateReferences(stateReferences).map((stateReference) => {
-    const dataDependencies = computeDataDependenciesForStateReference(component, stateReference);
-    return { stateReference, dataDependencies };
+  return stateReferences.map((reference) => {
+    const dataDependencies = computeDataDependenciesForStateReference(component, reference);
+    return { reference, dataDependencies };
   });
-}
-
-/**
- * Utility Functions
- */
-
-/**
- * Dedupes state references by componentName + property, returning a consolidate
- * list, stripping the `set` property from them. We do this by serializing to json,
- * collecting in a set, then deserializing.
- */
-function dedupeStateReferences(stateReferences: StateReference[]): StateReference[] {
-  const dedupedSerializedRefs = [
-    ...new Set(
-      stateReferences.map((stateReference) => {
-        const { componentName, property } = stateReference;
-        return JSON.stringify({ componentName, property });
-      }),
-    ),
-  ];
-  return dedupedSerializedRefs.map((ref) => JSON.parse(ref));
 }
 
 function reduceDataDependencies(dataDependencies: string[]): string[] {

--- a/packages/codegen-ui/lib/utils/state-reference-metadata.ts
+++ b/packages/codegen-ui/lib/utils/state-reference-metadata.ts
@@ -1,0 +1,117 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { StudioComponent, StudioComponentProperty, StateReference } from '../types';
+import { getComponentFromComponentTree } from './component-tree';
+
+/**
+ * TODO: UNIT TESTS ON ME
+ */
+
+export type StateReferenceMetadata = {
+  stateReference: StateReference;
+  dataDependencies: string[];
+};
+
+/**
+ * Component Structure Functions
+ */
+
+export function computeStateReferenceMetadata(
+  component: StudioComponent,
+  stateReferences: StateReference[],
+): StateReferenceMetadata[] {
+  return dedupeStateReferences(stateReferences).map((stateReference) => {
+    const dataDependencies = computeDataDependenciesForStateReference(component, stateReference);
+    return { stateReference, dataDependencies };
+  });
+}
+
+/**
+ * Utility Functions
+ */
+
+/**
+ * Dedupes state references by componentName + property, returning a consolidate
+ * list, stripping the `set` property from them. We do this by serializing to json,
+ * collecting in a set, then deserializing.
+ */
+function dedupeStateReferences(stateReferences: StateReference[]): StateReference[] {
+  const dedupedSerializedRefs = [
+    ...new Set(
+      stateReferences.map((stateReference) => {
+        const { componentName, property } = stateReference;
+        return JSON.stringify({ componentName, property });
+      }),
+    ),
+  ];
+  return dedupedSerializedRefs.map((ref) => JSON.parse(ref));
+}
+
+function reduceDataDependencies(dataDependencies: string[]): string[] {
+  return [...new Set(dataDependencies)];
+}
+
+/**
+ * Property Functions
+ */
+
+function computeDataDependenciesForStudioComponentProperty(property: StudioComponentProperty): string[] {
+  return reduceDataDependencies(
+    ([] as string[])
+      .concat(
+        'concat' in property && property.concat
+          ? property.concat.flatMap(computeDataDependenciesForStudioComponentProperty)
+          : [],
+      )
+      .concat('userAttribute' in property && property.userAttribute ? ['authAttributes'] : [])
+      .concat(
+        'bindingProperties' in property && property.bindingProperties ? [property.bindingProperties.property] : [],
+      )
+      .concat('collectionBindingProperties' in property && property.collectionBindingProperties ? ['items'] : [])
+      .concat(
+        'condition' in property && property.condition && 'property' in property.condition && property.condition.property
+          ? [property.condition.property]
+          : [],
+      )
+      .concat(
+        'condition' in property && property.condition && 'then' in property.condition && property.condition.then
+          ? computeDataDependenciesForStudioComponentProperty(property.condition.then)
+          : [],
+      )
+      .concat(
+        'condition' in property && property.condition && 'else' in property.condition && property.condition.else
+          ? computeDataDependenciesForStudioComponentProperty(property.condition.else)
+          : [],
+      ),
+  );
+}
+
+/**
+ * State Functions
+ */
+
+function computeDataDependenciesForStateReference(
+  component: StudioComponent,
+  stateReference: StateReference,
+): string[] {
+  const { componentName, property } = stateReference;
+  const namedComponent = getComponentFromComponentTree(component, componentName);
+  const propertyDefinition = namedComponent.properties[property];
+  if (propertyDefinition) {
+    return computeDataDependenciesForStudioComponentProperty(propertyDefinition);
+  }
+  return [];
+}

--- a/packages/test-generator/integration-test-templates/cypress/integration/action-binding-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/action-binding-spec.ts
@@ -144,5 +144,17 @@ describe('Workflow', () => {
         cy.contains('Mutated Value');
       });
     });
+
+    it('supports values in text fields', () => {
+      cy.get('#text-field-value-initial-binding-section').within(() => {
+        cy.get('input').should('have.attr', 'value', 'Auth Value');
+        cy.get('button').click();
+        cy.get('input').should('have.attr', 'value', 'Mutated Value');
+        cy.get('input').type(' with typing');
+        cy.get('input').should('have.attr', 'value', 'Mutated Value with typing');
+        cy.get('button').click();
+        cy.get('input').should('have.attr', 'value', 'Mutated Value');
+      });
+    });
   });
 });

--- a/packages/test-generator/integration-test-templates/cypress/integration/action-binding-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/action-binding-spec.ts
@@ -105,7 +105,7 @@ describe('Workflow', () => {
       });
     });
 
-    it.skip('supports bound values', () => {
+    it('supports bound values', () => {
       cy.get('#bound-value-initial-binding-section').within(() => {
         cy.contains('Bound Value');
         cy.contains('Mutate').click();
@@ -121,7 +121,7 @@ describe('Workflow', () => {
       });
     });
 
-    it.skip('supports conditional values', () => {
+    it('supports conditional values', () => {
       cy.get('#conditional-value-initial-binding-section').within(() => {
         cy.contains('Conditional Value');
         cy.contains('Mutate').click();
@@ -129,7 +129,7 @@ describe('Workflow', () => {
       });
     });
 
-    it.skip('supports auth values', () => {
+    it('supports auth values', () => {
       cy.get('#auth-value-initial-binding-section').within(() => {
         cy.contains('Auth Value');
         cy.contains('Mutate').click();

--- a/packages/test-generator/integration-test-templates/src/ActionBindingTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ActionBindingTests.tsx
@@ -72,6 +72,7 @@ export default function ActionBindingTests() {
           ConditionalValueInitialBindingSection: { id: 'conditional-value-initial-binding-section' },
           AuthValueInitialBindingSection: { id: 'auth-value-initial-binding-section' },
           StateValueInitialBindingSection: { id: 'state-value-initial-binding-section' },
+          TextFieldValueInitialBindingSection: { id: 'text-field-value-initial-binding-section' },
         }}
       />
     </AmplifyProvider>

--- a/packages/test-generator/lib/components/workflow/initialValueBindings.json
+++ b/packages/test-generator/lib/components/workflow/initialValueBindings.json
@@ -396,6 +396,61 @@
           }
         }
       ]
+    },
+    {
+      "componentType": "Flex",
+      "name": "TextFieldValueInitialBindingSection",
+      "properties": {
+        "direction": {
+          "value": "row"
+        }
+      },
+      "children": [
+        {
+          "componentType": "Heading",
+          "name": "TextFieldValueHeading",
+          "properties": {
+            "level": {
+              "value": 5
+            },
+            "label": {
+              "value": "Text Field Initial Value"
+            }
+          }
+        },
+        {
+          "componentType": "TextField",
+          "name": "TextFieldValueContents",
+          "properties": {
+            "value": {
+              "userAttribute": "email"
+            }
+          }
+        },
+        {
+          "componentType": "Button",
+          "name": "TextFieldValueMutation",
+          "events": {
+            "click": {
+              "action": "Amplify.Mutation",
+              "parameters": {
+                "state": {
+                  "componentName": "TextFieldValueContents",
+                  "property": "value",
+                  "set": {
+                    "value": "Mutated Value"
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "children": {
+              "value": "Mutate"
+            }
+          }
+        }
+      ]
     }
   ],
   "schemaVersion": "1.0"

--- a/scripts/integ-setup.bat
+++ b/scripts/integ-setup.bat
@@ -13,7 +13,7 @@ call npm run integ:templates
 :: install
 call lerna bootstrap
 call lerna add --scope integration-test aws-amplify
-call lerna add --scope integration-test @aws-amplify/ui-react
+call lerna add --scope integration-test @aws-amplify/ui-react@2.5.0
 call lerna add --scope integration-test @aws-amplify/datastore
 call lerna add --scope integration-test @aws-amplify/codegen-ui
 call lerna add --scope integration-test @aws-amplify/codegen-ui-react


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Add support for useEffect to update dependent state values once useData or useAuth values have settled.
* Still needs unit tests.
* Still needs improved E2E verification
* Still likely needs to determine how we keep from mutations and state values waffling a bound state element back and forth. (I'd propose we initialize these to `undefined` and then only set the value if the depenedencies are all non-null, and the value itself isn't yet set).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
