### PR TITLE
chore: move form-to-component util

### DIFF
--- a/packages/codegen-ui/lib/generate-form-definition/index.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/index.ts
@@ -21,4 +21,3 @@ export {
   getFieldConfigFromModelField,
 } from './helpers';
 export { generateFormDefinition } from './generate-form-definition';
-export { mapFormDefinitionToComponent } from './form-to-component';

--- a/packages/codegen-ui/lib/utils/form-to-component/index.ts
+++ b/packages/codegen-ui/lib/utils/form-to-component/index.ts
@@ -13,21 +13,4 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-// import { postSchema } from '../__utils__/mock-schemas';
-import { StudioForm } from '../../types';
-
-describe('formToComponent', () => {
-  it('should map datastore model fields', () => {
-    const myForm: StudioForm = {
-      id: '123',
-      name: 'mySampleForm',
-      formActionType: 'create',
-      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Post' },
-      fields: {},
-      sectionalElements: {},
-      style: {},
-    };
-
-    expect(myForm).toBeDefined();
-  });
-});
+export { mapFormDefinitionToComponent } from './map-form-definition-to-component';

--- a/packages/codegen-ui/lib/utils/form-to-component/map-form-definition-to-component.ts
+++ b/packages/codegen-ui/lib/utils/form-to-component/map-form-definition-to-component.ts
@@ -21,13 +21,13 @@ import {
   FormStyleConfig,
   StudioComponentProperties,
   StudioFormStyle,
-} from '../types';
+} from '../../types';
 
 const getStyleResolvedValue = (config?: FormStyleConfig): string | undefined => {
   return config?.value ?? config?.tokenReference;
 };
 
-export const resolveStyles = (
+const resolveStyles = (
   style: StudioFormStyle,
 ): Record<keyof Omit<StudioFormStyle, 'alignment'>, string | undefined> => {
   return {
@@ -37,11 +37,7 @@ export const resolveStyles = (
   };
 };
 
-export const parentGrid = (
-  name: string,
-  style: StudioFormStyle,
-  children: StudioComponentChild[],
-): StudioComponentChild => {
+const parentGrid = (name: string, style: StudioFormStyle, children: StudioComponentChild[]): StudioComponentChild => {
   const { verticalGap, horizontalGap } = resolveStyles(style);
   return {
     name,
@@ -62,7 +58,7 @@ const mapFieldElementProps = (element: FormDefinitionElement) => {
   return props;
 };
 
-export const fieldComponentMapper = (name: string, formDefinition: FormDefinition): StudioComponentChild => {
+const fieldComponentMapper = (name: string, formDefinition: FormDefinition): StudioComponentChild => {
   // will accept a field matrix from a defnition and map
   const fieldChildren = formDefinition.elementMatrix.map<StudioComponentChild>((row: string[], rowIdx: number) => {
     return {
@@ -88,7 +84,7 @@ export const fieldComponentMapper = (name: string, formDefinition: FormDefinitio
   return parentGrid(`${name}Grid`, formDefinition.form.layoutStyle, fieldChildren);
 };
 
-export const ctaButtonConfig = (): StudioComponentChild => {
+const ctaButtonConfig = (): StudioComponentChild => {
   return {
     name: 'CTAFlex',
     componentType: 'Flex',

--- a/packages/codegen-ui/lib/utils/index.ts
+++ b/packages/codegen-ui/lib/utils/index.ts
@@ -18,3 +18,4 @@ export * from './component-tree';
 export * from './state-reference-metadata';
 export * from './string-formatter';
 export * from './form-component-metadata';
+export * from './form-to-component';


### PR DESCRIPTION
*Description of changes:*
We had a backlog task to move form-to-component out of the form definition mapper because it does not quite belong. 
This PR moves it to the util folder, in its own subfolder, to accommodate the growing number of helpers for this logic.
The test file is removed because it didn't contain any tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
