### PR TITLE
chore: add default breakpointhook and style with tests and updated snapshots

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -1443,7 +1443,7 @@ export type ComplexTest4Props = React.PropsWithChildren<
 export default function ComplexTest4(
   props: ComplexTest4Props
 ): React.ReactElement {
-  const { overrides: overridesProp, ...rest } = props;
+  const { overrides: overridesProp, ...restProp } = props;
   const variants: Variant[] = [
     {
       overrides: {
@@ -1486,8 +1486,20 @@ export default function ComplexTest4(
       variantValues: { colors: \\"Red/Orange\\" },
     },
   ];
+  const breakpointHook = useBreakpointValue({
+    base: \\"base\\",
+    large: \\"large\\",
+    medium: \\"medium\\",
+    small: \\"small\\",
+    xl: \\"xl\\",
+    xxl: \\"xxl\\",
+  });
+  const rest = { style: { transition: \\"all 0.25s\\" }, ...restProp };
   const overrides = mergeVariantsAndOverrides(
-    getOverridesFromVariants(variants, props),
+    getOverridesFromVariants(variants, {
+      breakpoint: breakpointHook,
+      ...props,
+    }),
     overridesProp || {}
   );
   return (
@@ -1834,7 +1846,7 @@ export type ComplexTest9Props = React.PropsWithChildren<
 export default function ComplexTest9(
   props: ComplexTest9Props
 ): React.ReactElement {
-  const { overrides: overridesProp, ...rest } = props;
+  const { overrides: overridesProp, ...restProp } = props;
   const variants: Variant[] = [
     {
       nodeId: \\"2878:3221\\",
@@ -2068,8 +2080,20 @@ export default function ComplexTest9(
       },
     },
   ];
+  const breakpointHook = useBreakpointValue({
+    base: \\"base\\",
+    large: \\"large\\",
+    medium: \\"medium\\",
+    small: \\"small\\",
+    xl: \\"xl\\",
+    xxl: \\"xxl\\",
+  });
+  const rest = { style: { transition: \\"all 0.25s\\" }, ...restProp };
   const overrides = mergeVariantsAndOverrides(
-    getOverridesFromVariants(variants, props),
+    getOverridesFromVariants(variants, {
+      breakpoint: breakpointHook,
+      ...props,
+    }),
     overridesProp || {}
   );
   return (
@@ -4226,7 +4250,7 @@ export type ViewPrimitiveProps = React.PropsWithChildren<
 export default function ViewPrimitive(
   props: ViewPrimitiveProps
 ): React.ReactElement {
-  const { overrides: overridesProp, ...rest } = props;
+  const { overrides: overridesProp, ...restProp } = props;
   const variants: Variant[] = [
     {
       variantValues: { variant: \\"primary\\" },
@@ -4235,8 +4259,20 @@ export default function ViewPrimitive(
       },
     },
   ];
+  const breakpointHook = useBreakpointValue({
+    base: \\"base\\",
+    large: \\"large\\",
+    medium: \\"medium\\",
+    small: \\"small\\",
+    xl: \\"xl\\",
+    xxl: \\"xxl\\",
+  });
+  const rest = { style: { transition: \\"all 0.25s\\" }, ...restProp };
   const overrides = mergeVariantsAndOverrides(
-    getOverridesFromVariants(variants, props),
+    getOverridesFromVariants(variants, {
+      breakpoint: breakpointHook,
+      ...props,
+    }),
     overridesProp || {}
   );
   return (
@@ -4277,7 +4313,7 @@ export type IconVariantsProps = React.PropsWithChildren<
 export default function IconVariants(
   props: IconVariantsProps
 ): React.ReactElement {
-  const { overrides: overridesProp, ...rest } = props;
+  const { overrides: overridesProp, ...restProp } = props;
   const variants: Variant[] = [
     {
       variantValues: { variant: \\"primary\\" },
@@ -4310,8 +4346,20 @@ export default function IconVariants(
       },
     },
   ];
+  const breakpointHook = useBreakpointValue({
+    base: \\"base\\",
+    large: \\"large\\",
+    medium: \\"medium\\",
+    small: \\"small\\",
+    xl: \\"xl\\",
+    xxl: \\"xxl\\",
+  });
+  const rest = { style: { transition: \\"all 0.25s\\" }, ...restProp };
   const overrides = mergeVariantsAndOverrides(
-    getOverridesFromVariants(variants, props),
+    getOverridesFromVariants(variants, {
+      breakpoint: breakpointHook,
+      ...props,
+    }),
     overridesProp || {}
   );
   return (
@@ -4349,7 +4397,7 @@ export type CustomButtonProps = React.PropsWithChildren<
 export default function CustomButton(
   props: CustomButtonProps
 ): React.ReactElement {
-  const { overrides: overridesProp, ...rest } = props;
+  const { overrides: overridesProp, ...restProp } = props;
   const variants: Variant[] = [
     {
       variantValues: { variant: \\"primary\\" },
@@ -4364,8 +4412,20 @@ export default function CustomButton(
       overrides: { CustomButton: { width: \\"500\\" } },
     },
   ];
+  const breakpointHook = useBreakpointValue({
+    base: \\"base\\",
+    large: \\"large\\",
+    medium: \\"medium\\",
+    small: \\"small\\",
+    xl: \\"xl\\",
+    xxl: \\"xxl\\",
+  });
+  const rest = { style: { transition: \\"all 0.25s\\" }, ...restProp };
   const overrides = mergeVariantsAndOverrides(
-    getOverridesFromVariants(variants, props),
+    getOverridesFromVariants(variants, {
+      breakpoint: breakpointHook,
+      ...props,
+    }),
     overridesProp || {}
   );
   return (
@@ -4403,7 +4463,7 @@ export type CustomButtonProps = React.PropsWithChildren<
 export default function CustomButton(
   props: CustomButtonProps
 ): React.ReactElement {
-  const { overrides: overridesProp, ...rest } = props;
+  const { overrides: overridesProp, ...restProp } = props;
   const variants: Variant[] = [
     {
       variantValues: { variant: \\"primary\\" },
@@ -4429,8 +4489,20 @@ export default function CustomButton(
       },
     },
   ];
+  const breakpointHook = useBreakpointValue({
+    base: \\"base\\",
+    large: \\"large\\",
+    medium: \\"medium\\",
+    small: \\"small\\",
+    xl: \\"xl\\",
+    xxl: \\"xxl\\",
+  });
+  const rest = { style: { transition: \\"all 0.25s\\" }, ...restProp };
   const overrides = mergeVariantsAndOverrides(
-    getOverridesFromVariants(variants, props),
+    getOverridesFromVariants(variants, {
+      breakpoint: breakpointHook,
+      ...props,
+    }),
     overridesProp || {}
   );
   return (

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -44,6 +44,12 @@ describe('amplify render tests', () => {
     it('should generate a simple image component', () => {});
 
     it('should generate a simple string component', () => {});
+
+    it('should generate a basic component without variant specific generation', () => {
+      const generatedCode = generateWithAmplifyRenderer('buttonGolden');
+      expect(generatedCode.componentText.indexOf('restProp')).toEqual(-1);
+      expect(generatedCode.componentText.indexOf('breakpointHook')).toEqual(-1);
+    });
   });
 
   describe('complex component tests', () => {
@@ -231,6 +237,12 @@ describe('amplify render tests', () => {
     it('should render object variants', () => {
       const generatedCode = generateWithAmplifyRenderer('componentWithObjectVariants');
       expect(generatedCode).toMatchSnapshot();
+    });
+
+    it('should have variant specific generation', () => {
+      const generatedCode = generateWithAmplifyRenderer('componentWithVariants');
+      expect(generatedCode.componentText.indexOf('restProp')).toBeGreaterThanOrEqual(0);
+      expect(generatedCode.componentText.indexOf('breakpointHook')).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -594,7 +594,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       factory.createBindingElement(
         factory.createToken(ts.SyntaxKind.DotDotDotToken),
         undefined,
-        factory.createIdentifier('rest'),
+        factory.createIdentifier(hasVariant ? 'restProp' : 'rest'),
         undefined,
       ),
     );
@@ -618,6 +618,8 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     if (isStudioComponentWithVariants(component)) {
       this.importCollection.addMappedImport(ImportValue.MERGE_VARIANTS_OVERRIDES);
       statements.push(this.buildVariantDeclaration(component.variants));
+      statements.push(this.buildDefaultBreakpointMap());
+      statements.push(this.buildRestWithStyle());
       statements.push(this.buildOverridesFromVariantsAndProp());
     }
 
@@ -720,9 +722,100 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
   }
 
   /**
+   *     const breakpointHook = useBreakpointValue({
+   *        base: 'base',
+   *        large: 'large',
+   *        medium: 'medium',
+   *        small: 'small',
+   *        xl: 'xl',
+   *        xxl: 'xxl',
+   *     });
+   */
+  private buildDefaultBreakpointMap() {
+    return factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('breakpointHook'),
+            undefined,
+            undefined,
+            factory.createCallExpression(factory.createIdentifier('useBreakpointValue'), undefined, [
+              factory.createObjectLiteralExpression(
+                [
+                  factory.createPropertyAssignment(
+                    factory.createIdentifier('base'),
+                    factory.createStringLiteral('base'),
+                  ),
+                  factory.createPropertyAssignment(
+                    factory.createIdentifier('large'),
+                    factory.createStringLiteral('large'),
+                  ),
+                  factory.createPropertyAssignment(
+                    factory.createIdentifier('medium'),
+                    factory.createStringLiteral('medium'),
+                  ),
+                  factory.createPropertyAssignment(
+                    factory.createIdentifier('small'),
+                    factory.createStringLiteral('small'),
+                  ),
+                  factory.createPropertyAssignment(factory.createIdentifier('xl'), factory.createStringLiteral('xl')),
+                  factory.createPropertyAssignment(factory.createIdentifier('xxl'), factory.createStringLiteral('xxl')),
+                ],
+                true,
+              ),
+            ]),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    );
+  }
+
+  /**
+   *   const rest = {style: {transition:"all 1s"}, ...restProp}
+   */
+  private buildRestWithStyle() {
+    return factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('rest'),
+            undefined,
+            undefined,
+            factory.createObjectLiteralExpression(
+              [
+                factory.createPropertyAssignment(
+                  factory.createIdentifier('style'),
+                  factory.createObjectLiteralExpression(
+                    [
+                      factory.createPropertyAssignment(
+                        factory.createIdentifier('transition'),
+                        factory.createStringLiteral('all 0.25s'),
+                      ),
+                    ],
+                    false,
+                  ),
+                ),
+                factory.createSpreadAssignment(factory.createIdentifier('restProp')),
+              ],
+              false,
+            ),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    );
+  }
+
+  /**
    * const overrides = mergeVariantsAndOverrides(
-   *   getOverridesFromVariants(variants, props),
-   *   overridesProp || {}
+   *  getOverridesFromVariants(variants, {
+   *   breakpoint: breakpointHook,
+   *   ...props,
+   *  }),
+   *  overridesProp || {}
    * );
    */
   private buildOverridesFromVariantsAndProp() {
@@ -740,7 +833,16 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
             factory.createCallExpression(factory.createIdentifier('mergeVariantsAndOverrides'), undefined, [
               factory.createCallExpression(factory.createIdentifier('getOverridesFromVariants'), undefined, [
                 factory.createIdentifier('variants'),
-                factory.createIdentifier('props'),
+                factory.createObjectLiteralExpression(
+                  [
+                    factory.createPropertyAssignment(
+                      factory.createIdentifier('breakpoint'),
+                      factory.createIdentifier('breakpointHook'),
+                    ),
+                    factory.createSpreadAssignment(factory.createIdentifier('props')),
+                  ],
+                  false,
+                ),
               ]),
               factory.createBinaryExpression(
                 factory.createIdentifier('overridesProp'),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

On components with variants:
- Added generation of default breakpoint map and integrated into variants
- Added transition style

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
