### PR TITLE
feat: support type casting for DataStore hooks

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -10,6 +10,7 @@ import {
   useDataStoreCreateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Customer } from \\"../models\\";
+import { schema } from \\"../models/schema\\";
 import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type CreateCustomerButtonProps = React.PropsWithChildren<
@@ -24,6 +25,7 @@ export default function CreateCustomerButton(
   const createCustomerButtonOnClick = useDataStoreCreateAction({
     model: Customer,
     fields: { firstName: \\"Din\\", lastName: \\"Djarin\\" },
+    schema: schema,
   });
   return (
     /* @ts-ignore: TS2322 */
@@ -53,6 +55,7 @@ import {
   useDataStoreDeleteAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Customer } from \\"../models\\";
+import { schema } from \\"../models/schema\\";
 import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type DeleteCustomerButtonProps = React.PropsWithChildren<
@@ -67,6 +70,7 @@ export default function DeleteCustomerButton(
   const deleteCustomerButtonOnClick = useDataStoreDeleteAction({
     model: Customer,
     id: \\"d9887268-47dd-4899-9568-db5809218751\\",
+    schema: schema,
   });
   return (
     /* @ts-ignore: TS2322 */
@@ -96,6 +100,7 @@ import {
   useDataStoreUpdateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Customer } from \\"../models\\";
+import { schema } from \\"../models/schema\\";
 import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type UpdateCustomerButtonProps = React.PropsWithChildren<
@@ -111,6 +116,7 @@ export default function UpdateCustomerButton(
     model: Customer,
     id: \\"d9887268-47dd-4899-9568-db5809218751\\",
     fields: { firstName: \\"Din\\", lastName: \\"Djarin\\" },
+    schema: schema,
   });
   return (
     /* @ts-ignore: TS2322 */
@@ -503,6 +509,7 @@ import {
   useDataStoreCreateAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Customer } from \\"../models\\";
+import { schema } from \\"../models/schema\\";
 import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
 
 export type ComponentWithAuthEventBindingProps = React.PropsWithChildren<
@@ -521,6 +528,7 @@ export default function ComponentWithAuthEventBinding(
       userName: authAttributes[\\"username\\"],
       favoriteIceCream: authAttributes[\\"custom:favorite_icecream\\"],
     },
+    schema: schema,
   });
   return (
     /* @ts-ignore: TS2322 */
@@ -5473,6 +5481,7 @@ import {
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Customer } from \\"../models\\";
+import { schema } from \\"../models/schema\\";
 import { Button, Flex, FlexProps, TextField } from \\"@aws-amplify/ui-react\\";
 
 export type MyFormProps = React.PropsWithChildren<
@@ -5488,6 +5497,7 @@ export default function MyForm(props: MyFormProps): React.ReactElement {
     model: Customer,
     id: \\"d9887268-47dd-4899-9568-db5809218751\\",
     fields: { username: usernameTextFieldValue },
+    schema: schema,
   });
   return (
     /* @ts-ignore: TS2322 */

--- a/packages/codegen-ui-react/lib/imports/import-mapping.ts
+++ b/packages/codegen-ui-react/lib/imports/import-mapping.ts
@@ -19,6 +19,7 @@ export enum ImportSource {
   UI_REACT_INTERNAL = '@aws-amplify/ui-react/internal',
   AMPLIFY_DATASTORE = '@aws-amplify/datastore',
   LOCAL_MODELS = '../models',
+  LOCAL_SCHEMA = '../models/schema',
 }
 
 export enum ImportValue {

--- a/packages/test-generator/integration-test-templates/cypress/integration/workflow-spec.ts
+++ b/packages/test-generator/integration-test-templates/cypress/integration/workflow-spec.ts
@@ -167,18 +167,21 @@ describe('Workflow', () => {
     });
 
     describe('DataStore', () => {
-      it('supports creating a datastore item', () => {
-        cy.get('#user-collection').contains('Din Djarin').should('not.exist');
+      it('supports creating a datastore item, type-casting scalar values', () => {
+        const expected = 'Din Djarin | age: 200 | isLoggedIn: true';
+        cy.get('#user-collection').contains(expected).should('not.exist');
         cy.get('#create-item').click();
-        cy.get('#user-collection').contains('Din Djarin');
+        cy.get('#user-collection').contains(expected);
       });
 
-      it('supports updating a datastore item', () => {
-        cy.get('#user-collection').contains('UpdateMe Me');
-        cy.get('#user-collection').contains('Moff Gideon').should('not.exist');
+      it('supports updating a datastore item, type-casting scalar values', () => {
+        const before = 'UpdateMe Me';
+        const after = 'Moff Gideon | age: 200 | isLoggedIn: true';
+        cy.get('#user-collection').contains(before);
+        cy.get('#user-collection').contains(after).should('not.exist');
         cy.get('#update-item').click();
-        cy.get('#user-collection').contains('UpdateMe Me').should('not.exist');
-        cy.get('#user-collection').contains('Moff Gideon');
+        cy.get('#user-collection').contains(before).should('not.exist');
+        cy.get('#user-collection').contains(after);
       });
 
       it('supports deleting a datastore item', () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { AmplifyProvider } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
 import { DataStore } from 'aws-amplify';
@@ -128,8 +128,13 @@ const initializeListingTestData = async (): Promise<void> => {
 
 export default function ComponentTests() {
   const [isInitialized, setInitialized] = useState(false);
+  const initializeStarted = useRef(false);
+
   useEffect(() => {
     const initializeTestUserData = async () => {
+      if (initializeStarted.current) {
+        return;
+      }
       // DataStore.clear() doesn't appear to reliably work in this scenario.
       indexedDB.deleteDatabase('amplify-datastore');
       await Promise.all([initializeUserTestData(), initializeListingTestData()]);
@@ -142,6 +147,7 @@ export default function ComponentTests() {
     };
 
     initializeTestUserData();
+    initializeStarted.current = true;
   }, []);
 
   if (!isInitialized) {

--- a/packages/test-generator/lib/components/collections/simpleUserCollection.json
+++ b/packages/test-generator/lib/components/collections/simpleUserCollection.json
@@ -34,6 +34,24 @@
                 "property": "user",
                 "field": "lastName"
               }
+            },
+            {
+              "value": " | age: "
+            },
+            {
+              "collectionBindingProperties": {
+                "property": "user",
+                "field": "age"
+              }
+            },
+            {
+              "value": " | isLoggedIn: "
+            },
+            {
+              "collectionBindingProperties": {
+                "property": "user",
+                "field": "isLoggedIn"
+              }
             }
           ]
         }

--- a/packages/test-generator/lib/components/workflow/dataStoreActions.json
+++ b/packages/test-generator/lib/components/workflow/dataStoreActions.json
@@ -33,6 +33,12 @@
               },
               "lastName": {
                 "value": "Djarin"
+              },
+              "isLoggedIn": {
+                "value": "true"
+              },
+              "age": {
+                "value": "200"
               }
             }
           }
@@ -66,6 +72,12 @@
               },
               "lastName": {
                 "value": "Gideon"
+              },
+              "isLoggedIn": {
+                "value": "true"
+              },
+              "age": {
+                "value": "200"
               }
             }
           }


### PR DESCRIPTION
*Description of changes:*
Support type casting for Datastore hooks introduced in UI Components version 2.13.0 (related PR)
by passing local schema object as param to the hooks.

*Additional changes:*
Some tests involving DataStore were broken before these changes were introduced (reproducible on another dev machine).
RCA pending but fixes introduced with current understanding of the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
