### PR TITLE
fix: onSubmit for custom forms

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -9,7 +9,6 @@ import {
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
-import { DataStore } from \\"aws-amplify\\";
 export default function customDataForm(props) {
   const {
     onSubmit: customDataFormOnSubmit,
@@ -26,22 +25,7 @@ export default function customDataForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
-        if (onSubmitBefore) {
-          setModelFields(onSubmitBefore({ fields: modelFields }));
-        }
-        try {
-          await DataStore.save(new Post(modelFields));
-          if (onSubmitComplete) {
-            onSubmitComplete({ saveSuccessful: true });
-          }
-        } catch (err) {
-          if (onSubmitComplete) {
-            onSubmitComplete({
-              saveSuccessful: false,
-              errorMessage: err.message,
-            });
-          }
-        }
+        await customDataFormOnSubmit(modelFields);
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"customDataForm\\")}

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -13,36 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-
-import { StudioTemplateRendererFactory } from '@aws-amplify/codegen-ui/lib/template-renderer-factory';
-import { StudioForm, Schema, GenericDataSchema, getGenericFromDataStore } from '@aws-amplify/codegen-ui';
-import { ReactRenderConfig, AmplifyFormRenderer, ModuleKind, ScriptKind, ScriptTarget } from '..';
-import { loadSchemaFromJSONFile } from './__utils__';
-
-export const defaultCLIRenderConfig: ReactRenderConfig = {
-  module: ModuleKind.ES2020,
-  target: ScriptTarget.ES2020,
-  script: ScriptKind.JSX,
-  renderTypeDeclarations: true,
-};
-
-export const generateWithAmplifyFormRenderer = (
-  formJsonFile: string,
-  dataSchemaJsonFile: string | undefined,
-  renderConfig: ReactRenderConfig = defaultCLIRenderConfig,
-): { componentText: string; declaration?: string } => {
-  let dataSchema: GenericDataSchema | undefined;
-  if (dataSchemaJsonFile) {
-    const dataStoreSchema = loadSchemaFromJSONFile<Schema>(dataSchemaJsonFile);
-    dataSchema = getGenericFromDataStore(dataStoreSchema);
-  }
-  const rendererFactory = new StudioTemplateRendererFactory(
-    (component: StudioForm) => new AmplifyFormRenderer(component, dataSchema, renderConfig),
-  );
-
-  const renderer = rendererFactory.buildRenderer(loadSchemaFromJSONFile<StudioForm>(formJsonFile));
-  return renderer.renderComponent();
-};
+import { generateWithAmplifyFormRenderer } from './__utils__';
 
 describe('amplify form renderer tests', () => {
   describe('datastore form tests', () => {
@@ -70,7 +41,7 @@ describe('amplify form renderer tests', () => {
   describe('custom form tests', () => {
     it('should render a custom backed form', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer('forms/post-custom-create', undefined);
-      expect(componentText.replace(/\s/g, '')).toContain('setModelFields(onSubmitBefore');
+      expect(componentText.replace(/\s/g, '')).toContain('onSubmit:customDataFormOnSubmit');
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -97,7 +97,7 @@ export const buildMutationBindings = (form: StudioForm) => {
       factory.createBindingElement(
         undefined,
         factory.createIdentifier('onSubmit'),
-        getActionIdentifier(form.name, 'onSubmit'),
+        getActionIdentifier(form.name, 'onSubmit'), // custom onsubmit function with the name of the form
         undefined,
       ),
     );


### PR DESCRIPTION
*Issue #, if available:*
- Custom Forms were still generating the DataStore save functionality
*Description of changes:*
- This uses the custom onSubmit hook which is passed in for custom forms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
