### PR TITLE
feat: expand return type of overrideItems

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -594,6 +594,7 @@ import {
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
+import { MyFlexProps } from \\"./MyFlex\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -601,7 +602,10 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => MyFlexProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -694,6 +698,7 @@ import {
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
+import { MyFlexProps } from \\"./MyFlex\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -701,7 +706,10 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => MyFlexProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -800,6 +808,7 @@ import {
   CollectionProps,
   Flex,
 } from \\"@aws-amplify/ui-react\\";
+import { MyFlexProps } from \\"./MyFlex\\";
 
 export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
@@ -807,7 +816,10 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     backgroundColor?: String;
     buttonColor?: UserPreferences;
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => MyFlexProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -891,13 +903,16 @@ import {
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
-import ListingCard from \\"./ListingCard\\";
+import ListingCard, { ListingCardProps } from \\"./ListingCard\\";
 import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
 
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => ListingCardProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -942,7 +957,7 @@ export default function ListingCardCollection(
 exports[`amplify render tests collection should render collection without data binding 1`] = `
 "/* eslint-disable */
 import React from \\"react\\";
-import ListingCard from \\"./ListingCard\\";
+import ListingCard, { ListingCardProps } from \\"./ListingCard\\";
 import {
   EscapeHatchProps,
   getOverrideProps,
@@ -952,7 +967,10 @@ import { Collection, CollectionProps } from \\"@aws-amplify/ui-react\\";
 export type ListingCardCollectionProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => ListingCardProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }
@@ -5044,11 +5062,15 @@ import {
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Collection, CollectionProps, Text } from \\"@aws-amplify/ui-react\\";
+import { MyTextProps } from \\"./MyText\\";
 
 export type CollectionDefaultValueProps = React.PropsWithChildren<
   Partial<CollectionProps<any>> & {
     items?: any[];
-    overrideItems?: ({ item: any, index: number }) => Record<string, string>;
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => MyTextProps;
   } & {
     overrides?: EscapeHatchProps | undefined | null;
   }

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -332,7 +332,10 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     if (componentIsPrimitive) {
       this.importCollection.addImport(ImportSource.UI_REACT, propsType);
     } else {
-      this.importCollection.addImport(`./${component.componentType}`, `${component.componentType}Props`);
+      this.importCollection.addImport(
+        `./${component.componentType}`,
+        `${getComponentPropName(component.componentType)}`,
+      );
     }
 
     const propsTypeParameter = componentIsPrimitive
@@ -466,6 +469,16 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       });
     }
     if (component.componentType === 'Collection') {
+      const child = component.children?.[0];
+      if (!child) {
+        throw new Error(`Collection component must have a child`);
+      }
+
+      const childComponentName = child.name;
+      const childComponentProps = getComponentPropName(childComponentName);
+
+      this.importCollection.addImport(`./${childComponentName}`, `${childComponentProps}`);
+
       propSignatures.push(
         factory.createPropertySignature(
           undefined,
@@ -486,26 +499,26 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                 undefined,
                 undefined,
                 undefined,
-                factory.createObjectBindingPattern([
-                  factory.createBindingElement(
+                factory.createIdentifier('collectionItem'),
+                undefined,
+                factory.createTypeLiteralNode([
+                  factory.createPropertySignature(
                     undefined,
                     factory.createIdentifier('item'),
-                    factory.createIdentifier('any'),
                     undefined,
+                    factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
                   ),
-                  factory.createBindingElement(
+                  factory.createPropertySignature(
                     undefined,
                     factory.createIdentifier('index'),
-                    factory.createIdentifier('number'),
                     undefined,
+                    factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
                   ),
                 ]),
                 undefined,
-                undefined,
-                undefined,
               ),
             ],
-            factory.createTypeReferenceNode(factory.createIdentifier('Record<string, string>'), undefined),
+            factory.createTypeReferenceNode(factory.createIdentifier(childComponentProps), undefined),
           ),
         ),
       );

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
@@ -210,6 +210,15 @@ describe('Generated Components', () => {
       cy.get('#collectionWithOverrideItems').contains('0 - Doodle, Yankee');
       cy.get('#collectionWithOverrideItems').contains('1 - Cap, Feather');
     });
+
+    it('Supports overrideItems that return JSX.Element prop values', () => {
+      cy.get('#collectionWithJSXOverrideItems').within(() => {
+        cy.contains('Yankee');
+        cy.contains('Doodle');
+        cy.contains('Feather');
+        cy.contains('Cap');
+      });
+    });
   });
 
   describe('Default Value', () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -333,9 +333,34 @@ export default function ComponentTests() {
               lastName: 'Cap',
             },
           ]}
-          overrideItems={({ item, index }: { item: any; index: number }) => {
+          overrideItems={({ item, index }) => {
             return {
               children: `${index} - ${item.lastName}, ${item.firstName}`,
+            };
+          }}
+        />
+        <CollectionWithBinding
+          id="collectionWithJSXOverrideItems"
+          items={[
+            {
+              id: '1',
+              firstName: 'Yankee',
+              lastName: 'Doodle',
+            },
+            {
+              id: '2',
+              firstName: 'Feather',
+              lastName: 'Cap',
+            },
+          ]}
+          overrideItems={({ item }) => {
+            return {
+              children: (
+                <>
+                  <div>{item.lastName}</div>
+                  <div>{item.firstName}</div>
+                </>
+              ),
             };
           }}
         />


### PR DESCRIPTION
*Description of changes:*
1. Fix type for `overrideItems`: It was generating invalid typescript.
2. Import child's prop type to the collection type file.
3. Use it as the return type for `overrideItems`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
