### PR TITLE
fix: fix release yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get Version Number
         id: get-version-number
         run: |
-          version_number=$(echo "${{github.event.head_commit.message}}" | sed -e "s/^chore(release): v//" -e "s/ (#[[:digit:]]\+)$//")
+          version_number=$(echo "${{github.event.head_commit.message}}" | sed -n "s/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p")
           echo "::set-output name=version_number::$version_number"
       - name: Get Release Description
         run: npx -y changelog-parser CHANGELOG.md | jq -r '.versions[0].body' > release_description.md


### PR DESCRIPTION
*Issue #, if available:*
sed command in version number can print characters other than version number

*Description of changes:*
- update `sed` command to only print "0-9" and "." to get version number

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
