### PR TITLE
fix: rename Slot to Amplify.Slot

### DIFF
--- a/packages/codegen-ui/lib/types/bindings.ts
+++ b/packages/codegen-ui/lib/types/bindings.ts
@@ -28,7 +28,7 @@ export enum StudioComponentPropertyType {
   Number = 'Number',
   Boolean = 'Boolean',
   Date = 'Date',
-  Slot = 'Slot',
+  Slot = 'Amplify.Slot',
 }
 
 export type StudioComponentSimplePropertyBinding = {
@@ -91,7 +91,7 @@ export type StudioComponentSlotBinding = {
   /**
    * This declares that the binding is a Slot type
    */
-  type: 'Slot';
+  type: 'Amplify.Slot';
   bindingProperties: StudioComponentSlotBindingProperty;
 };
 


### PR DESCRIPTION
*Description of changes:*
* Renaming Slot to Amplify.Slot to follow the latest naming convention

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
