### PR TITLE
chore: flip back to integ test secrets instead of temp release secrets

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,13 +53,13 @@ jobs:
       - name: Run CLI Pull in test app
         working-directory: e2e-test-app
         run: |
-          FORCE_RENDER=1 amplify-dev pull --appId ${{ secrets.Q1_RELEASE_E2E_TEST_APP_ID }} --envName staging -y --providers "{\
+          FORCE_RENDER=1 amplify-dev pull --appId ${{ secrets.E2E_TEST_APP_ID }} --envName staging -y --providers "{\
             \"awscloudformation\":{\
               \"configLevel\":\"project\",\
               \"useProfile\":false,\
               \"profileName\":\"default\",\
-              \"accessKeyId\":\"${{ secrets.Q1_RELEASE_E2E_TEST_ACCESS_KEY }}\",\
-              \"secretAccessKey\":\"${{ secrets.Q1_RELEASE_E2E_TEST_SECRET_KEY }}\",\
+              \"accessKeyId\":\"${{ secrets.E2E_TEST_ACCESS_KEY }}\",\
+              \"secretAccessKey\":\"${{ secrets.E2E_TEST_SECRET_KEY }}\",\
               \"region\":\"us-west-2\"\
             }\
           }"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We had a separate account which we were using for testing. Flipping back to the standard app secrets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
