### PR TITLE
feat: add default, unremovable validations for certain form inputs

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -256,7 +256,7 @@ export default function myPostForm(props) {
               const { value } = e.target;
               const isValidResult = onValidate?.[\\"post_url\\"]
                 ? await onValidate[\\"post_url\\"](value)
-                : validateField(value, []);
+                : validateField(value, [{ type: \\"URL\\" }]);
               setPost_urlFieldError({
                 ...post_urlFieldError,
                 ...isValidResult,
@@ -283,7 +283,7 @@ export default function myPostForm(props) {
               const { value } = e.target;
               const isValidResult = onValidate?.[\\"profile_url\\"]
                 ? await onValidate[\\"profile_url\\"](value)
-                : validateField(value, []);
+                : validateField(value, [{ type: \\"URL\\" }]);
               setProfile_urlFieldError({
                 ...profile_urlFieldError,
                 ...isValidResult,
@@ -512,7 +512,7 @@ export default function myPostForm(props) {
               const { value } = e.target;
               const isValidResult = onValidate?.[\\"profile_url\\"]
                 ? await onValidate[\\"profile_url\\"](value)
-                : validateField(value, []);
+                : validateField(value, [{ type: \\"URL\\" }]);
               setProfile_urlFieldError({
                 ...profile_urlFieldError,
                 ...isValidResult,
@@ -539,7 +539,7 @@ export default function myPostForm(props) {
               const { value } = e.target;
               const isValidResult = onValidate?.[\\"post_url\\"]
                 ? await onValidate[\\"post_url\\"](value)
-                : validateField(value, []);
+                : validateField(value, [{ type: \\"URL\\" }]);
               setPost_urlFieldError({
                 ...post_urlFieldError,
                 ...isValidResult,

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
@@ -16,7 +16,15 @@
 
 import { mapFormFieldConfig, getFormDefinitionInputElement } from '../../../generate-form-definition/helpers';
 import { mergeValueMappings } from '../../../generate-form-definition/helpers/form-field';
-import { FormDefinition, ModelFieldsConfigs, StudioFormFieldConfig, StudioGenericFieldConfig } from '../../../types';
+import {
+  FormDefinition,
+  GenericValidationType,
+  ModelFieldsConfigs,
+  StringLengthValidationType,
+  StudioFormFieldConfig,
+  StudioGenericFieldConfig,
+  ValidationTypes,
+} from '../../../types';
 
 describe('mapFormFieldConfig', () => {
   it('should map fields', () => {
@@ -197,6 +205,7 @@ describe('getFormDefinitionInputElement', () => {
         label: 'Label',
       },
       studioFormComponentType: 'IPAddressField',
+      validations: [{ type: ValidationTypes.IP_ADDRESS, immutable: true }],
     });
   });
 
@@ -213,6 +222,7 @@ describe('getFormDefinitionInputElement', () => {
         label: 'Label',
       },
       studioFormComponentType: 'URLField',
+      validations: [{ type: ValidationTypes.URL, immutable: true }],
     });
   });
 
@@ -229,6 +239,7 @@ describe('getFormDefinitionInputElement', () => {
         label: 'Label',
       },
       studioFormComponentType: 'EmailField',
+      validations: [{ type: ValidationTypes.EMAIL, immutable: true }],
     });
   });
 
@@ -325,6 +336,38 @@ describe('getFormDefinitionInputElement', () => {
         label: 'Label',
       },
       studioFormComponentType: 'JSONField',
+      validations: [{ type: ValidationTypes.JSON, immutable: true }],
+    });
+  });
+
+  it('should merge validations', () => {
+    const configValidation: StringLengthValidationType = {
+      type: ValidationTypes.LESS_THAN_CHAR_LENGTH,
+      numValues: [4],
+    };
+    const config = {
+      inputType: {
+        type: 'JSONField',
+      },
+      validations: [configValidation],
+    };
+
+    const baseConfigValidation: GenericValidationType = { type: ValidationTypes.REQUIRED };
+
+    const baseConfig = {
+      inputType: {
+        type: 'JSONField',
+      },
+      validations: [baseConfigValidation],
+    };
+
+    expect(getFormDefinitionInputElement(config, baseConfig)).toStrictEqual({
+      componentType: 'TextAreaField',
+      props: {
+        label: 'Label',
+      },
+      studioFormComponentType: 'JSONField',
+      validations: [{ type: ValidationTypes.JSON, immutable: true }, baseConfigValidation, configValidation],
     });
   });
 

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -14,7 +14,12 @@
   limitations under the License.
  */
 
+import { FieldValidationConfiguration } from './form-validation';
 import { StudioFormValueMappings } from './input-config';
+
+type FormDefinitionInputElementCommon = {
+  validations?: (FieldValidationConfiguration & { immutable?: true })[];
+};
 
 export type FormDefinitionTextFieldElement = {
   componentType: 'TextField';
@@ -147,7 +152,7 @@ export type FormDefinitionPasswordFieldElement = {
   };
 };
 
-export type FormDefinitionInputElement =
+export type FormDefinitionInputElement = (
   | FormDefinitionTextFieldElement
   | FormDefinitionSwitchFieldElement
   | FormDefinitionPhoneNumberFieldElement
@@ -158,7 +163,9 @@ export type FormDefinitionInputElement =
   | FormDefinitionToggleButtonElement
   | FormDefinitionCheckboxFieldElement
   | FormDefinitionRadioGroupFieldElement
-  | FormDefinitionPasswordFieldElement;
+  | FormDefinitionPasswordFieldElement
+) &
+  FormDefinitionInputElementCommon;
 
 export type FormDefinitionHeadingElement = {
   componentType: 'Heading';

--- a/packages/codegen-ui/lib/utils/form-component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/form-component-metadata.ts
@@ -31,14 +31,21 @@ export const mapFormMetadata = (form: StudioForm, formDefinition: FormDefinition
       }
       return fields;
     }, []),
-    onValidationFields: Object.entries(form.fields).reduce<{ [field: string]: FieldValidationConfiguration[] }>(
-      (validationFields, [field, config]) => {
-        const updatedFields = validationFields;
-        updatedFields[field] = ('validations' in config && config.validations) || [];
-        return updatedFields;
-      },
-      {},
-    ),
+    onValidationFields: Object.entries(formDefinition.elements).reduce<{
+      [field: string]: FieldValidationConfiguration[];
+    }>((validationFields, [elementName, elementConfig]) => {
+      const updatedValidationFields = validationFields;
+
+      if ('validations' in elementConfig && elementConfig.validations) {
+        updatedValidationFields[elementName] = elementConfig.validations.map((validation) => {
+          const updatedValidation = validation;
+          delete updatedValidation.immutable;
+          return updatedValidation;
+        });
+      }
+
+      return updatedValidationFields;
+    }, {}),
     errorStateFields: [],
   };
 };


### PR DESCRIPTION
Notes:
- the `immutable` field of the mapped validations in the form definition is for use in Amplify Studio for styling/ UI purposes. It is removed when the customer form is being rendered.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.