### PR TITLE
chore: skip field generation for read-only fields

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -56,6 +56,52 @@ describe('generateFormDefinition', () => {
     });
   });
 
+  it('should add to elementMatrix if readOnly override exists', () => {
+    const formDefinition = generateFormDefinition({
+      form: {
+        name: 'mySampleForm',
+        formActionType: 'create',
+        dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+        fields: {
+          weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2, readOnly: false } },
+        },
+        sectionalElements: {},
+        style: {},
+      },
+      modelInfo: { fields: [{ name: 'weight', type: 'Float', isReadOnly: true, isRequired: true, isArray: false }] },
+    });
+    expect(formDefinition.elements).toStrictEqual({
+      weight: {
+        componentType: 'SliderField',
+        props: { label: 'weight', min: 1, max: 100, step: 2, isDisabled: false, isRequired: true },
+      },
+    });
+    expect(formDefinition.elementMatrix).toStrictEqual([['weight']]);
+  });
+
+  it('should not add to elementMatrix if readOnly override does not exist', () => {
+    const formDefinition = generateFormDefinition({
+      form: {
+        name: 'mySampleForm',
+        formActionType: 'create',
+        dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+        fields: {
+          weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } },
+        },
+        sectionalElements: {},
+        style: {},
+      },
+      modelInfo: { fields: [{ name: 'weight', type: 'Float', isReadOnly: true, isRequired: true, isArray: false }] },
+    });
+    expect(formDefinition.elements).toStrictEqual({
+      weight: {
+        componentType: 'SliderField',
+        props: { label: 'weight', min: 1, max: 100, step: 2, isDisabled: true, isRequired: true },
+      },
+    });
+    expect(formDefinition.elementMatrix).toStrictEqual([['weight']]);
+  });
+
   it('should not add overrides to the matrix', () => {
     const formDefinition = generateFormDefinition({
       form: {
@@ -294,6 +340,27 @@ it('should skip adding read-only fields to element matrix', () => {
     },
   });
   expect(formDefinition.elementMatrix).toStrictEqual([]);
+});
+
+it('should add to element matrix if readOnly exists', () => {
+  const formDefinition = generateFormDefinition({
+    form: {
+      name: 'sampleForm',
+      formActionType: 'create',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+      fields: { name: { inputType: { type: 'TextField', readOnly: false } } },
+      sectionalElements: {},
+      style: {},
+    },
+    modelInfo: { fields: [{ name: 'name', type: 'String', isReadOnly: true, isRequired: true, isArray: false }] },
+  });
+  expect(formDefinition.elements).toStrictEqual({
+    name: {
+      componentType: 'TextField',
+      props: { label: 'name', isRequired: true, isReadOnly: false },
+    },
+  });
+  expect(formDefinition.elementMatrix).toStrictEqual([['name']]);
 });
 
 it('should skip adding id field to element matrix', () => {

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -56,52 +56,6 @@ describe('generateFormDefinition', () => {
     });
   });
 
-  it('should add to elementMatrix if readOnly override exists', () => {
-    const formDefinition = generateFormDefinition({
-      form: {
-        name: 'mySampleForm',
-        formActionType: 'create',
-        dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
-        fields: {
-          weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2, readOnly: false } },
-        },
-        sectionalElements: {},
-        style: {},
-      },
-      modelInfo: { fields: [{ name: 'weight', type: 'Float', isReadOnly: true, isRequired: true, isArray: false }] },
-    });
-    expect(formDefinition.elements).toStrictEqual({
-      weight: {
-        componentType: 'SliderField',
-        props: { label: 'weight', min: 1, max: 100, step: 2, isDisabled: false, isRequired: true },
-      },
-    });
-    expect(formDefinition.elementMatrix).toStrictEqual([['weight']]);
-  });
-
-  it('should not add to elementMatrix if readOnly override does not exist', () => {
-    const formDefinition = generateFormDefinition({
-      form: {
-        name: 'mySampleForm',
-        formActionType: 'create',
-        dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
-        fields: {
-          weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } },
-        },
-        sectionalElements: {},
-        style: {},
-      },
-      modelInfo: { fields: [{ name: 'weight', type: 'Float', isReadOnly: true, isRequired: true, isArray: false }] },
-    });
-    expect(formDefinition.elements).toStrictEqual({
-      weight: {
-        componentType: 'SliderField',
-        props: { label: 'weight', min: 1, max: 100, step: 2, isDisabled: true, isRequired: true },
-      },
-    });
-    expect(formDefinition.elementMatrix).toStrictEqual([['weight']]);
-  });
-
   it('should not add overrides to the matrix', () => {
     const formDefinition = generateFormDefinition({
       form: {

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -274,3 +274,45 @@ it('should fill out styles using defaults', () => {
     outerPadding: { value: '20px' },
   });
 });
+
+it('should skip adding read-only fields to element matrix', () => {
+  const formDefinition = generateFormDefinition({
+    form: {
+      name: 'sampleForm',
+      formActionType: 'create',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+      fields: {},
+      sectionalElements: {},
+      style: {},
+    },
+    modelInfo: { fields: [{ name: 'name', type: 'String', isReadOnly: true, isRequired: true, isArray: false }] },
+  });
+  expect(formDefinition.elements).toStrictEqual({
+    name: {
+      componentType: 'TextField',
+      props: { label: 'name', isRequired: true, isReadOnly: true },
+    },
+  });
+  expect(formDefinition.elementMatrix).toStrictEqual([]);
+});
+
+it('should skip adding id field to element matrix', () => {
+  const formDefinition = generateFormDefinition({
+    form: {
+      name: 'sampleForm',
+      formActionType: 'create',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+      fields: {},
+      sectionalElements: {},
+      style: {},
+    },
+    modelInfo: { fields: [{ name: 'id', type: 'ID', isReadOnly: false, isRequired: true, isArray: false }] },
+  });
+  expect(formDefinition.elements).toStrictEqual({
+    id: {
+      componentType: 'TextField',
+      props: { label: 'id', isRequired: true, isReadOnly: false },
+    },
+  });
+  expect(formDefinition.elementMatrix).toStrictEqual([]);
+});

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/datastore-model.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/datastore-model.test.ts
@@ -86,7 +86,18 @@ describe('addDataStoreModelField', () => {
     addDataStoreModelField(formDefinition, modelFieldsConfigs, dataStoreModelField);
 
     expect(formDefinition.elementMatrix).toStrictEqual([]);
-    expect(modelFieldsConfigs).toStrictEqual({});
+    expect(modelFieldsConfigs).toStrictEqual({
+      id: {
+        inputType: {
+          name: 'id',
+          readOnly: true,
+          required: true,
+          type: 'TextField',
+          value: 'true',
+        },
+        label: 'id',
+      },
+    });
   });
 
   it('should skip generation of read only fields from data store model', () => {
@@ -97,13 +108,24 @@ describe('addDataStoreModelField', () => {
       elementMatrix: [],
     };
 
-    const dataStoreModelField = { name: 'name', type: 'String', isReadOnly: true, isRequired: false, isArray: false };
+    const dataStoreModelField = { name: 'name', type: 'Boolean', isReadOnly: true, isRequired: false, isArray: false };
 
     const modelFieldsConfigs: ModelFieldsConfigs = {};
 
     addDataStoreModelField(formDefinition, modelFieldsConfigs, dataStoreModelField);
 
     expect(formDefinition.elementMatrix).toStrictEqual([]);
-    expect(modelFieldsConfigs).toStrictEqual({});
+    expect(modelFieldsConfigs).toStrictEqual({
+      name: {
+        inputType: {
+          name: 'name',
+          readOnly: true,
+          required: false,
+          type: 'SwitchField',
+          value: 'true',
+        },
+        label: 'name',
+      },
+    });
   });
 });

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/datastore-model.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/datastore-model.test.ts
@@ -70,4 +70,40 @@ describe('addDataStoreModelField', () => {
 
     expect(() => addDataStoreModelField(formDefinition, {}, dataStoreModelField)).toThrow();
   });
+
+  it('should skip generation of id field from data store model', () => {
+    const formDefinition: FormDefinition = {
+      form: { layoutStyle: {} },
+      elements: {},
+      buttons: {},
+      elementMatrix: [],
+    };
+
+    const dataStoreModelField = { name: 'id', type: 'ID', isReadOnly: true, isRequired: true, isArray: false };
+
+    const modelFieldsConfigs: ModelFieldsConfigs = {};
+
+    addDataStoreModelField(formDefinition, modelFieldsConfigs, dataStoreModelField);
+
+    expect(formDefinition.elementMatrix).toStrictEqual([]);
+    expect(modelFieldsConfigs).toStrictEqual({});
+  });
+
+  it('should skip generation of read only fields from data store model', () => {
+    const formDefinition: FormDefinition = {
+      form: { layoutStyle: {} },
+      elements: {},
+      buttons: {},
+      elementMatrix: [],
+    };
+
+    const dataStoreModelField = { name: 'name', type: 'String', isReadOnly: true, isRequired: false, isArray: false };
+
+    const modelFieldsConfigs: ModelFieldsConfigs = {};
+
+    addDataStoreModelField(formDefinition, modelFieldsConfigs, dataStoreModelField);
+
+    expect(formDefinition.elementMatrix).toStrictEqual([]);
+    expect(modelFieldsConfigs).toStrictEqual({});
+  });
 });

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/datastore-model.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/datastore-model.ts
@@ -32,10 +32,6 @@ export function addDataStoreModelField(
     throw new InvalidInputError('Array types are not yet supported');
   }
 
-  if (field.isReadOnly || (field.name === 'id' && field.type === 'ID' && field.isRequired)) {
-    return;
-  }
-
   const dataType = typeof field.type === 'string' ? field.type : Object.keys(field.type)[0];
   const defaultComponent = FIELD_TYPE_MAP[dataType]?.defaultComponent;
 
@@ -43,7 +39,9 @@ export function addDataStoreModelField(
     throw new InvalidInputError('Field type could not be mapped to a component');
   }
 
-  formDefinition.elementMatrix.push([field.name]);
+  if (!field.isReadOnly && field.name !== 'id' && field.type !== 'ID' && !field.isRequired) {
+    formDefinition.elementMatrix.push([field.name]);
+  }
 
   // TODO: map Enums to valueMappings
   modelFieldsConfigs[field.name] = {

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/datastore-model.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/datastore-model.ts
@@ -32,6 +32,10 @@ export function addDataStoreModelField(
     throw new InvalidInputError('Array types are not yet supported');
   }
 
+  if (field.isReadOnly || (field.name === 'id' && field.type === 'ID' && field.isRequired)) {
+    return;
+  }
+
   const dataType = typeof field.type === 'string' ? field.type : Object.keys(field.type)[0];
   const defaultComponent = FIELD_TYPE_MAP[dataType]?.defaultComponent;
 


### PR DESCRIPTION
*Description of changes:*
For forms generated by data model, we do not want to generate fields that are auto-generated read only (such as createdBy or updatedBy).  We also do not want to generate a field for the ID field that is auto generated for every model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
