### PR TITLE
fix: don't use replaceAll since it's not supported in ES2015

### DIFF
--- a/packages/codegen-ui-react/lib/react-component-render-helper.ts
+++ b/packages/codegen-ui-react/lib/react-component-render-helper.ts
@@ -607,7 +607,7 @@ export function addBindingPropertiesImports(
 // Scrub all non-alphanum characters, and any leading numbers so we can generate a legal
 // variable name.
 export function sanitizeName(componentName: string): string {
-  return componentName.replaceAll(/[^a-zA-Z0-9]/g, '').replace(/^[0-9]*/, '');
+  return componentName.replace(/[^a-zA-Z0-9]/g, '').replace(/^[0-9]*/, '');
 }
 
 export function getStateName(stateReference: StateStudioComponentProperty): string {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Studio UI transpiles to ES2015, and replaceAll isn't supported, replacing w/ a global replace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
