### PR TITLE
fix: update label to children for cta buttons on forms

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -90,7 +90,7 @@ export default function customDataForm(props) {
         {...getOverrideProps(overrides, \\"CTAFlex\\")}
       >
         <Button
-          label=\\"Cancel\\"
+          children=\\"Cancel\\"
           type=\\"button\\"
           onClick={() => {
             onCancel && onCancel();
@@ -99,12 +99,12 @@ export default function customDataForm(props) {
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
           <Button
-            label=\\"Clear\\"
+            children=\\"Clear\\"
             type=\\"reset\\"
             {...getOverrideProps(overrides, \\"ClearButton\\")}
           ></Button>
           <Button
-            label=\\"Submit\\"
+            children=\\"Submit\\"
             type=\\"submit\\"
             variation=\\"primary\\"
             isDisabled={!formValid}
@@ -303,7 +303,7 @@ export default function myPostForm(props) {
         {...getOverrideProps(overrides, \\"CTAFlex\\")}
       >
         <Button
-          label=\\"Cancel\\"
+          children=\\"Cancel\\"
           type=\\"button\\"
           onClick={() => {
             onCancel && onCancel();
@@ -312,12 +312,12 @@ export default function myPostForm(props) {
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
           <Button
-            label=\\"Clear\\"
+            children=\\"Clear\\"
             type=\\"reset\\"
             {...getOverrideProps(overrides, \\"ClearButton\\")}
           ></Button>
           <Button
-            label=\\"Submit\\"
+            children=\\"Submit\\"
             type=\\"submit\\"
             variation=\\"primary\\"
             isDisabled={!formValid}
@@ -559,7 +559,7 @@ export default function myPostForm(props) {
         {...getOverrideProps(overrides, \\"CTAFlex\\")}
       >
         <Button
-          label=\\"Cancel\\"
+          children=\\"Cancel\\"
           type=\\"button\\"
           onClick={() => {
             onCancel && onCancel();
@@ -568,12 +568,12 @@ export default function myPostForm(props) {
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
           <Button
-            label=\\"Clear\\"
+            children=\\"Clear\\"
             type=\\"reset\\"
             {...getOverrideProps(overrides, \\"ClearButton\\")}
           ></Button>
           <Button
-            label=\\"Submit\\"
+            children=\\"Submit\\"
             type=\\"submit\\"
             variation=\\"primary\\"
             isDisabled={!formValid}

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-react",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript/vfs": "~1.3.5",

--- a/packages/codegen-ui/lib/generate-form-definition/form-to-component.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/form-to-component.ts
@@ -105,7 +105,7 @@ export const ctaButtonConfig = (): StudioComponentChild => {
         componentType: 'Button',
         name: 'CancelButton',
         properties: {
-          label: {
+          children: {
             value: 'Cancel',
           },
           type: {
@@ -122,7 +122,7 @@ export const ctaButtonConfig = (): StudioComponentChild => {
             componentType: 'Button',
             name: 'ClearButton',
             properties: {
-              label: {
+              children: {
                 value: 'Clear',
               },
               type: {
@@ -134,7 +134,7 @@ export const ctaButtonConfig = (): StudioComponentChild => {
             componentType: 'Button',
             name: 'SubmitButton',
             properties: {
-              label: {
+              children: {
                 value: 'Submit',
               },
               type: {

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"change-case": "^4.1.2",

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-test-generator",
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "^15.12.1",


### PR DESCRIPTION
update form-to-component ctaConfig to use children as opposed to labels
to render the button text

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
