### PR TITLE
chore: separate out and export logic to map model field to field config

### DIFF
--- a/packages/codegen-ui/lib/generate-form-definition/index.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/index.ts
@@ -18,6 +18,7 @@ export {
   getFormDefinitionInputElement,
   getFormDefinitionSectionalElement,
   getFieldTypeMapKey,
+  getFieldConfigFromModelField,
 } from './helpers';
 export { generateFormDefinition } from './generate-form-definition';
 export { mapFormDefinitionToComponent } from './form-to-component';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
separate out and export logic to map model field to field config so that it can be used in Amplify Studio.
Needed in order to take advantage of the case conversion for label and enum mappings for previews.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
