### PR TITLE
feat: allow unknown type prop value through overrideItems

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -601,7 +601,10 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => Record<string, unknown>;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -701,7 +704,10 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => Record<string, unknown>;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -807,7 +813,10 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => Record<string, unknown>;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -897,7 +906,10 @@ import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => Record<string, unknown>;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -952,7 +964,10 @@ import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => Record<string, unknown>;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -5012,7 +5027,10 @@ import { Collection, CollectionProps, Text } from \\"@aws-amplify/ui-react\\";
 export type CollectionDefaultValueProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => Record<string, unknown>;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -474,26 +474,29 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                 undefined,
                 undefined,
                 undefined,
-                factory.createObjectBindingPattern([
-                  factory.createBindingElement(
+                factory.createIdentifier('collectionItem'),
+                undefined,
+                factory.createTypeLiteralNode([
+                  factory.createPropertySignature(
                     undefined,
                     factory.createIdentifier('item'),
-                    factory.createIdentifier('any'),
                     undefined,
+                    factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
                   ),
-                  factory.createBindingElement(
+                  factory.createPropertySignature(
                     undefined,
                     factory.createIdentifier('index'),
-                    factory.createIdentifier('number'),
                     undefined,
+                    factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
                   ),
                 ]),
                 undefined,
-                undefined,
-                undefined,
               ),
             ],
-            factory.createTypeReferenceNode(factory.createIdentifier('Record<string, string>'), undefined),
+            factory.createTypeReferenceNode(factory.createIdentifier('Record'), [
+              factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+              factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+            ]),
           ),
         ),
       );

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
@@ -201,6 +201,15 @@ describe('Generated Components', () => {
       cy.get('#collectionWithOverrideItems').contains('0 - Doodle, Yankee');
       cy.get('#collectionWithOverrideItems').contains('1 - Cap, Feather');
     });
+
+    it('Supports overrideItems that return JSX.Element prop values', () => {
+      cy.get('#collectionWithJSXOverrideItems').within(() => {
+        cy.contains('Yankee');
+        cy.contains('Doodle');
+        cy.contains('Feather');
+        cy.contains('Cap');
+      });
+    });
   });
 
   describe('Default Value', () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -331,9 +331,34 @@ export default function ComponentTests() {
               lastName: 'Cap',
             },
           ]}
-          overrideItems={({ item, index }: { item: any; index: number }) => {
+          overrideItems={({ item, index }) => {
             return {
               children: `${index} - ${item.lastName}, ${item.firstName}`,
+            };
+          }}
+        />
+        <CollectionWithBinding
+          id="collectionWithJSXOverrideItems"
+          items={[
+            {
+              id: '1',
+              firstName: 'Yankee',
+              lastName: 'Doodle',
+            },
+            {
+              id: '2',
+              firstName: 'Feather',
+              lastName: 'Cap',
+            },
+          ]}
+          overrideItems={({ item }) => {
+            return {
+              children: (
+                <>
+                  <div>{item.lastName}</div>
+                  <div>{item.firstName}</div>
+                </>
+              ),
             };
           }}
         />


### PR DESCRIPTION
*Description of changes:*
1. Fix type for `overrideItems`: It was generating invalid typescript.
2. Allow `overrideItems` to return property values that are type `unknown`, not just `string`, so that `React.ReactNode`, among other types, can get set.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
