### PR TITLE
chore: clean up form definition mapper

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -275,13 +275,29 @@ it('should fill out styles using defaults', () => {
   });
 });
 
-it('should skip adding read-only fields to element matrix', () => {
+it('should skip read-only fields without overrides', () => {
   const formDefinition = generateFormDefinition({
     form: {
       name: 'sampleForm',
       formActionType: 'create',
       dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
       fields: {},
+      sectionalElements: {},
+      style: {},
+    },
+    modelInfo: { fields: [{ name: 'name', type: 'String', isReadOnly: true, isRequired: true, isArray: false }] },
+  });
+  expect(formDefinition.elements).toStrictEqual({});
+  expect(formDefinition.elementMatrix).toStrictEqual([]);
+});
+
+it('should add read-only fields if it has overrides', () => {
+  const formDefinition = generateFormDefinition({
+    form: {
+      name: 'sampleForm',
+      formActionType: 'create',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+      fields: { name: { inputType: { type: 'TextField' } } },
       sectionalElements: {},
       style: {},
     },
@@ -293,31 +309,10 @@ it('should skip adding read-only fields to element matrix', () => {
       props: { label: 'name', isRequired: true, isReadOnly: true },
     },
   });
-  expect(formDefinition.elementMatrix).toStrictEqual([]);
-});
-
-it('should add to element matrix if readOnly exists', () => {
-  const formDefinition = generateFormDefinition({
-    form: {
-      name: 'sampleForm',
-      formActionType: 'create',
-      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
-      fields: { name: { inputType: { type: 'TextField', readOnly: false } } },
-      sectionalElements: {},
-      style: {},
-    },
-    modelInfo: { fields: [{ name: 'name', type: 'String', isReadOnly: true, isRequired: true, isArray: false }] },
-  });
-  expect(formDefinition.elements).toStrictEqual({
-    name: {
-      componentType: 'TextField',
-      props: { label: 'name', isRequired: true, isReadOnly: false },
-    },
-  });
   expect(formDefinition.elementMatrix).toStrictEqual([['name']]);
 });
 
-it('should skip adding id field to element matrix', () => {
+it('should skip adding id field if it has no overrides', () => {
   const formDefinition = generateFormDefinition({
     form: {
       name: 'sampleForm',
@@ -329,11 +324,6 @@ it('should skip adding id field to element matrix', () => {
     },
     modelInfo: { fields: [{ name: 'id', type: 'ID', isReadOnly: false, isRequired: true, isArray: false }] },
   });
-  expect(formDefinition.elements).toStrictEqual({
-    id: {
-      componentType: 'TextField',
-      props: { label: 'id', isRequired: true, isReadOnly: false },
-    },
-  });
+  expect(formDefinition.elements).toStrictEqual({});
   expect(formDefinition.elementMatrix).toStrictEqual([]);
 });

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
@@ -15,12 +15,11 @@
  */
 
 import { mapFormFieldConfig, getFormDefinitionInputElement } from '../../../generate-form-definition/helpers';
-import { FormDefinition, ModelFieldsConfigs, StudioGenericFieldConfig } from '../../../types';
+import { FormDefinition, ModelFieldsConfigs, StudioFormFieldConfig, StudioGenericFieldConfig } from '../../../types';
 
 describe('mapFormFieldConfig', () => {
   it('should map fields', () => {
-    const element: { type: string; name: string; config: StudioGenericFieldConfig } = {
-      type: 'field',
+    const element: { name: string; config: StudioGenericFieldConfig } = {
       name: 'price',
       config: {
         label: 'Price',
@@ -60,6 +59,33 @@ describe('mapFormFieldConfig', () => {
       componentType: 'SliderField',
       props: { label: 'Price', isDisabled: true, min: 0, max: 100, step: 1, isRequired: true },
     });
+  });
+
+  it('should throw if there is attempt to map excluded field', () => {
+    const element: { name: string; config: StudioFormFieldConfig } = {
+      name: 'price',
+      config: { excluded: true },
+    };
+
+    const formDefinition: FormDefinition = {
+      form: { layoutStyle: {} },
+      elements: {},
+      buttons: {},
+      elementMatrix: [['price']],
+    };
+
+    const modelFieldsConfigs: ModelFieldsConfigs = {
+      price: {
+        label: 'price',
+        inputType: {
+          type: 'TextField',
+          readOnly: false,
+          required: false,
+        },
+      },
+    };
+
+    expect(() => mapFormFieldConfig(element, formDefinition, modelFieldsConfigs)).toThrow();
   });
 });
 

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/map-elements.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/map-elements.test.ts
@@ -1,0 +1,92 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { mapElements } from '../../../generate-form-definition/helpers';
+import { FormDefinition, SectionalElement, ModelFieldsConfigs, StudioForm } from '../../../types';
+
+describe('mapElements', () => {
+  it('should map sectional elements & input elements with and without overrides', () => {
+    const sectionalConfig: SectionalElement = {
+      type: 'Text',
+      text: 'MyText',
+      position: { fixed: 'first' },
+    };
+
+    const formDefinition: FormDefinition = {
+      form: { layoutStyle: {} },
+      elements: {},
+      buttons: {},
+      elementMatrix: [['myText', 'name'], ['price']],
+    };
+
+    const modelFieldsConfigs: ModelFieldsConfigs = {
+      price: {
+        label: 'price',
+        inputType: {
+          type: 'TextField',
+          readOnly: false,
+          required: false,
+        },
+      },
+      weight: {
+        label: 'weight',
+        inputType: { type: 'TextField' },
+      },
+    };
+
+    const form: StudioForm = {
+      name: 'sampleForm',
+      formActionType: 'create',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+      fields: { name: { inputType: { type: 'TextField' } } },
+      sectionalElements: { myText: sectionalConfig },
+      style: {},
+    };
+
+    mapElements({ formDefinition, modelFieldsConfigs, form });
+    expect(formDefinition.elements).toStrictEqual({
+      myText: { componentType: 'Text', props: { children: 'MyText' } },
+      name: { componentType: 'TextField', props: { label: 'Label' } },
+      price: {
+        componentType: 'TextField',
+        props: { label: 'price', isRequired: false, isReadOnly: false },
+      },
+    });
+
+    expect('weight' in formDefinition.elements).toBe(false);
+  });
+
+  it('should throw if config for element not found', () => {
+    const formDefinition: FormDefinition = {
+      form: { layoutStyle: {} },
+      elements: {},
+      buttons: {},
+      elementMatrix: [['myText']],
+    };
+
+    const modelFieldsConfigs: ModelFieldsConfigs = {};
+
+    const form: StudioForm = {
+      name: 'sampleForm',
+      formActionType: 'create',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
+      fields: {},
+      sectionalElements: {},
+      style: {},
+    };
+
+    expect(() => mapElements({ formDefinition, modelFieldsConfigs, form })).toThrow();
+  });
+});

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/sectional-element.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/sectional-element.test.ts
@@ -26,8 +26,7 @@ describe('mapSectionalElement', () => {
       elementMatrix: [],
     };
 
-    const element: { type: string; name: string; config: SectionalElement } = {
-      type: 'sectionalElement',
+    const element: { name: string; config: SectionalElement } = {
       name: 'Heading123',
       config: { type: 'Heading', level: 1, text: 'My Heading', position: { fixed: 'first' } },
     };
@@ -43,8 +42,7 @@ describe('mapSectionalElement', () => {
       elementMatrix: [],
     };
 
-    const element: { type: string; name: string; config: SectionalElement } = {
-      type: 'sectionalElement',
+    const element: { name: string; config: SectionalElement } = {
       name: 'Heading123',
       config: { type: 'Heading', level: 1, text: 'My Heading', position: { fixed: 'first' } },
     };

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/datastore-model.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/datastore-model.ts
@@ -39,7 +39,9 @@ export function addDataStoreModelField(
     throw new InvalidInputError('Field type could not be mapped to a component');
   }
 
-  if (!field.isReadOnly && field.name !== 'id' && field.type !== 'ID' && !field.isRequired) {
+  const isAutoExcludedField = field.isReadOnly || (field.name === 'id' && field.type === 'ID' && field.isRequired);
+
+  if (!isAutoExcludedField) {
     formDefinition.elementMatrix.push([field.name]);
   }
 

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -13,8 +13,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { FormDefinition, FormDefinitionInputElement, StudioGenericFieldConfig, ModelFieldsConfigs } from '../../types';
-import { InvalidInputError } from '../../errors';
+import {
+  FormDefinition,
+  FormDefinitionInputElement,
+  StudioGenericFieldConfig,
+  ModelFieldsConfigs,
+  StudioFormFieldConfig,
+} from '../../types';
+import { InternalError, InvalidInputError } from '../../errors';
 import { FORM_DEFINITION_DEFAULTS } from './defaults';
 import { deleteUndefined, getFirstDefinedValue, getFirstNumber, getFirstString } from './mapper-utils';
 
@@ -231,28 +237,16 @@ export function getFormDefinitionInputElement(
  */
 /* eslint-disable no-param-reassign */
 export function mapFormFieldConfig(
-  element: { type: string; name: string; config: StudioGenericFieldConfig },
+  element: { name: string; config: StudioFormFieldConfig },
   formDefinition: FormDefinition,
   modelFieldsConfigs: ModelFieldsConfigs,
 ) {
+  if ('excluded' in element.config) {
+    throw new InternalError(`Attempted to map excluded element ${element.name}`);
+  }
   formDefinition.elements[element.name] = getFormDefinitionInputElement(
     element.config,
     modelFieldsConfigs[element.name],
   );
-}
-
-/* eslint-enable no-param-reassign */
-
-/**
- * Impure function that adds field configurations to formDefinition
- * for model fields that are not currently in the definition
- */
-/* eslint-disable no-param-reassign */
-export function mapMissingConfigs(modelFieldsConfigs: ModelFieldsConfigs, formDefinition: FormDefinition) {
-  Object.entries(modelFieldsConfigs).forEach(([fieldName, fieldConfig]) => {
-    if (!formDefinition.elements[fieldName]) {
-      formDefinition.elements[fieldName] = getFormDefinitionInputElement(fieldConfig);
-    }
-  });
 }
 /* eslint-enable no-param-reassign */

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/sectional-element.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/sectional-element.ts
@@ -66,7 +66,7 @@ export function getFormDefinitionSectionalElement(config: SectionalElement): For
  */
 /* eslint-disable no-param-reassign */
 export function mapSectionalElement(
-  element: { type: string; name: string; config: SectionalElement },
+  element: { name: string; config: SectionalElement },
   formDefinition: FormDefinition,
 ) {
   if (formDefinition.elements[element.name]) {

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -19,6 +19,7 @@ import { StudioFormFields, StudioFormFieldConfig, StudioGenericFieldConfig } fro
 import { SectionalElement } from './sectional-element';
 import { FormDefinition, ModelFieldsConfigs } from './form-definition';
 import { StudioFieldInputConfig } from './input-config';
+import { StudioFieldPosition } from './position';
 
 /**
  * Data type definition for StudioForm
@@ -61,4 +62,5 @@ export type {
   StudioGenericFieldConfig,
   StudioFormFields,
   ModelFieldsConfigs,
+  StudioFieldPosition,
 };


### PR DESCRIPTION
*Description of changes:*
- Fix condition for auto-excluded DataStore fields
- Break out positioning logic into helper
- Consolidate logic for mapping elements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
