### PR TITLE
feat: add datastore onSubmitBefore and onSubmitComplete callbacks

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -7,7 +7,13 @@ import {
   getOverrideProps,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  Flex,
+  Grid,
+  TextField,
+  useTypeCastFields,
+} from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function customDataForm(props) {
   const {
@@ -134,7 +140,13 @@ import {
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
 import { schema } from \\"../models/schema\\";
-import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  Flex,
+  Grid,
+  TextField,
+  useTypeCastFields,
+} from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function myPostForm(props) {
   const { onSubmitBefore, onSubmitComplete, onCancel, overrides, ...rest } =
@@ -285,7 +297,13 @@ import {
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
 import { schema } from \\"../models/schema\\";
-import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
+import {
+  Button,
+  Flex,
+  Grid,
+  TextField,
+  useTypeCastFields,
+} from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function myPostForm(props) {
   const { id, onSubmitBefore, onSubmitComplete, onCancel, overrides, ...rest } =

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -24,7 +24,6 @@ export default function customDataForm(props) {
         if (onSubmitBefore) {
           onSubmitBefore({ fields: customDataFormFields });
         }
-        customDataFormOnSubmit(customDataFormFields);
         try {
           await customDataFormOnSubmit(customDataFormFields);
           if (onSubmitComplete) {
@@ -144,7 +143,6 @@ export default function myPostForm(props) {
         if (onSubmitBefore) {
           onSubmitBefore({ fields: myPostFormFields });
         }
-        myPostFormOnSubmit();
         try {
           await myPostFormOnSubmit();
           if (onSubmitComplete) {
@@ -291,7 +289,6 @@ export default function myPostForm(props) {
         if (onSubmitBefore) {
           onSubmitBefore({ fields: myPostFormFields });
         }
-        myPostFormOnSubmit();
         try {
           await myPostFormOnSubmit();
           if (onSubmitComplete) {

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -21,11 +21,17 @@ export default function customDataForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        let onSubmitBeforeFields = {};
         if (onSubmitBefore) {
-          onSubmitBefore({ fields: customDataFormFields });
+          onSubmitBeforeFields = onSubmitBefore({
+            fields: customDataFormFields,
+          });
         }
         try {
-          await customDataFormOnSubmit(customDataFormFields);
+          await customDataFormOnSubmit(
+            customDataFormFields,
+            onSubmitBeforeFields
+          );
           if (onSubmitComplete) {
             onSubmitComplete({ saveSuccessful: true });
           }
@@ -140,8 +146,9 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        let onSubmitBeforeFields = {};
         if (onSubmitBefore) {
-          onSubmitBefore({ fields: myPostFormFields });
+          onSubmitBeforeFields = onSubmitBefore({ fields: myPostFormFields });
         }
         try {
           await myPostFormOnSubmit();
@@ -286,8 +293,9 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        let onSubmitBeforeFields = {};
         if (onSubmitBefore) {
-          onSubmitBefore({ fields: myPostFormFields });
+          onSubmitBeforeFields = onSubmitBefore({ fields: myPostFormFields });
         }
         try {
           await myPostFormOnSubmit();

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -21,7 +21,23 @@ export default function customDataForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        if (onSubmitBefore) {
+          onSubmitBefore({ fields: customDataFormFields });
+        }
         customDataFormOnSubmit(customDataFormFields);
+        try {
+          await customDataFormOnSubmit(customDataFormFields);
+          if (onSubmitComplete) {
+            onSubmitComplete({ saveSuccessful: true });
+          }
+        } catch (err) {
+          if (onSubmitComplete) {
+            onSubmitComplete({
+              saveSuccessful: false,
+              errorMessage: err.message,
+            });
+          }
+        }
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"customDataForm\\")}
@@ -125,7 +141,23 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        if (onSubmitBefore) {
+          onSubmitBefore({ fields: myPostFormFields });
+        }
         myPostFormOnSubmit();
+        try {
+          await myPostFormOnSubmit();
+          if (onSubmitComplete) {
+            onSubmitComplete({ saveSuccessful: true });
+          }
+        } catch (err) {
+          if (onSubmitComplete) {
+            onSubmitComplete({
+              saveSuccessful: false,
+              errorMessage: err.message,
+            });
+          }
+        }
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"myPostForm\\")}
@@ -256,7 +288,23 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        if (onSubmitBefore) {
+          onSubmitBefore({ fields: myPostFormFields });
+        }
         myPostFormOnSubmit();
+        try {
+          await myPostFormOnSubmit();
+          if (onSubmitComplete) {
+            onSubmitComplete({ saveSuccessful: true });
+          }
+        } catch (err) {
+          if (onSubmitComplete) {
+            onSubmitComplete({
+              saveSuccessful: false,
+              errorMessage: err.message,
+            });
+          }
+        }
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"myPostForm\\")}

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -8,6 +8,7 @@ import {
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
+import { DataStore } from \\"aws-amplify\\";
 export default function customDataForm(props) {
   const {
     onSubmit: customDataFormOnSubmit,
@@ -21,20 +22,21 @@ export default function customDataForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
-        let onSubmitBeforeFields = {};
         if (onSubmitBefore) {
-          onSubmitBeforeFields = onSubmitBefore({
-            fields: customDataFormFields,
-          });
+          setCustomDataFormFields(
+            onSubmitBefore({ fields: customDataFormFields })
+          );
         }
         try {
-          await customDataFormOnSubmit(
-            customDataFormFields,
-            onSubmitBeforeFields
+          await DataStore.save(
+            new Post(
+              useTypeCastFields({
+                fields: customDataFormFields,
+                modelName: Post.name,
+                schema,
+              })
+            )
           );
-          if (onSubmitComplete) {
-            onSubmitComplete({ saveSuccessful: true });
-          }
         } catch (err) {
           if (onSubmitComplete) {
             onSubmitComplete({
@@ -133,6 +135,7 @@ import {
 import { Post } from \\"../models\\";
 import { schema } from \\"../models/schema\\";
 import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
+import { DataStore } from \\"aws-amplify\\";
 export default function myPostForm(props) {
   const { onSubmitBefore, onSubmitComplete, onCancel, overrides, ...rest } =
     props;
@@ -146,15 +149,19 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
-        let onSubmitBeforeFields = {};
         if (onSubmitBefore) {
-          onSubmitBeforeFields = onSubmitBefore({ fields: myPostFormFields });
+          setMyPostFormFields(onSubmitBefore({ fields: myPostFormFields }));
         }
         try {
-          await myPostFormOnSubmit();
-          if (onSubmitComplete) {
-            onSubmitComplete({ saveSuccessful: true });
-          }
+          await DataStore.save(
+            new Post(
+              useTypeCastFields({
+                fields: myPostFormFields,
+                modelName: Post.name,
+                schema,
+              })
+            )
+          );
         } catch (err) {
           if (onSubmitComplete) {
             onSubmitComplete({
@@ -279,6 +286,7 @@ import {
 import { Post } from \\"../models\\";
 import { schema } from \\"../models/schema\\";
 import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
+import { DataStore } from \\"aws-amplify\\";
 export default function myPostForm(props) {
   const { id, onSubmitBefore, onSubmitComplete, onCancel, overrides, ...rest } =
     props;
@@ -293,15 +301,19 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
-        let onSubmitBeforeFields = {};
         if (onSubmitBefore) {
-          onSubmitBeforeFields = onSubmitBefore({ fields: myPostFormFields });
+          setMyPostFormFields(onSubmitBefore({ fields: myPostFormFields }));
         }
         try {
-          await myPostFormOnSubmit();
-          if (onSubmitComplete) {
-            onSubmitComplete({ saveSuccessful: true });
-          }
+          await DataStore.save(
+            new Post(
+              useTypeCastFields({
+                fields: myPostFormFields,
+                modelName: Post.name,
+                schema,
+              })
+            )
+          );
         } catch (err) {
           if (onSubmitComplete) {
             onSubmitComplete({

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -70,7 +70,9 @@ describe('amplify form renderer tests', () => {
   describe('custom form tests', () => {
     it('should render a custom backed form', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer('forms/post-custom-create', undefined);
-      expect(componentText).toContain('customDataFormOnSubmit(customDataFormFields)');
+      expect(componentText.replace(/\s/g, '')).toContain(
+        'customDataFormOnSubmit(customDataFormFields,onSubmitBeforeFields)',
+      );
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -70,9 +70,7 @@ describe('amplify form renderer tests', () => {
   describe('custom form tests', () => {
     it('should render a custom backed form', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer('forms/post-custom-create', undefined);
-      expect(componentText.replace(/\s/g, '')).toContain(
-        'customDataFormOnSubmit(customDataFormFields,onSubmitBeforeFields)',
-      );
+      expect(componentText.replace(/\s/g, '')).toContain('setCustomDataFormFields(onSubmitBefore');
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -22,7 +22,7 @@ import {
   StudioForm,
   StudioNode,
 } from '@aws-amplify/codegen-ui';
-import { factory, JsxAttribute, JsxChild, JsxElement, JsxOpeningElement, SyntaxKind } from 'typescript';
+import ts, { factory, JsxAttribute, JsxChild, JsxElement, JsxOpeningElement, SyntaxKind } from 'typescript';
 import { ReactComponentRenderer } from '../react-component-renderer';
 import { buildOpeningElementProperties, getStateName } from '../react-component-render-helper';
 import { ImportCollection } from '../imports';
@@ -108,22 +108,40 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                   [],
                 ),
               ),
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createIdentifier('onSubmitBeforeFields'),
+                      undefined,
+                      undefined,
+                      factory.createObjectLiteralExpression([], false),
+                    ),
+                  ],
+                  ts.NodeFlags.Let,
+                ),
+              ),
               factory.createIfStatement(
                 factory.createIdentifier('onSubmitBefore'),
                 factory.createBlock(
                   [
                     factory.createExpressionStatement(
-                      factory.createCallExpression(factory.createIdentifier('onSubmitBefore'), undefined, [
-                        factory.createObjectLiteralExpression(
-                          [
-                            factory.createPropertyAssignment(
-                              factory.createIdentifier('fields'),
-                              factory.createIdentifier(getStateName(FieldStateVariable(name))),
-                            ),
-                          ],
-                          false,
-                        ),
-                      ]),
+                      factory.createBinaryExpression(
+                        factory.createIdentifier('onSubmitBeforeFields'),
+                        factory.createToken(ts.SyntaxKind.EqualsToken),
+                        factory.createCallExpression(factory.createIdentifier('onSubmitBefore'), undefined, [
+                          factory.createObjectLiteralExpression(
+                            [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('fields'),
+                                factory.createIdentifier(getStateName(FieldStateVariable(name))),
+                              ),
+                            ],
+                            false,
+                          ),
+                        ]),
+                      ),
                     ),
                   ],
                   true,
@@ -138,7 +156,12 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                         factory.createCallExpression(
                           factory.createIdentifier(getActionIdentifier(name, 'onSubmit')),
                           undefined,
-                          dataSourceType === 'DataStore' ? [] : [factory.createIdentifier(getFormFieldStateName(name))],
+                          dataSourceType === 'DataStore'
+                            ? []
+                            : [
+                                factory.createIdentifier(getFormFieldStateName(name)),
+                                factory.createIdentifier('onSubmitBeforeFields'),
+                              ],
                         ),
                       ),
                     ),

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -48,6 +48,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
     );
 
     this.importCollection.addImport('@aws-amplify/ui-react', this.component.componentType);
+    this.importCollection.addImport('@aws-amplify/ui-react', 'useTypeCastFields');
     this.importCollection.addImport('aws-amplify', 'DataStore');
 
     return element;

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -24,9 +24,10 @@ import {
 } from '@aws-amplify/codegen-ui';
 import { factory, JsxAttribute, JsxChild, JsxElement, JsxOpeningElement, SyntaxKind } from 'typescript';
 import { ReactComponentRenderer } from '../react-component-renderer';
-import { buildOpeningElementProperties } from '../react-component-render-helper';
+import { buildOpeningElementProperties, getStateName } from '../react-component-render-helper';
 import { ImportCollection } from '../imports';
 import { getActionIdentifier } from '../workflow';
+import { FieldStateVariable } from '../forms/form-renderer-helper';
 
 export default class FormRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -107,12 +108,110 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                   [],
                 ),
               ),
+              factory.createIfStatement(
+                factory.createIdentifier('onSubmitBefore'),
+                factory.createBlock(
+                  [
+                    factory.createExpressionStatement(
+                      factory.createCallExpression(factory.createIdentifier('onSubmitBefore'), undefined, [
+                        factory.createObjectLiteralExpression(
+                          [
+                            factory.createPropertyAssignment(
+                              factory.createIdentifier('fields'),
+                              factory.createIdentifier(getStateName(FieldStateVariable(name))),
+                            ),
+                          ],
+                          false,
+                        ),
+                      ]),
+                    ),
+                  ],
+                  true,
+                ),
+                undefined,
+              ),
               factory.createExpressionStatement(
                 factory.createCallExpression(
                   factory.createIdentifier(getActionIdentifier(name, 'onSubmit')),
                   undefined,
                   dataSourceType === 'DataStore' ? [] : [factory.createIdentifier(getFormFieldStateName(name))],
                 ),
+              ),
+              factory.createTryStatement(
+                factory.createBlock(
+                  [
+                    factory.createExpressionStatement(
+                      factory.createAwaitExpression(
+                        factory.createCallExpression(
+                          factory.createIdentifier(getActionIdentifier(name, 'onSubmit')),
+                          undefined,
+                          dataSourceType === 'DataStore' ? [] : [factory.createIdentifier(getFormFieldStateName(name))],
+                        ),
+                      ),
+                    ),
+                    factory.createIfStatement(
+                      factory.createIdentifier('onSubmitComplete'),
+                      factory.createBlock(
+                        [
+                          factory.createExpressionStatement(
+                            factory.createCallExpression(factory.createIdentifier('onSubmitComplete'), undefined, [
+                              factory.createObjectLiteralExpression(
+                                [
+                                  factory.createPropertyAssignment(
+                                    factory.createIdentifier('saveSuccessful'),
+                                    factory.createTrue(),
+                                  ),
+                                ],
+                                false,
+                              ),
+                            ]),
+                          ),
+                        ],
+                        true,
+                      ),
+                      undefined,
+                    ),
+                  ],
+                  true,
+                ),
+                factory.createCatchClause(
+                  factory.createVariableDeclaration(factory.createIdentifier('err'), undefined, undefined, undefined),
+                  factory.createBlock(
+                    [
+                      factory.createIfStatement(
+                        factory.createIdentifier('onSubmitComplete'),
+                        factory.createBlock(
+                          [
+                            factory.createExpressionStatement(
+                              factory.createCallExpression(factory.createIdentifier('onSubmitComplete'), undefined, [
+                                factory.createObjectLiteralExpression(
+                                  [
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('saveSuccessful'),
+                                      factory.createFalse(),
+                                    ),
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('errorMessage'),
+                                      factory.createPropertyAccessExpression(
+                                        factory.createIdentifier('err'),
+                                        factory.createIdentifier('message'),
+                                      ),
+                                    ),
+                                  ],
+                                  false,
+                                ),
+                              ]),
+                            ),
+                          ],
+                          true,
+                        ),
+                        undefined,
+                      ),
+                    ],
+                    true,
+                  ),
+                ),
+                undefined,
               ),
             ],
             false,

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -130,13 +130,6 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                 ),
                 undefined,
               ),
-              factory.createExpressionStatement(
-                factory.createCallExpression(
-                  factory.createIdentifier(getActionIdentifier(name, 'onSubmit')),
-                  undefined,
-                  dataSourceType === 'DataStore' ? [] : [factory.createIdentifier(getFormFieldStateName(name))],
-                ),
-              ),
               factory.createTryStatement(
                 factory.createBlock(
                   [


### PR DESCRIPTION
*Issue #, if available:* 
https://app.asana.com/0/1202624607923297/1202422922235645

*Description of changes:* 
listen to onSubmitBefore and onSubmitComplete events 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
