### PR TITLE
chore: fix form types

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -25,12 +25,22 @@ export default function customDataForm(props) {
     overrides,
     ...rest
   } = props;
-  const [nameFieldError, setNameFieldError] = useStateMutationAction({});
-  const [emailFieldError, setEmailFieldError] = useStateMutationAction({});
-  const [cityFieldError, setCityFieldError] = useStateMutationAction({});
-  const [categoryFieldError, setCategoryFieldError] = useStateMutationAction(
-    {}
-  );
+  const [nameFieldError, setNameFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [emailFieldError, setEmailFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [cityFieldError, setCityFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [categoryFieldError, setCategoryFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
   const [modelFields, setModelFields] = useStateMutationAction({});
   const [formValid, setFormValid] = useStateMutationAction(true);
   return (
@@ -232,6 +242,10 @@ export declare type customDataFormProps = React.PropsWithChildren<{
 } & {
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
+    onValidate?: Record<string, (value: any) => Promise<{
+        hasError: boolean;
+        errorMessage?: string;
+    }>>;
 }>;
 export default function customDataForm(props: customDataFormProps): React.ReactElement;
 "
@@ -257,15 +271,20 @@ export default function myPostForm(props) {
     overrides,
     ...rest
   } = props;
-  const [captionFieldError, setCaptionFieldError] = useStateMutationAction({});
-  const [usernameFieldError, setUsernameFieldError] = useStateMutationAction(
-    {}
-  );
-  const [post_urlFieldError, setPost_urlFieldError] = useStateMutationAction(
-    {}
-  );
+  const [captionFieldError, setCaptionFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [usernameFieldError, setUsernameFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [post_urlFieldError, setPost_urlFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
   const [profile_urlFieldError, setProfile_urlFieldError] =
-    useStateMutationAction({});
+    useStateMutationAction({ hasError: false, errorMessage: \\"\\" });
   const [modelFields, setModelFields] = useStateMutationAction({});
   const [formValid, setFormValid] = useStateMutationAction(true);
   return (
@@ -457,10 +476,14 @@ export declare type myPostFormProps = React.PropsWithChildren<{
 } & {
     onSubmitBefore?: (fields: Record<string, string>) => Record<string, string>;
     onSubmitComplete?: ({ saveSuccessful, errorMessage }: {
-        saveSuccessful: string;
+        saveSuccessful: boolean;
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
+    onValidate?: Record<string, (value: any) => Promise<{
+        hasError: boolean;
+        errorMessage?: string;
+    }>>;
 }>;
 export default function myPostForm(props: myPostFormProps): React.ReactElement;
 "
@@ -494,16 +517,21 @@ export default function myPostForm(props) {
     ...rest
   } = props;
   const [TextAreaFieldbbd63464FieldError, setTextAreaFieldbbd63464FieldError] =
-    useStateMutationAction({});
-  const [captionFieldError, setCaptionFieldError] = useStateMutationAction({});
-  const [usernameFieldError, setUsernameFieldError] = useStateMutationAction(
-    {}
-  );
+    useStateMutationAction({ hasError: false, errorMessage: \\"\\" });
+  const [captionFieldError, setCaptionFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [usernameFieldError, setUsernameFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
   const [profile_urlFieldError, setProfile_urlFieldError] =
-    useStateMutationAction({});
-  const [post_urlFieldError, setPost_urlFieldError] = useStateMutationAction(
-    {}
-  );
+    useStateMutationAction({ hasError: false, errorMessage: \\"\\" });
+  const [post_urlFieldError, setPost_urlFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
   const [modelFields, setModelFields] = useStateMutationAction({});
   const [formValid, setFormValid] = useStateMutationAction(true);
   return (
@@ -728,10 +756,14 @@ export declare type myPostFormProps = React.PropsWithChildren<{
     id: string;
     onSubmitBefore?: (fields: Record<string, string>) => Record<string, string>;
     onSubmitComplete?: ({ saveSuccessful, errorMessage }: {
-        saveSuccessful: string;
+        saveSuccessful: boolean;
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
+    onValidate?: Record<string, (value: any) => Promise<{
+        hasError: boolean;
+        errorMessage?: string;
+    }>>;
 }>;
 export default function myPostForm(props: myPostFormProps): React.ReactElement;
 "

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -4,10 +4,14 @@ exports[`form-render utils should generate before & complete types if datastore 
 "{
     onSubmitBefore?: (fields: Record<string, string>) => Record<string, string>;
     onSubmitComplete?: ({ saveSuccessful, errorMessage }: {
-        saveSuccessful: string;
+        saveSuccessful: boolean;
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
+    onValidate?: Record<string, (value: any) => Promise<{
+        hasError: boolean;
+        errorMessage?: string;
+    }>>;
 }"
 `;
 
@@ -15,5 +19,9 @@ exports[`form-render utils should generate regular onsubmit if dataSourceType is
 "{
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
+    onValidate?: Record<string, (value: any) => Promise<{
+        hasError: boolean;
+        errorMessage?: string;
+    }>>;
 }"
 `;

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -193,7 +193,7 @@ export const buildFormPropNode = (form: StudioForm) => {
                   undefined,
                   'saveSuccessful',
                   undefined,
-                  factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+                  factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword),
                 ),
                 factory.createPropertySignature(
                   undefined,
@@ -244,6 +244,47 @@ export const buildFormPropNode = (form: StudioForm) => {
       'onCancel',
       factory.createToken(SyntaxKind.QuestionToken),
       factory.createFunctionTypeNode(undefined, [], factory.createKeywordTypeNode(SyntaxKind.VoidKeyword)),
+    ),
+  );
+  // onValidate?: (value: any) => Promise<{ hasError: boolean; errorMessage?: string }>>
+  propSignatures.push(
+    factory.createPropertySignature(
+      undefined,
+      factory.createIdentifier('onValidate'),
+      factory.createToken(SyntaxKind.QuestionToken),
+      factory.createTypeReferenceNode(factory.createIdentifier('Record'), [
+        factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+        factory.createFunctionTypeNode(
+          undefined,
+          [
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              undefined,
+              factory.createIdentifier('value'),
+              undefined,
+              factory.createKeywordTypeNode(SyntaxKind.AnyKeyword),
+              undefined,
+            ),
+          ],
+          factory.createTypeReferenceNode(factory.createIdentifier('Promise'), [
+            factory.createTypeLiteralNode([
+              factory.createPropertySignature(
+                undefined,
+                factory.createIdentifier('hasError'),
+                undefined,
+                factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword),
+              ),
+              factory.createPropertySignature(
+                undefined,
+                factory.createIdentifier('errorMessage'),
+                factory.createToken(SyntaxKind.QuestionToken),
+                factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+              ),
+            ]),
+          ]),
+        ),
+      ]),
     ),
   );
   return factory.createTypeLiteralNode(propSignatures);

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -328,7 +328,21 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     );
     if (this.componentMetadata.formMetadata?.onChangeFields.length) {
       this.componentMetadata.formMetadata?.onChangeFields.forEach((field) => {
-        statements.push(buildStateMutationStatement(`${field}FieldError`, factory.createObjectLiteralExpression()));
+        statements.push(
+          buildStateMutationStatement(
+            `${field}FieldError`,
+            factory.createObjectLiteralExpression(
+              [
+                factory.createPropertyAssignment(factory.createIdentifier('hasError'), factory.createFalse()),
+                factory.createPropertyAssignment(
+                  factory.createIdentifier('errorMessage'),
+                  factory.createStringLiteral(''),
+                ),
+              ],
+              false,
+            ),
+          ),
+        );
       });
       this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD);
     }

--- a/packages/codegen-ui-react/lib/utils/forms/validation.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/validation.ts
@@ -5,7 +5,7 @@ type ValidationResponse = { hasError: boolean; errorMessage?: string };
 
 export const validateField = (
   value: any,
-  validations: { type: string; strValues?: string[]; numValues?: number[]; validationMessage: string }[],
+  validations: { type: string; strValues?: string[]; numValues?: number[]; validationMessage?: string }[],
 ): ValidationResponse => {
   for (const validation of validations) {
     if (validation.numValues?.length) {
@@ -201,7 +201,7 @@ export const generateValidationFunction = () => {
                       factory.createPropertySignature(
                         undefined,
                         factory.createIdentifier('validationMessage'),
-                        undefined,
+                        factory.createToken(ts.SyntaxKind.QuestionToken),
                         factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
                       ),
                     ]),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add default validation state 
```useStateMutationAction({` hasError: false, errorMessage: "" });```
- Add onValidate declaration type
- Fix  onSubmitComplete saveSuccessful type to boolean
- Change `validationMessage` in `validateField` to optional

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
