### PR TITLE
chore: downgrade ui-react dep since they're no longer MV bumping

### DIFF
--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -24,7 +24,7 @@ export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<
     return [
       {
         dependencyName: '@aws-amplify/ui-react',
-        supportedSemVerPattern: '^3.0.0',
+        supportedSemVerPattern: '^2.6.1',
         reason: 'Required to leverage amplify ui primitives, and studio component helper functions.',
       },
     ];


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We'll likely need to bump a patch version once this is fixed and resolved, but https://github.com/aws-amplify/amplify-ui/issues/1396, but we definitely won't be on 3.0.0 anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
