### PR TITLE
fix: change recommended ui-react version to ^3.1.0

### DIFF
--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -24,7 +24,7 @@ export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<
     return [
       {
         dependencyName: '@aws-amplify/ui-react',
-        supportedSemVerPattern: '^3.10.0',
+        supportedSemVerPattern: '^3.1.0',
         reason: 'Required to leverage amplify ui primitives, and studio component helper functions.',
       },
     ];


### PR DESCRIPTION
*Description of changes:*
Recommended version for ui-react was set to non-existent version.
Setting to existing: https://www.npmjs.com/package/@aws-amplify/ui-react/v/3.1.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
