### PR TITLE
fix: handle auth prop in concat

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
@@ -250,6 +250,8 @@ NodeObject {
 }
 `;
 
+exports[`react-component-render-helper buildConcatExpression should build concat with userAttribute 1`] = `"\`\${authAttributes[\\"email\\"]}\${\\", welcome!\\"}\`"`;
+
 exports[`react-component-render-helper buildContionalExpression operandType does not exist 1`] = `"(user?.age && user?.age > \\"18\\") ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;
 
 exports[`react-component-render-helper buildContionalExpression operandType exists 1`] = `"(user?.age && user?.age > 18) ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;

--- a/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
@@ -18,6 +18,7 @@ import {
   ConditionalStudioComponentProperty,
   StudioComponentProperty,
   ComponentMetadata,
+  ConcatenatedStudioComponentProperty,
 } from '@aws-amplify/codegen-ui';
 import {
   getFixedComponentPropValueExpression,
@@ -32,6 +33,7 @@ import {
   getSyntaxKindToken,
   buildChildElement,
   buildConditionalExpression,
+  buildConcatExpression,
 } from '../react-component-render-helper';
 
 import { assertASTMatchesSnapshot } from './__utils__';
@@ -293,6 +295,17 @@ describe('react-component-render-helper', () => {
       expect(() =>
         buildConditionalExpression(buildEmptyComponentMetadata(), buildConditionalWithOperand('18', 'boolean')),
       ).toThrow('Parsed value 18 and type boolean mismatch');
+    });
+  });
+
+  describe('buildConcatExpression', () => {
+    test('should build concat with userAttribute', () => {
+      const concatProp: ConcatenatedStudioComponentProperty = {
+        concat: [{ userAttribute: 'email' }, { value: ', welcome!', type: 'string' }],
+      };
+
+      const exp = buildConcatExpression(concatProp);
+      assertASTMatchesSnapshot(exp);
     });
   });
 });

--- a/packages/codegen-ui-react/lib/react-component-render-helper.ts
+++ b/packages/codegen-ui-react/lib/react-component-render-helper.ts
@@ -301,6 +301,8 @@ export function buildConcatExpression(prop: ConcatenatedStudioComponentProperty)
           ? buildBindingExpression(propItem)
           : buildBindingWithDefaultExpression(propItem, propItem.defaultValue);
       expressions.push(expr);
+    } else if (isAuthProperty(propItem)) {
+      expressions.push(buildAuthExpression(propItem));
     } else if (isCollectionItemBoundProperty(propItem)) {
       const expr =
         propItem.defaultValue === undefined

--- a/packages/codegen-ui/lib/__tests__/renderer-helper.test.ts
+++ b/packages/codegen-ui/lib/__tests__/renderer-helper.test.ts
@@ -17,6 +17,7 @@ import {
   StudioComponentDataPropertyBinding,
   StudioComponentSimplePropertyBinding,
   StudioComponentEventPropertyBinding,
+  StudioComponentAuthProperty,
 } from '../types';
 import {
   isStudioComponentWithBinding,
@@ -25,6 +26,7 @@ import {
   isStudioComponentWithCollectionProperties,
   isStudioComponentWithVariants,
   isEventPropertyBinding,
+  isAuthProperty,
 } from '../renderer-helper';
 
 describe('render-helper', () => {
@@ -35,6 +37,7 @@ describe('render-helper', () => {
     number: StudioComponentSimplePropertyBinding;
     date: StudioComponentSimplePropertyBinding;
     event: StudioComponentEventPropertyBinding;
+    auth: StudioComponentAuthProperty;
   } = {
     data: {
       type: 'Data',
@@ -56,6 +59,9 @@ describe('render-helper', () => {
     },
     event: {
       type: 'Event',
+    },
+    auth: {
+      userAttribute: 'email',
     },
   };
 
@@ -182,6 +188,14 @@ describe('render-helper', () => {
       expect(isEventPropertyBinding(bindingProperties.event)).toBeTruthy();
       const { event, ...otherTypes } = bindingProperties;
       Object.values(otherTypes).forEach((otherType) => expect(isEventPropertyBinding(otherType)).toBeFalsy());
+    });
+  });
+
+  describe('isAuthProperty', () => {
+    test('property has type userAttribute', () => {
+      expect(isAuthProperty(bindingProperties.auth)).toBeTruthy();
+      const { auth, ...otherTypes } = bindingProperties;
+      Object.values(otherTypes).forEach((otherType) => expect(isAuthProperty(otherType)).toBeFalsy());
     });
   });
 });

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
@@ -69,6 +69,10 @@ describe('Generated Components', () => {
       it('Renders Button text as a concatenated, bound element, with overrides', () => {
         cy.get('#concat-and-conditional').contains('Norm Gunderson');
       });
+
+      it('Renders Button text as a concatenated, auth element', () => {
+        cy.get('#concat-and-conditional').contains('Harry Callahan TestUser');
+      });
     });
 
     describe('Conditional Data', () => {

--- a/packages/test-generator/lib/components/operators/componentWithConcatenation.json
+++ b/packages/test-generator/lib/components/operators/componentWithConcatenation.json
@@ -29,6 +29,12 @@
             "field": "lastName"
           },
           "defaultValue": "Callahan"
+        },
+        {
+          "value": " "
+        },
+        {
+          "userAttribute": "username"
         }
       ]
     }


### PR DESCRIPTION
*Issue #, if available:*
Customers are not able to concat auth bindings

*Description of changes:*
Handle auth props in concat

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
