### PR TITLE
chore: have form definition mapper accept dataStore schema

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -17,6 +17,8 @@ import { generateFormDefinition } from '../../generate-form-definition';
 
 describe('generateFormDefinition', () => {
   it('should map DataStore model fields', () => {
+    const field1 = { name: 'name', type: 'String' as const, isReadOnly: false, isRequired: true, isArray: false };
+
     const formDefinition = generateFormDefinition({
       form: {
         name: 'sampleForm',
@@ -26,7 +28,21 @@ describe('generateFormDefinition', () => {
         sectionalElements: {},
         style: {},
       },
-      modelInfo: { fields: [{ name: 'name', type: 'String', isReadOnly: false, isRequired: true, isArray: false }] },
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {
+                [field1.name]: field1,
+              },
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
+      },
     });
     expect(formDefinition.elements).toStrictEqual({
       name: {
@@ -37,6 +53,8 @@ describe('generateFormDefinition', () => {
   });
 
   it('should override field configurations from DataStore', () => {
+    const field1 = { name: 'weight', type: 'Float' as const, isReadOnly: false, isRequired: true, isArray: false };
+
     const formDefinition = generateFormDefinition({
       form: {
         name: 'mySampleForm',
@@ -46,7 +64,21 @@ describe('generateFormDefinition', () => {
         sectionalElements: {},
         style: {},
       },
-      modelInfo: { fields: [{ name: 'weight', type: 'Float', isReadOnly: false, isRequired: true, isArray: false }] },
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {
+                [field1.name]: field1,
+              },
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
+      },
     });
     expect(formDefinition.elements).toStrictEqual({
       weight: {
@@ -57,6 +89,8 @@ describe('generateFormDefinition', () => {
   });
 
   it('should not add overrides to the matrix', () => {
+    const field1 = { name: 'weight', type: 'Float' as const, isReadOnly: false, isRequired: true, isArray: false };
+
     const formDefinition = generateFormDefinition({
       form: {
         name: 'mySampleForm',
@@ -66,7 +100,21 @@ describe('generateFormDefinition', () => {
         sectionalElements: {},
         style: {},
       },
-      modelInfo: { fields: [{ name: 'weight', type: 'Float', isReadOnly: false, isRequired: true, isArray: false }] },
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {
+                [field1.name]: field1,
+              },
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
+      },
     });
 
     expect(formDefinition.elementMatrix).toStrictEqual([['weight']]);
@@ -82,7 +130,19 @@ describe('generateFormDefinition', () => {
         sectionalElements: {},
         style: {},
       },
-      modelInfo: { fields: [] },
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {},
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
+      },
     });
     expect(formDefinition.elements).toStrictEqual({
       weight: { componentType: 'SliderField', props: { min: 1, max: 100, step: 2, label: 'Label' } },
@@ -99,12 +159,26 @@ describe('generateFormDefinition', () => {
         sectionalElements: {},
         style: {},
       },
-      modelInfo: { fields: [] },
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {},
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
+      },
     });
     expect(formDefinition.elementMatrix).toStrictEqual([['weight']]);
   });
 
   it('should add sectional elements', () => {
+    const field1 = { name: 'weight', type: 'Float' as const, isReadOnly: false, isRequired: true, isArray: false };
+
     const formDefinition = generateFormDefinition({
       form: {
         name: 'mySampleForm',
@@ -116,7 +190,21 @@ describe('generateFormDefinition', () => {
         },
         style: {},
       },
-      modelInfo: { fields: [{ name: 'weight', type: 'Float', isReadOnly: false, isRequired: true, isArray: false }] },
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {
+                [field1.name]: field1,
+              },
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
+      },
     });
     expect(formDefinition.elements.Heading123).toStrictEqual({
       componentType: 'Heading',
@@ -139,12 +227,28 @@ describe('generateFormDefinition', () => {
         sectionalElements: {},
         style,
       },
-      modelInfo: { fields: [] },
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {},
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
+      },
     });
     expect(formDefinition.form.layoutStyle).toStrictEqual(style);
   });
 
   it('should not leave empty rows in the matrix', () => {
+    const field1 = { name: 'name', type: 'String' as const, isReadOnly: false, isRequired: true, isArray: false };
+    const field2 = { name: 'weight', type: 'Float' as const, isReadOnly: false, isRequired: true, isArray: false };
+    const field3 = { name: 'age', type: 'Int' as const, isReadOnly: false, isRequired: true, isArray: false };
+
     const formDefinition = generateFormDefinition({
       form: {
         name: 'mySampleForm',
@@ -161,18 +265,32 @@ describe('generateFormDefinition', () => {
 
         style: {},
       },
-      modelInfo: {
-        fields: [
-          { name: 'name', type: 'String', isReadOnly: false, isRequired: true, isArray: false },
-          { name: 'weight', type: 'Float', isReadOnly: false, isRequired: true, isArray: false },
-          { name: 'age', type: 'Int', isReadOnly: false, isRequired: true, isArray: false },
-        ],
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {
+                [field1.name]: field1,
+                [field2.name]: field2,
+                [field3.name]: field3,
+              },
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
       },
     });
     expect(formDefinition.elementMatrix).toStrictEqual([['Heading123']]);
   });
 
   it('should correctly map positions', () => {
+    const field1 = { name: 'name', type: 'String' as const, isReadOnly: false, isRequired: true, isArray: false };
+    const field2 = { name: 'weight', type: 'Float' as const, isReadOnly: false, isRequired: true, isArray: false };
+    const field3 = { name: 'age', type: 'Int' as const, isReadOnly: false, isRequired: true, isArray: false };
+
     const formDefinition = generateFormDefinition({
       form: {
         name: 'mySampleForm',
@@ -189,12 +307,22 @@ describe('generateFormDefinition', () => {
 
         style: {},
       },
-      modelInfo: {
-        fields: [
-          { name: 'name', type: 'String', isReadOnly: false, isRequired: true, isArray: false },
-          { name: 'weight', type: 'Float', isReadOnly: false, isRequired: true, isArray: false },
-          { name: 'age', type: 'Int', isReadOnly: false, isRequired: true, isArray: false },
-        ],
+      dataStore: {
+        schema: {
+          models: {
+            Dog: {
+              name: 'Dog',
+              pluralName: 'Dogs',
+              fields: {
+                [field1.name]: field1,
+                [field2.name]: field2,
+                [field3.name]: field3,
+              },
+            },
+          },
+          enums: {},
+          version: 'version',
+        },
       },
     });
     expect(formDefinition.elementMatrix).toStrictEqual([['Heading123'], ['name', 'age', 'weight']]);
@@ -219,8 +347,18 @@ it('should requeue if related element is not yet found', () => {
 
       style: {},
     },
-    modelInfo: {
-      fields: [],
+    dataStore: {
+      schema: {
+        models: {
+          Dog: {
+            name: 'Dog',
+            pluralName: 'Dogs',
+            fields: {},
+          },
+        },
+        enums: {},
+        version: 'version',
+      },
     },
   });
   expect(formDefinition.elementMatrix).toStrictEqual([['Heading123'], ['name', 'age', 'weight'], ['color']]);
@@ -245,8 +383,18 @@ it('should handle fields without position', () => {
 
       style: {},
     },
-    modelInfo: {
-      fields: [],
+    dataStore: {
+      schema: {
+        models: {
+          Dog: {
+            name: 'Dog',
+            pluralName: 'Dogs',
+            fields: {},
+          },
+        },
+        enums: {},
+        version: 'version',
+      },
     },
   });
   expect(formDefinition.elementMatrix).toStrictEqual([['Heading123'], ['name', 'age', 'weight'], ['color'], ['bark']]);
@@ -263,8 +411,18 @@ it('should fill out styles using defaults', () => {
 
       style: {},
     },
-    modelInfo: {
-      fields: [],
+    dataStore: {
+      schema: {
+        models: {
+          Dog: {
+            name: 'Dog',
+            pluralName: 'Dogs',
+            fields: {},
+          },
+        },
+        enums: {},
+        version: 'version',
+      },
     },
   });
 

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/datastore-model.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/datastore-model.test.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 
-import { addDataStoreModelField } from '../../../generate-form-definition/helpers';
+import { addDataStoreModelFields } from '../../../generate-form-definition/helpers';
 import { FormDefinition, ModelFieldsConfigs } from '../../../types';
 
 describe('addDataStoreModelField', () => {
@@ -26,11 +26,25 @@ describe('addDataStoreModelField', () => {
       elementMatrix: [],
     };
 
-    const dataStoreModelField = { name: 'name', type: 'String', isReadOnly: false, isRequired: false, isArray: false };
+    const field1 = { name: 'name', type: 'String' as const, isReadOnly: false, isRequired: false, isArray: false };
+
+    const schema = {
+      models: {
+        Dog: {
+          name: 'Dog',
+          pluralName: 'Dogs',
+          fields: {
+            [field1.name]: field1,
+          },
+        },
+      },
+      enums: {},
+      version: 'version',
+    };
 
     const modelFieldsConfigs: ModelFieldsConfigs = {};
 
-    addDataStoreModelField(formDefinition, modelFieldsConfigs, dataStoreModelField);
+    addDataStoreModelFields({ formDefinition, modelFieldsConfigs, schema, modelName: 'Dog' });
 
     expect(formDefinition.elementMatrix).toStrictEqual([['name']]);
     expect(modelFieldsConfigs.name).toStrictEqual({
@@ -47,9 +61,25 @@ describe('addDataStoreModelField', () => {
       elementMatrix: [],
     };
 
-    const dataStoreModelField = { name: 'name', type: 'String', isReadOnly: false, isRequired: false, isArray: true };
+    const field1 = { name: 'name', type: 'String' as const, isReadOnly: false, isRequired: false, isArray: true };
 
-    expect(() => addDataStoreModelField(formDefinition, {}, dataStoreModelField)).toThrow();
+    const schema = {
+      models: {
+        Dog: {
+          name: 'Dog',
+          pluralName: 'Dogs',
+          fields: {
+            [field1.name]: field1,
+          },
+        },
+      },
+      enums: {},
+      version: 'version',
+    };
+
+    const modelFieldsConfigs: ModelFieldsConfigs = {};
+
+    expect(() => addDataStoreModelFields({ formDefinition, modelFieldsConfigs, schema, modelName: 'Dog' })).toThrow();
   });
 
   it('should throw if there is no default component', () => {
@@ -60,14 +90,30 @@ describe('addDataStoreModelField', () => {
       elementMatrix: [],
     };
 
-    const dataStoreModelField = {
+    const field1 = {
       name: 'name',
-      type: 'ErrantType',
+      type: 'ErrantType' as any,
       isReadOnly: false,
       isRequired: false,
       isArray: false,
     };
 
-    expect(() => addDataStoreModelField(formDefinition, {}, dataStoreModelField)).toThrow();
+    const schema = {
+      models: {
+        Dog: {
+          name: 'Dog',
+          pluralName: 'Dogs',
+          fields: {
+            [field1.name]: field1,
+          },
+        },
+      },
+      enums: {},
+      version: 'version',
+    };
+
+    const modelFieldsConfigs: ModelFieldsConfigs = {};
+
+    expect(() => addDataStoreModelFields({ formDefinition, modelFieldsConfigs, schema, modelName: 'Dog' })).toThrow();
   });
 });

--- a/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
@@ -16,7 +16,7 @@
 
 import {
   findIndices,
-  addDataStoreModelField,
+  addDataStoreModelFields,
   removeFromMatrix,
   removeAndReturnItemOnward,
   mapStyles,
@@ -25,12 +25,12 @@ import {
 } from './helpers';
 import {
   StudioForm,
-  DataStoreModelField,
   SectionalElement,
   StudioFormFieldConfig,
   FormDefinition,
   StudioGenericFieldConfig,
   ModelFieldsConfigs,
+  Schema,
 } from '../types';
 
 /**
@@ -42,10 +42,10 @@ import {
  */
 export function generateFormDefinition({
   form,
-  modelInfo,
+  dataStore,
 }: {
   form: StudioForm;
-  modelInfo?: { fields: DataStoreModelField[] };
+  dataStore?: { schema: Schema };
 }): FormDefinition {
   const formDefinition: FormDefinition = {
     form: { layoutStyle: {} },
@@ -55,9 +55,12 @@ export function generateFormDefinition({
   };
 
   const modelFieldsConfigs: ModelFieldsConfigs = {};
-  if (modelInfo) {
-    modelInfo.fields.forEach((field) => {
-      addDataStoreModelField(formDefinition, modelFieldsConfigs, field);
+  if (dataStore && form.dataType.dataSourceType === 'DataStore') {
+    addDataStoreModelFields({
+      formDefinition,
+      schema: dataStore.schema,
+      modelFieldsConfigs,
+      modelName: form.dataType.dataTypeName,
     });
   }
 

--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -16,15 +16,5 @@
 
 // exporting types and scalar functions from aws-amplify
 // as these will be used when loading in dataschema for form generation
-export type { SchemaModel, ModelFields } from '@aws-amplify/datastore';
+export type { SchemaModel, ModelFields, Schema } from '@aws-amplify/datastore';
 export { isGraphQLScalarType } from '@aws-amplify/datastore';
-
-type FieldType = string | { model: string } | { nonModel: string } | { enum: string };
-
-export type DataStoreModelField = {
-  name: string;
-  type: FieldType;
-  isReadOnly: boolean;
-  isRequired: boolean;
-  isArray: boolean;
-};


### PR DESCRIPTION
*Description of changes:*
Currently, `generateFormDefinition` accepts DataStore fields of a single model.
We are finding now that we need much more information about DataStore to map a single form, including:
- nonModels
- Enums
- join tables
- information about fields like associations and connectionType that are not included in the field type we were using.

So this PR has the helper accept the schema (of DataStore `Schema` type) instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
