### PR TITLE
chore: add form-related types

### DIFF
--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -13,14 +13,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-export * from './actions';
-export * from './components';
-export * from './bindings';
-export * from './events';
-export * from './figma';
-export * from './properties';
-export * from './theme';
-export * from './relational-operator';
-export * from './studio-schema';
-export * from './form';
-export * from './data';
+type FieldType = string | { model: string } | { nonModel: string } | { enum: string };
+
+export type DataStoreModelField = {
+  name: string;
+  type: FieldType;
+  isReadOnly: boolean;
+  isRequired: boolean;
+  isArray: boolean;
+};

--- a/packages/codegen-ui/lib/types/form/fields.ts
+++ b/packages/codegen-ui/lib/types/form/fields.ts
@@ -1,0 +1,46 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { StudioFieldPosition } from './position';
+import { StudioFieldInputConfig } from './input-config';
+
+/**
+ * Field configurations for StudioForm
+ */
+type StudioFieldConfig = {
+  label?: string;
+
+  position?: StudioFieldPosition;
+};
+
+/**
+ * If a field is excluded, it should have no other properties.
+ */
+type ExcludedStudioFieldConfig = {
+  excluded: true;
+};
+
+type StudioGenericFieldConfig = {
+  /**
+   * The configuration for what type of input is used.
+   */
+  inputType?: StudioFieldInputConfig;
+} & StudioFieldConfig;
+
+export type StudioFormFieldConfig = StudioGenericFieldConfig | ExcludedStudioFieldConfig;
+
+export type StudioFormFields = {
+  [field: string]: StudioFormFieldConfig;
+};

--- a/packages/codegen-ui/lib/types/form/form-definition.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition.ts
@@ -13,14 +13,27 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-export * from './actions';
-export * from './components';
-export * from './bindings';
-export * from './events';
-export * from './figma';
-export * from './properties';
-export * from './theme';
-export * from './relational-operator';
-export * from './studio-schema';
-export * from './form';
-export * from './data';
+import { StudioFormStyle } from './style';
+
+export type FormDefinitionElementProps = {
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  label?: string;
+  placeholder?: string;
+  minValue?: number;
+  maxValue?: number;
+  step?: number;
+  level?: number;
+  text?: string;
+};
+
+export type FormDefinition = {
+  form: {
+    props: {
+      layoutStyle: StudioFormStyle;
+    };
+  };
+  elements: { [element: string]: { componentType: string; dataType?: string; props: FormDefinitionElementProps } };
+  buttons: { [key: string]: string };
+  elementMatrix: string[][];
+};

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -1,0 +1,44 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { StudioFormStyle } from './style';
+import { StudioFormFields, StudioFormFieldConfig } from './fields';
+import { SectionalElement } from './sectional-element';
+import { FormDefinition, FormDefinitionElementProps } from './form-definition';
+
+/**
+ * Data type definition for StudioForm
+ */
+type StudioFormDataType = {
+  dataSourceType: 'DataStore' | 'Custom';
+
+  dataTypeName: string;
+};
+
+/**
+ * This is the base type for all StudioForms
+ */
+export type StudioForm = {
+  dataType: StudioFormDataType;
+
+  fields: StudioFormFields;
+
+  sectionalElements: SectionalElement[];
+
+  style: StudioFormStyle;
+};
+
+export type { StudioFormStyle, SectionalElement, StudioFormFieldConfig, FormDefinition, FormDefinitionElementProps };

--- a/packages/codegen-ui/lib/types/form/input-config.ts
+++ b/packages/codegen-ui/lib/types/form/input-config.ts
@@ -1,0 +1,59 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+type StudioFieldBaseConfig = {
+  required?: boolean;
+
+  readOnly?: boolean;
+};
+
+type StudioFieldTextFieldConfig = {
+  type: 'TextField';
+
+  placeholder?: string;
+};
+
+type StudioFieldSelectListFieldConfig = {
+  type: 'SelectField';
+
+  placeholder?: string;
+
+  valueMappings: { value: string; displayValue: string }[];
+};
+
+type StudioFieldRadioListFieldConfig = {
+  type: 'RadioGroupField';
+
+  valueMappings: { value: string; displayValue: string }[];
+};
+
+type StudioFieldSliderFieldConfig = {
+  type: 'SliderField';
+
+  minValue: number;
+
+  maxValue: number;
+
+  step: number;
+};
+
+export type StudioFieldInputConfig = (
+  | StudioFieldTextFieldConfig
+  | StudioFieldSelectListFieldConfig
+  | StudioFieldRadioListFieldConfig
+  | StudioFieldSliderFieldConfig
+) &
+  StudioFieldBaseConfig;

--- a/packages/codegen-ui/lib/types/form/position.ts
+++ b/packages/codegen-ui/lib/types/form/position.ts
@@ -13,14 +13,4 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-export * from './actions';
-export * from './components';
-export * from './bindings';
-export * from './events';
-export * from './figma';
-export * from './properties';
-export * from './theme';
-export * from './relational-operator';
-export * from './studio-schema';
-export * from './form';
-export * from './data';
+export type StudioFieldPosition = { fixed: 'first' } | { rightOf: string } | { below: string };

--- a/packages/codegen-ui/lib/types/form/sectional-element.ts
+++ b/packages/codegen-ui/lib/types/form/sectional-element.ts
@@ -13,14 +13,30 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-export * from './actions';
-export * from './components';
-export * from './bindings';
-export * from './events';
-export * from './figma';
-export * from './properties';
-export * from './theme';
-export * from './relational-operator';
-export * from './studio-schema';
-export * from './form';
-export * from './data';
+import { StudioFieldPosition } from './position';
+/**
+ * Sectional elements are visual helpers for the form. They don't have any data associated with them.
+ */
+type HeadingSectionalElement = {
+  type: 'Heading';
+
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+
+  text: string;
+};
+
+type TextSectionalElement = {
+  type: 'Text';
+
+  text: string;
+};
+
+type DividerSectionalElement = {
+  type: 'Divider';
+};
+
+export type SectionalElement = { position: StudioFieldPosition; name: string } & (
+  | HeadingSectionalElement
+  | DividerSectionalElement
+  | TextSectionalElement
+);

--- a/packages/codegen-ui/lib/types/form/style.ts
+++ b/packages/codegen-ui/lib/types/form/style.ts
@@ -13,14 +13,21 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-export * from './actions';
-export * from './components';
-export * from './bindings';
-export * from './events';
-export * from './figma';
-export * from './properties';
-export * from './theme';
-export * from './relational-operator';
-export * from './studio-schema';
-export * from './form';
-export * from './data';
+type FormStyleConfigCommon = {
+  tokenReference?: string;
+};
+
+type FormStyleConfig = {
+  value?: string;
+} & FormStyleConfigCommon;
+
+type FormAlignmentConfig = {
+  value?: 'left' | 'center' | 'right';
+} & FormStyleConfigCommon;
+
+export type StudioFormStyle = {
+  horizontalGap?: FormStyleConfig;
+  verticalGap?: FormStyleConfig;
+  outerPadding?: FormStyleConfig;
+  alignment?: FormAlignmentConfig;
+};


### PR DESCRIPTION
*Description of changes:*
As we start codegen work for rendering customer forms, we need to have the types ready.
So far, only the ones that were necessary for the current work-in-progress mapper were added.
You may find, for example, that types for custom validations are not yet there.
They will be added as we understand the process of mapping them better.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
