### PR TITLE
fix: limit workers during testing in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "homepage": "https://docs.amplify.aws/",
   "scripts": {
     "test": "lerna run test --stream",
+    "test:ci": "lerna run test:ci --stream",
     "test:update": "lerna run test:update --stream",
     "build": "lerna run build --stream",
     "setup-dev": "npm install && lerna bootstrap && lerna run build",

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test:ci": "jest --ci --maxWorkers=30%",
     "test:update": "jest --updateSnapshot",
     "build": "tsc -p tsconfig.build.json",
     "build:watch": "npm run build -- --watch"

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test:ci": "jest --ci --maxWorkers=30%",
     "test:update": "jest --updateSnapshot",
     "build": "tsc -p tsconfig.build.json",
     "build:watch": "npm run build -- --watch"


### PR DESCRIPTION
*Description of changes:*
Unit tests sometimes hang after finishing successfully in CI. This limits workers to factor in the limited capacity in CI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
