### PR TITLE
feat: support for cta labels

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -106,7 +106,7 @@ export default function customDataForm(props) {
         {...getOverrideProps(overrides, \\"CTAFlex\\")}
       >
         <Button
-          label=\\"Cancel\\"
+          label=\\"go back\\"
           type=\\"button\\"
           onClick={() => {
             onCancel && onCancel();
@@ -115,12 +115,12 @@ export default function customDataForm(props) {
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
           <Button
-            label=\\"Clear\\"
+            label=\\"empty\\"
             type=\\"reset\\"
             {...getOverrideProps(overrides, \\"ClearButton\\")}
           ></Button>
           <Button
-            label=\\"Submit\\"
+            label=\\"create\\"
             type=\\"submit\\"
             variation=\\"primary\\"
             isDisabled={!formValid}

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
@@ -37,6 +37,7 @@ describe('form-render utils', () => {
       fields: {},
       sectionalElements: {},
       style: {},
+      ctaConfig: {},
     };
 
     const propSignatures = buildFormPropNode(form);
@@ -53,6 +54,7 @@ describe('form-render utils', () => {
       fields: {},
       sectionalElements: {},
       style: {},
+      ctaConfig: {},
     };
     const propSignatures = buildFormPropNode(form);
     const node = printNode(propSignatures);

--- a/packages/codegen-ui/example-schemas/forms/post-custom-create.json
+++ b/packages/codegen-ui/example-schemas/forms/post-custom-create.json
@@ -26,5 +26,19 @@
     }
   },
   "sectionalElements": {},
-  "style": {}
+  "style": {},
+  "ctaConfig": {
+    "clear": {
+      "visible": true,
+      "label": "empty"
+    },
+    "cancel": {
+      "visible": true,
+      "label": "go back"
+    },
+    "submit": {
+      "visible": true,
+      "label": "create"
+    }
+  }
 }

--- a/packages/codegen-ui/example-schemas/forms/post-datastore-create.json
+++ b/packages/codegen-ui/example-schemas/forms/post-datastore-create.json
@@ -7,5 +7,6 @@
   },
   "fields": {},
   "sectionalElements": {},
-  "style": {}
+  "style": {},
+  "ctaConfig": {}
 }

--- a/packages/codegen-ui/example-schemas/forms/post-datastore-update.json
+++ b/packages/codegen-ui/example-schemas/forms/post-datastore-update.json
@@ -7,5 +7,6 @@
   },
   "fields": {},
   "sectionalElements": {},
-  "style": {}
+  "style": {},
+  "ctaConfig": {}
 }

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -26,6 +26,7 @@ describe('generateFormDefinition', () => {
         fields: {},
         sectionalElements: {},
         style: {},
+        ctaConfig: {},
       },
       dataSchema: {
         dataSourceType: 'DataStore',
@@ -42,6 +43,80 @@ describe('generateFormDefinition', () => {
     });
   });
 
+  it('should map ctaConfig options', () => {
+    const formDefinition = generateFormDefinition({
+      form: {
+        id: '123',
+        name: 'sampleForm',
+        formActionType: 'create',
+        dataType: { dataSourceType: 'Custom', dataTypeName: 'dfsdjflk' },
+        fields: {},
+        sectionalElements: {},
+        style: {},
+        ctaConfig: {
+          position: 'bottom',
+          cancel: {
+            visible: false,
+            label: 'cancelling',
+          },
+          clear: {
+            visible: false,
+            label: 'clearing',
+          },
+          submit: {
+            visible: false,
+            label: 'create',
+          },
+        },
+      },
+    });
+    expect(formDefinition.buttons).toStrictEqual({
+      position: 'bottom',
+      cancel: {
+        visible: false,
+        label: 'cancelling',
+      },
+      clear: {
+        visible: false,
+        label: 'clearing',
+      },
+      submit: {
+        visible: false,
+        label: 'create',
+      },
+    });
+  });
+
+  it('should map empty ctaConfig to defaults', () => {
+    const formDefinition = generateFormDefinition({
+      form: {
+        id: '123',
+        name: 'sampleForm',
+        formActionType: 'create',
+        dataType: { dataSourceType: 'Custom', dataTypeName: 'dfsdjflk' },
+        fields: {},
+        sectionalElements: {},
+        style: {},
+        ctaConfig: {},
+      },
+    });
+    expect(formDefinition.buttons).toStrictEqual({
+      position: 'bottom',
+      cancel: {
+        visible: true,
+        label: 'Cancel',
+      },
+      clear: {
+        visible: true,
+        label: 'Clear',
+      },
+      submit: {
+        visible: true,
+        label: 'Submit',
+      },
+    });
+  });
+
   it('should throw if form has source type DataStore, but no schema is available', () => {
     expect(() =>
       generateFormDefinition({
@@ -53,6 +128,7 @@ describe('generateFormDefinition', () => {
           fields: {},
           sectionalElements: {},
           style: {},
+          ctaConfig: {},
         },
       }),
     ).toThrow();
@@ -68,6 +144,7 @@ describe('generateFormDefinition', () => {
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: {},
         style: {},
+        ctaConfig: {},
       },
       dataSchema: {
         dataSourceType: 'DataStore',
@@ -94,6 +171,7 @@ describe('generateFormDefinition', () => {
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: {},
         style: {},
+        ctaConfig: {},
       },
       dataSchema: {
         dataSourceType: 'DataStore',
@@ -116,6 +194,7 @@ describe('generateFormDefinition', () => {
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: {},
         style: {},
+        ctaConfig: {},
       },
       dataSchema: { dataSourceType: 'DataStore', enums: {}, nonModels: {}, models: { Dog: { fields: {} } } },
     });
@@ -134,6 +213,7 @@ describe('generateFormDefinition', () => {
         fields: { weight: { inputType: { type: 'SliderField', minValue: 1, maxValue: 100, step: 2 } } },
         sectionalElements: {},
         style: {},
+        ctaConfig: {},
       },
       dataSchema: { dataSourceType: 'DataStore', enums: {}, nonModels: {}, models: { Dog: { fields: {} } } },
     });
@@ -152,6 +232,7 @@ describe('generateFormDefinition', () => {
           Heading123: { type: 'Heading', position: { fixed: 'first' }, level: 1, text: 'Create Dog' },
         },
         style: {},
+        ctaConfig: {},
       },
     });
     expect(formDefinition.elements.Heading123).toStrictEqual({
@@ -175,6 +256,7 @@ describe('generateFormDefinition', () => {
         fields: {},
         sectionalElements: {},
         style,
+        ctaConfig: {},
       },
     });
     expect(formDefinition.form.layoutStyle).toStrictEqual(style);
@@ -197,6 +279,7 @@ describe('generateFormDefinition', () => {
         },
 
         style: {},
+        ctaConfig: {},
       },
       dataSchema: {
         dataSourceType: 'DataStore',
@@ -233,6 +316,7 @@ describe('generateFormDefinition', () => {
         },
 
         style: {},
+        ctaConfig: {},
       },
       dataSchema: {
         dataSourceType: 'DataStore',
@@ -271,6 +355,7 @@ it('should requeue if related element is not yet found', () => {
       },
 
       style: {},
+      ctaConfig: {},
     },
   });
   expect(formDefinition.elementMatrix).toStrictEqual([['Heading123'], ['name', 'age', 'weight'], ['color']]);
@@ -295,6 +380,7 @@ it('should handle fields without position', () => {
       },
 
       style: {},
+      ctaConfig: {},
     },
   });
   expect(formDefinition.elementMatrix).toStrictEqual([['Heading123'], ['name', 'age', 'weight'], ['color'], ['bark']]);
@@ -311,6 +397,7 @@ it('should fill out styles using defaults', () => {
       sectionalElements: {},
 
       style: {},
+      ctaConfig: {},
     },
   });
 
@@ -331,6 +418,7 @@ it('should skip read-only fields without overrides', () => {
       fields: {},
       sectionalElements: {},
       style: {},
+      ctaConfig: {},
     },
     dataSchema: {
       dataSourceType: 'DataStore',
@@ -359,6 +447,7 @@ it('should add read-only fields if it has overrides', () => {
       fields: { name: { inputType: { type: 'TextField' } } },
       sectionalElements: {},
       style: {},
+      ctaConfig: {},
     },
     dataSchema: {
       dataSourceType: 'DataStore',
@@ -392,6 +481,7 @@ it('should skip adding id field if it has no overrides', () => {
       fields: {},
       sectionalElements: {},
       style: {},
+      ctaConfig: {},
     },
     dataSchema: {
       dataSourceType: 'DataStore',

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/map-elements.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/map-elements.test.ts
@@ -54,6 +54,7 @@ describe('mapElements', () => {
       fields: { name: { inputType: { type: 'TextField' } } },
       sectionalElements: { myText: sectionalConfig },
       style: {},
+      ctaConfig: {},
     };
 
     mapElements({ formDefinition, modelFieldsConfigs, form });
@@ -87,6 +88,7 @@ describe('mapElements', () => {
       fields: {},
       sectionalElements: {},
       style: {},
+      ctaConfig: {},
     };
 
     expect(() => mapElements({ formDefinition, modelFieldsConfigs, form })).toThrow();

--- a/packages/codegen-ui/lib/generate-form-definition/form-to-component.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/form-to-component.ts
@@ -22,6 +22,7 @@ import {
   StudioComponentProperties,
   StudioFormStyle,
 } from '../types';
+import { FORM_DEFINITION_DEFAULTS } from './helpers/defaults';
 
 const getStyleResolvedValue = (config?: FormStyleConfig): string | undefined => {
   return config?.value ?? config?.tokenReference;
@@ -88,7 +89,19 @@ export const fieldComponentMapper = (name: string, formDefinition: FormDefinitio
   return parentGrid(`${name}Grid`, formDefinition.form.layoutStyle, fieldChildren);
 };
 
-export const ctaButtonConfig = (): StudioComponentChild => {
+const resolveCtaLabels = (
+  formDefinition: FormDefinition,
+): { cancelLabel: string; clearLabel: string; submitLabel: string } => {
+  const cancelLabel = formDefinition.buttons.cancel?.label || FORM_DEFINITION_DEFAULTS.ctaConfig.cancel.label;
+  const clearLabel = formDefinition.buttons.clear?.label || FORM_DEFINITION_DEFAULTS.ctaConfig.clear.label;
+  const submitLabel = formDefinition.buttons.submit?.label || FORM_DEFINITION_DEFAULTS.ctaConfig.submit.label;
+
+  return { cancelLabel, clearLabel, submitLabel };
+};
+
+export const ctaButtonConfig = (formDefinition: FormDefinition): StudioComponentChild => {
+  const { cancelLabel, clearLabel, submitLabel } = resolveCtaLabels(formDefinition);
+
   return {
     name: 'CTAFlex',
     componentType: 'Flex',
@@ -106,7 +119,7 @@ export const ctaButtonConfig = (): StudioComponentChild => {
         name: 'CancelButton',
         properties: {
           label: {
-            value: 'Cancel',
+            value: cancelLabel,
           },
           type: {
             value: 'button',
@@ -123,7 +136,7 @@ export const ctaButtonConfig = (): StudioComponentChild => {
             name: 'ClearButton',
             properties: {
               label: {
-                value: 'Clear',
+                value: clearLabel,
               },
               type: {
                 value: 'reset',
@@ -135,7 +148,7 @@ export const ctaButtonConfig = (): StudioComponentChild => {
             name: 'SubmitButton',
             properties: {
               label: {
-                value: 'Submit',
+                value: submitLabel,
               },
               type: {
                 value: 'submit',
@@ -160,8 +173,7 @@ export const mapFormDefinitionToComponent = (name: string, formDefinition: FormD
       onCancel: { type: 'Event' },
     },
     events: {},
-    // TODO: change cta button config based on formDefinition cta layout
-    children: [fieldComponentMapper(name, formDefinition), ctaButtonConfig()],
+    children: [fieldComponentMapper(name, formDefinition), ctaButtonConfig(formDefinition)],
   };
   return component;
 };

--- a/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 
-import { mapModelFieldsConfigs, mapElementMatrix, mapStyles, mapElements } from './helpers';
+import { mapModelFieldsConfigs, mapElementMatrix, mapStyles, mapElements, mapButtons } from './helpers';
 import { StudioForm, FormDefinition, ModelFieldsConfigs, StudioFieldPosition, GenericDataSchema } from '../types';
 import { InvalidInputError } from '../errors';
 
@@ -71,6 +71,8 @@ export function generateFormDefinition({
   mapElements({ form, formDefinition, modelFieldsConfigs });
 
   formDefinition.form.layoutStyle = mapStyles(form.style);
+
+  formDefinition.buttons = mapButtons(form.ctaConfig);
 
   return formDefinition;
 }

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/defaults.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/defaults.ts
@@ -40,4 +40,20 @@ export const FORM_DEFINITION_DEFAULTS = {
   sectionalElement: {
     text: 'text',
   },
+
+  ctaConfig: {
+    position: 'bottom',
+    cancel: {
+      visible: true,
+      label: 'Cancel',
+    },
+    clear: {
+      visible: true,
+      label: 'Clear',
+    },
+    submit: {
+      visible: true,
+      label: 'Submit',
+    },
+  },
 };

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/index.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/index.ts
@@ -20,3 +20,4 @@ export * from './sectional-element';
 export * from './field-type-map';
 export * from './map-element';
 export * from './map-styles';
+export * from './map-cta';

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/map-cta.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/map-cta.ts
@@ -1,0 +1,36 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { FORM_DEFINITION_DEFAULTS } from './defaults';
+import { StudioFormCTAConfig } from '../../types';
+
+export function mapButtons(buttons: StudioFormCTAConfig): StudioFormCTAConfig {
+  const defaults = FORM_DEFINITION_DEFAULTS.ctaConfig;
+  return {
+    position: buttons.position ? buttons.position : defaults.position,
+    clear: {
+      visible: typeof buttons.clear?.visible === 'boolean' ? buttons.clear?.visible : defaults.clear.visible,
+      label: buttons.clear?.label ? buttons.clear.label : defaults.clear.label,
+    },
+    cancel: {
+      visible: typeof buttons.cancel?.visible === 'boolean' ? buttons.cancel.visible : defaults.cancel.visible,
+      label: buttons.cancel?.label ? buttons.cancel.label : defaults.cancel.label,
+    },
+    submit: {
+      visible: typeof buttons.submit?.visible === 'boolean' ? buttons.submit.visible : defaults.submit.visible,
+      label: buttons.submit?.label ? buttons.submit.label : defaults.submit.label,
+    },
+  };
+}

--- a/packages/codegen-ui/lib/types/form/form-cta.ts
+++ b/packages/codegen-ui/lib/types/form/form-cta.ts
@@ -13,22 +13,28 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-// import { postSchema } from '../__utils__/mock-schemas';
-import { StudioForm } from '../../types';
+import { StudioFieldPosition } from './position';
 
-describe('formToComponent', () => {
-  it('should map datastore model fields', () => {
-    const myForm: StudioForm = {
-      id: '123',
-      name: 'mySampleForm',
-      formActionType: 'create',
-      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Post' },
-      fields: {},
-      sectionalElements: {},
-      style: {},
-      ctaConfig: {},
-    };
+type StudioFormButton = {
+  visible: boolean;
 
-    expect(myForm).toBeDefined();
-  });
-});
+  label?: string;
+
+  position?: StudioFieldPosition;
+};
+
+/**
+ * Configuration for each of the specified CTA's
+ */
+export type StudioFormCTAConfig = {
+  /**
+   * The position of the CTA's in the form when rendered
+   */
+  position?: string;
+
+  clear?: StudioFormButton;
+
+  cancel?: StudioFormButton;
+
+  submit?: StudioFormButton;
+};

--- a/packages/codegen-ui/lib/types/form/form-definition.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition.ts
@@ -16,6 +16,7 @@
 import { StudioFormStyle } from './style';
 import { FormDefinitionElement } from './form-definition-element';
 import { StudioGenericFieldConfig } from './fields';
+import { StudioFormCTAConfig } from './form-cta';
 
 export type ModelFieldsConfigs = { [key: string]: StudioGenericFieldConfig };
 
@@ -24,7 +25,7 @@ export type FormDefinition = {
     layoutStyle: StudioFormStyle;
   };
   elements: { [element: string]: FormDefinitionElement };
-  buttons: { [key: string]: string };
+  buttons: StudioFormCTAConfig;
   elementMatrix: string[][];
   inputFields?: string[];
 };

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -21,6 +21,7 @@ import { FormDefinition, ModelFieldsConfigs, FieldTypeMapKeys } from './form-def
 import { StudioFieldInputConfig, StudioFormValueMappings } from './input-config';
 import { StudioFieldPosition } from './position';
 import { FormMetadata } from './form-metadata';
+import { StudioFormCTAConfig } from './form-cta';
 
 /**
  * Data type definition for StudioForm
@@ -52,6 +53,8 @@ export type StudioForm = {
   sectionalElements: { [elementName: string]: SectionalElement };
 
   style: StudioFormStyle;
+
+  ctaConfig: StudioFormCTAConfig;
 };
 
 export * from './form-definition-element';
@@ -71,4 +74,5 @@ export type {
   StudioFieldPosition,
   FieldTypeMapKeys,
   StudioFormValueMappings,
+  StudioFormCTAConfig,
 };


### PR DESCRIPTION
*Issue #, if available:*
Updates FormDefinition and StudioForm to accept StudioFormButtons to customize CTA label names, visibility, and row position.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
