### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.2...v2.2.0) (2022-04-13)
+
+
+### Bug Fixes
+
+* change tabs to buttons per UI release 2.9.0 ([1db38f3](https://github.com/aws-amplify/amplify-codegen-ui/commit/1db38f3fd4f581a7b91ae782cb272a801ac78364))
+* make complex integ tests agnostic to style order ([b8e9922](https://github.com/aws-amplify/amplify-codegen-ui/commit/b8e9922e565bcba2a1c10d6def2d5a4996c87ec7))
+* remove hook from conditional statement ([#455](https://github.com/aws-amplify/amplify-codegen-ui/issues/455)) ([5b05377](https://github.com/aws-amplify/amplify-codegen-ui/commit/5b053772e3e018957c47c28962d09f843bdaad84))
+* remove jsx ext from declaration file ext ([#458](https://github.com/aws-amplify/amplify-codegen-ui/issues/458)) ([e4062c8](https://github.com/aws-amplify/amplify-codegen-ui/commit/e4062c8760b3c850125c7ab5c6ae7d4e2258c598))
+
+
+### Features
+
+* rev required minimum version of ui-react ([#462](https://github.com/aws-amplify/amplify-codegen-ui/issues/462)) ([d33f873](https://github.com/aws-amplify/amplify-codegen-ui/commit/d33f8736d4a51344a6d5e4f2b8cbbadca6e17b83))
+* support type casting for DataStore hooks ([#460](https://github.com/aws-amplify/amplify-codegen-ui/issues/460)) ([79953c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/79953c5d7dfd20d68238089fe9900532f1e9e0e6))
+
+
+
+
+
 ## [2.1.2](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.1...v2.1.2) (2022-03-03)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "exact": true,
-  "version": "2.1.2",
+  "version": "2.2.0",
   "command": {
     "version": {
       "message": "chore(release): %s"

--- a/packages/codegen-ui-react/CHANGELOG.md
+++ b/packages/codegen-ui-react/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.2...v2.2.0) (2022-04-13)
+
+
+### Bug Fixes
+
+* remove hook from conditional statement ([#455](https://github.com/aws-amplify/amplify-codegen-ui/issues/455)) ([5b05377](https://github.com/aws-amplify/amplify-codegen-ui/commit/5b053772e3e018957c47c28962d09f843bdaad84))
+* remove jsx ext from declaration file ext ([#458](https://github.com/aws-amplify/amplify-codegen-ui/issues/458)) ([e4062c8](https://github.com/aws-amplify/amplify-codegen-ui/commit/e4062c8760b3c850125c7ab5c6ae7d4e2258c598))
+
+
+### Features
+
+* rev required minimum version of ui-react ([#462](https://github.com/aws-amplify/amplify-codegen-ui/issues/462)) ([d33f873](https://github.com/aws-amplify/amplify-codegen-ui/commit/d33f8736d4a51344a6d5e4f2b8cbbadca6e17b83))
+* support type casting for DataStore hooks ([#460](https://github.com/aws-amplify/amplify-codegen-ui/issues/460)) ([79953c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/79953c5d7dfd20d68238089fe9900532f1e9e0e6))
+
+
+
+
+
 ## [2.1.2](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.1...v2.1.2) (2022-03-03)
 
 

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/codegen-ui-react",
-	"version": "2.1.2",
+	"version": "2.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Amplify UI React code generation implementation",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -26,7 +26,7 @@
     "semver": "^7.3.5"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.1.2",
+    "@aws-amplify/codegen-ui": "2.2.0",
     "@typescript/vfs": "~1.3.5",
     "typescript": "~4.4.4"
   },

--- a/packages/codegen-ui/CHANGELOG.md
+++ b/packages/codegen-ui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.2...v2.2.0) (2022-04-13)
+
+**Note:** Version bump only for package @aws-amplify/codegen-ui
+
+
+
+
+
 ## [2.1.2](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.1...v2.1.2) (2022-03-03)
 
 

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/codegen-ui",
-	"version": "2.1.2",
+	"version": "2.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "generic component code generation interface definitions",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",

--- a/packages/test-generator/CHANGELOG.md
+++ b/packages/test-generator/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.2.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.2...v2.2.0) (2022-04-13)
+
+
+### Bug Fixes
+
+* change tabs to buttons per UI release 2.9.0 ([1db38f3](https://github.com/aws-amplify/amplify-codegen-ui/commit/1db38f3fd4f581a7b91ae782cb272a801ac78364))
+* make complex integ tests agnostic to style order ([b8e9922](https://github.com/aws-amplify/amplify-codegen-ui/commit/b8e9922e565bcba2a1c10d6def2d5a4996c87ec7))
+* remove jsx ext from declaration file ext ([#458](https://github.com/aws-amplify/amplify-codegen-ui/issues/458)) ([e4062c8](https://github.com/aws-amplify/amplify-codegen-ui/commit/e4062c8760b3c850125c7ab5c6ae7d4e2258c598))
+
+
+### Features
+
+* support type casting for DataStore hooks ([#460](https://github.com/aws-amplify/amplify-codegen-ui/issues/460)) ([79953c5](https://github.com/aws-amplify/amplify-codegen-ui/commit/79953c5d7dfd20d68238089fe9900532f1e9e0e6))
+
+
+
+
+
 ## [2.1.2](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.1.1...v2.1.2) (2022-03-03)
 
 

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/codegen-ui-test-generator",
-	"version": "2.1.2",
+	"version": "2.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Test generator with sample JSON files",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -19,8 +19,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.1.2",
-    "@aws-amplify/codegen-ui-react": "2.1.2",
+    "@aws-amplify/codegen-ui": "2.2.0",
+    "@aws-amplify/codegen-ui-react": "2.2.0",
     "@types/node": "^15.12.1",
     "loglevel": "^1.7.1",
     "typescript": "^4.2.4"


### PR DESCRIPTION
*Description of changes:*
- Rename the “.jsx.d.ts” files to just “.d.ts” file in order for VS code to give Intellisense
- Support type casting in DataStore hooks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
