### PR TITLE
chore: make appId and environmentName optional for StudioView

### DIFF
--- a/packages/codegen-ui/lib/types/view/view.ts
+++ b/packages/codegen-ui/lib/types/view/view.ts
@@ -18,9 +18,9 @@ import { ViewStyle } from './style';
 import { ColumnsMap } from './table';
 
 export interface StudioView {
-  appId: string;
+  appId?: string;
   dataSource: ViewDataTypeConfig;
-  environmentName: string;
+  environmentName?: string;
   id: string;
   name: ViewName;
   schemaVersion: string;


### PR DESCRIPTION
*Description of changes:*
We do not need appId and environmentName on StudioView to codegen views. The UI extends on this shape for the model, but there, it can set those values as required.
This is motivated by not wanting to pass these values in for auto-gened views in the CLI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
