### PR TITLE
fix: remove jsx ext from declaration file ext

### DIFF
--- a/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
@@ -142,7 +142,7 @@ export function buildPrinter(fileName: string, renderConfig: ReactRenderConfig) 
 }
 
 export function getDeclarationFilename(filename: string): string {
-  return `${path.basename(filename, '.tsx')}.d.ts`;
+  return `${path.basename(filename, filename.includes('.tsx') ? '.tsx' : '.jsx')}.d.ts`;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
*Description of changes:*
Removes .jsx extension from generated declaration files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
