### PR TITLE
feat: add base form to component mapper with updated datastore types

### DIFF
--- a/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
@@ -1,0 +1,114 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { Schema } from '@aws-amplify/datastore';
+
+export const postSchema: Schema = {
+  models: {
+    Post: {
+      name: 'Post',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        caption: {
+          name: 'caption',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        username: {
+          name: 'username',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        post_url: {
+          name: 'post_url',
+          isArray: false,
+          type: 'AWSURL',
+          isRequired: false,
+          attributes: [],
+        },
+        profile_url: {
+          name: 'profile_url',
+          isArray: false,
+          type: 'AWSURL',
+          isRequired: false,
+          attributes: [],
+        },
+        status: {
+          name: 'status',
+          isArray: false,
+          type: {
+            enum: 'PostStatus',
+          },
+          isRequired: false,
+          attributes: [],
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'Posts',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'auth',
+          properties: {
+            rules: [
+              {
+                allow: 'private',
+                provider: 'iam',
+                operations: ['create', 'update', 'delete', 'read'],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  enums: {
+    PostStatus: {
+      name: 'PostStatus',
+      values: ['PENDING', 'POSTED', 'IN_REVIEW'],
+    },
+  },
+  nonModels: {},
+  version: '000000',
+};

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/form-to-component.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/form-to-component.test.ts
@@ -1,0 +1,47 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { postSchema } from '../__utils__/mock-schemas';
+import { mapFormToComponent } from '../../generate-form-definition/form-to-component';
+import { StudioForm } from '../../types';
+
+describe('formToComponent', () => {
+  it('should map datastore model fields', () => {
+    const myForm: StudioForm = {
+      name: 'mySampleForm',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Post' },
+      fields: {},
+      sectionalElements: [],
+      style: {},
+    };
+
+    // shallow test of mapper
+    const component = mapFormToComponent(myForm, postSchema.models.Post);
+    expect(component).toBeDefined();
+    expect(component.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'mySampleFormGrid',
+          componentType: 'Grid',
+          properties: expect.objectContaining({
+            columnGap: { value: '1rem' },
+            rowGap: { value: '1rem' },
+          }),
+          children: expect.any(Array),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/index.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/index.test.ts
@@ -19,6 +19,7 @@ describe('generateFormDefinition', () => {
   it('should map DataStore model fields', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'sampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: {},
         sectionalElements: [],
@@ -38,6 +39,7 @@ describe('generateFormDefinition', () => {
   it('should override field configurations from DataStore', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: [],
@@ -57,6 +59,7 @@ describe('generateFormDefinition', () => {
   it('should not add overrides to the matrix', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: [],
@@ -71,6 +74,7 @@ describe('generateFormDefinition', () => {
   it('should add fields that do not exist in DataStore', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: [],
@@ -86,6 +90,7 @@ describe('generateFormDefinition', () => {
   it('should add fields that do not exist in DataStore to the matrix', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: [],
@@ -99,6 +104,7 @@ describe('generateFormDefinition', () => {
   it('should add sectional elements', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: {},
         sectionalElements: [
@@ -118,6 +124,7 @@ describe('generateFormDefinition', () => {
     const style = { verticalGap: { value: '10px' }, horizontalGap: { tokenReference: 'color.primary.solid' } };
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: {},
         sectionalElements: [],
@@ -131,6 +138,7 @@ describe('generateFormDefinition', () => {
   it('should not leave empty rows in the matrix', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: {
           weight: { excluded: true },
@@ -156,6 +164,7 @@ describe('generateFormDefinition', () => {
   it('should correctly map positions', () => {
     const formDefinition = generateFormDefinition({
       form: {
+        name: 'mySampleForm',
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: {
           weight: { position: { rightOf: 'age' } },
@@ -182,6 +191,7 @@ describe('generateFormDefinition', () => {
 it('should requeue if related element is not yet found', () => {
   const formDefinition = generateFormDefinition({
     form: {
+      name: 'mySampleForm',
       dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
       fields: {
         color: { position: { below: 'name' } },
@@ -204,6 +214,7 @@ it('should requeue if related element is not yet found', () => {
 it('should handle fields without position', () => {
   const formDefinition = generateFormDefinition({
     form: {
+      name: 'mySampleForm',
       dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
       fields: {
         color: { position: { below: 'name' } },

--- a/packages/codegen-ui/lib/generate-form-definition/form-to-component.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/form-to-component.ts
@@ -1,0 +1,178 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import {
+  SchemaModel,
+  ModelFields,
+  isGraphQLScalarType,
+  StudioComponent,
+  StudioForm,
+  StudioComponentChild,
+  StudioComponentProperty,
+} from '../types';
+
+// map the datastore schema fields into form fields
+export const mapFieldsToForm = (fields: ModelFields) => {
+  const formFields: StudioComponentChild[] = [];
+  Object.entries(fields).forEach(([fieldName, fieldValue]) => {
+    // TODO: expand studio component child to also support other non text fields
+    if (isGraphQLScalarType(fieldValue.type) && !fieldValue.isArray) {
+      formFields.push({
+        name: `${fieldName}Field`,
+        componentType: 'TextField',
+        properties: {
+          name: {
+            value: fieldName,
+          },
+          label: {
+            value: fieldName,
+          },
+          placeholder: {
+            value: `${fieldValue.type}`,
+          },
+          ...(fieldValue.isRequired && {
+            required: {
+              value: 'true',
+              type: 'boolean',
+            },
+          }),
+        },
+      });
+    }
+  });
+
+  return formFields;
+};
+
+export const mapParentGrid = (name: string, children: StudioComponentChild[] = []): StudioComponentChild => {
+  return {
+    name: `${name}Grid`,
+    componentType: 'Grid',
+    properties: {
+      columnGap: {
+        value: '1rem',
+      },
+      rowGap: {
+        value: '1rem',
+      },
+    },
+    children,
+  };
+};
+
+export const ctaButtonConfig = (): StudioComponentChild => {
+  return {
+    name: 'CTAFlex',
+    componentType: 'Flex',
+    properties: {
+      justifyContent: {
+        value: 'space-between',
+      },
+      marginTop: {
+        value: '1rem',
+      },
+    },
+    children: [
+      {
+        componentType: 'Button',
+        name: 'CancelButton',
+        properties: {
+          label: {
+            value: 'Cancel',
+          },
+          type: {
+            value: 'button',
+          },
+        },
+      },
+      {
+        componentType: 'Flex',
+        name: 'SubmitAndResetFlex',
+        properties: {},
+        children: [
+          {
+            componentType: 'Button',
+            name: 'ClearButton',
+            properties: {
+              label: {
+                value: 'Clear',
+              },
+              type: {
+                value: 'reset',
+              },
+            },
+          },
+          {
+            componentType: 'Button',
+            name: 'onSubmitDataStore',
+            properties: {
+              label: {
+                value: 'Submit',
+              },
+              type: {
+                value: 'submit',
+              },
+              variation: {
+                value: 'primary',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+};
+
+export const mapFormToComponent = (form: StudioForm, dataSchema: SchemaModel): StudioComponent => {
+  // here we can merge the datastore schema with the form
+  // right now it's only creating fields from the existing datastore schema
+  // TODO: manage merging fields from form and datastore
+  const childrenFormFields = mapFieldsToForm(dataSchema.fields);
+
+  const component: StudioComponent = {
+    name: form.name,
+    properties: {},
+    bindingProperties: {
+      onCancel: {
+        type: 'Event',
+      },
+    },
+    events: {
+      onSubmit: {
+        action: 'Amplify.DataStoreCreateItemAction',
+        parameters: {
+          model: form.dataType.dataTypeName,
+          fields: childrenFormFields.reduce(
+            (prev: { [propertyName: string]: StudioComponentProperty }, { name, properties }) => {
+              return {
+                ...prev,
+                [(properties.name as any).value]: {
+                  componentName: name,
+                  property: 'value',
+                },
+              };
+            },
+            {},
+          ),
+        },
+      },
+    },
+    // codegen will default to rendering the component with this name
+    componentType: 'form',
+    children: [mapParentGrid(form.name, childrenFormFields), ctaButtonConfig()],
+  };
+
+  return component;
+};

--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -13,6 +13,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+
+// exporting types and scalar functions from aws-amplify
+// as these will be used when loading in dataschema for form generation
+export type { SchemaModel, ModelFields } from '@aws-amplify/datastore';
+export { isGraphQLScalarType } from '@aws-amplify/datastore';
+
 type FieldType = string | { model: string } | { nonModel: string } | { enum: string };
 
 export type DataStoreModelField = {

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -32,6 +32,8 @@ type StudioFormDataType = {
  * This is the base type for all StudioForms
  */
 export type StudioForm = {
+  name: string;
+
   dataType: StudioFormDataType;
 
   fields: StudioFormFields;

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -20,6 +20,9 @@
   "dependencies": {
     "yup": "^0.32.11"
   },
+  "peerDependencies": {
+    "@aws-amplify/datastore": "^3.7.8"
+  },
   "jest": {
     "verbose": false,
     "preset": "ts-jest",


### PR DESCRIPTION
*Description of changes:*
- stagging base form to component mapper
- added additional types from datastore
  - added as peerDep 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
