### PR TITLE
fix: change props of SwitchField form element

### DIFF
--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -93,8 +93,7 @@ export function getFormDefinitionInputElement(
             config.inputType?.defaultChecked,
             baseConfig?.inputType?.defaultChecked,
           ]),
-          isRequired: getFirstDefinedValue([config.inputType?.required, baseConfig?.inputType?.required]),
-          isReadOnly: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
+          isDisabled: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
         },
       };
 

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -30,7 +30,7 @@ export type FormDefinitionTextFieldElement = {
 
 export type FormDefinitionSwitchFieldElement = {
   componentType: 'SwitchField';
-  props: { label: string; defaultChecked?: boolean; isRequired?: boolean; isReadOnly?: boolean };
+  props: { label: string; defaultChecked?: boolean; isDisabled?: boolean };
 };
 
 export type FormDefinitionPhoneNumberFieldElement = {


### PR DESCRIPTION
*Description of changes:*
`isRequired` and `isReadOnly` have no effect on `SwitchField`. Remove `isRequired` and replace `isReadOnly` with `isDisabled`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
