### PR TITLE
test: pin typescript to 4.4.4 for integration tests

### DIFF
--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -11,6 +11,7 @@ npm run integ:templates
 
 # install
 lerna bootstrap
+lerna add --scope integration-test typescript@4.4.4
 lerna add --scope integration-test aws-amplify
 lerna add --scope integration-test @aws-amplify/ui-react
 lerna add --scope integration-test @aws-amplify/datastore


### PR DESCRIPTION
CRA automatically installs the latest version of TypeScript (4.6.2). This out of the supported range of codegen (~4.4.4) and caused an error with ScriptTarget. I'm not sure yet what the exact error is but this will resolve the issue until codegen needs to upgrade.
