### PR TITLE
fix: add type casting when doing on change

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -768,3 +768,373 @@ export declare type myPostFormProps = React.PropsWithChildren<{
 export default function myPostForm(props: myPostFormProps): React.ReactElement;
 "
 `;
+
+exports[`amplify form renderer tests datastore form tests should render a form with multiple date types 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
+import {
+  getOverrideProps,
+  useStateMutationAction,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { InputGallery } from \\"../models\\";
+import {
+  Button,
+  CheckboxField,
+  Flex,
+  Grid,
+  Radio,
+  RadioGroupField,
+  TextField,
+  ToggleButton,
+} from \\"@aws-amplify/ui-react\\";
+import { DataStore } from \\"aws-amplify\\";
+export default function InputGalleryCreateForm(props) {
+  const {
+    onSubmitBefore,
+    onSubmitComplete,
+    onCancel,
+    onValidate,
+    overrides,
+    ...rest
+  } = props;
+  const [numFieldError, setNumFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [rootbeerFieldError, setRootbeerFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [maybeFieldError, setMaybeFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [maybeSlideFieldError, setMaybeSlideFieldError] =
+    useStateMutationAction({ hasError: false, errorMessage: \\"\\" });
+  const [maybeCheckFieldError, setMaybeCheckFieldError] =
+    useStateMutationAction({ hasError: false, errorMessage: \\"\\" });
+  const [timestampFieldError, setTimestampFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [ippyFieldError, setIppyFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [timeisnowFieldError, setTimeisnowFieldError] = useStateMutationAction({
+    hasError: false,
+    errorMessage: \\"\\",
+  });
+  const [modelFields, setModelFields] = useStateMutationAction({});
+  const [formValid, setFormValid] = useStateMutationAction(true);
+  return (
+    <form
+      onSubmit={async (event) => {
+        event.preventDefault();
+        if (onSubmitBefore) {
+          setModelFields(onSubmitBefore({ fields: modelFields }));
+        }
+        try {
+          await DataStore.save(new InputGallery(modelFields));
+          if (onSubmitComplete) {
+            onSubmitComplete({ saveSuccessful: true });
+          }
+        } catch (err) {
+          if (onSubmitComplete) {
+            onSubmitComplete({
+              saveSuccessful: false,
+              errorMessage: err.message,
+            });
+          }
+        }
+      }}
+      {...rest}
+      {...getOverrideProps(overrides, \\"InputGalleryCreateForm\\")}
+    >
+      <Grid
+        columnGap=\\"15px\\"
+        rowGap=\\"15px\\"
+        {...getOverrideProps(overrides, \\"InputGalleryCreateFormGrid\\")}
+      >
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid0\\")}
+        >
+          <TextField
+            label=\\"Num\\"
+            isRequired={false}
+            isReadOnly={false}
+            type=\\"number\\"
+            onChange={async (e) => {
+              const value = parseInt(e.target.value);
+              const isValidResult = onValidate?.[\\"num\\"]
+                ? await onValidate[\\"num\\"](value)
+                : validateField(value, []);
+              setNumFieldError({ ...numFieldError, ...isValidResult });
+              setFormValid(!numFieldError.hasError);
+              setModelFields({ ...modelFields, num: value });
+            }}
+            errorMessage={numFieldError.errorMessage}
+            hasError={numFieldError.hasError}
+            {...getOverrideProps(overrides, \\"num\\")}
+          ></TextField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid1\\")}
+        >
+          <TextField
+            label=\\"Rootbeer\\"
+            isRequired={false}
+            isReadOnly={false}
+            type=\\"number\\"
+            onChange={async (e) => {
+              const value = Number(e.target.value);
+              const isValidResult = onValidate?.[\\"rootbeer\\"]
+                ? await onValidate[\\"rootbeer\\"](value)
+                : validateField(value, []);
+              setRootbeerFieldError({
+                ...rootbeerFieldError,
+                ...isValidResult,
+              });
+              setFormValid(!rootbeerFieldError.hasError);
+              setModelFields({ ...modelFields, rootbeer: value });
+            }}
+            errorMessage={rootbeerFieldError.errorMessage}
+            hasError={rootbeerFieldError.hasError}
+            {...getOverrideProps(overrides, \\"rootbeer\\")}
+          ></TextField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid2\\")}
+        >
+          <RadioGroupField
+            label=\\"Maybe\\"
+            name=\\"maybe\\"
+            isReadOnly={false}
+            isRequired=\\"false\\"
+            onChange={async (e) => {
+              const value = e.target.value === \\"Yes\\";
+              const isValidResult = onValidate?.[\\"maybe\\"]
+                ? await onValidate[\\"maybe\\"](value)
+                : validateField(value, []);
+              setMaybeFieldError({ ...maybeFieldError, ...isValidResult });
+              setFormValid(!maybeFieldError.hasError);
+              setModelFields({ ...modelFields, maybe: value });
+            }}
+            errorMessage={maybeFieldError.errorMessage}
+            hasError={maybeFieldError.hasError}
+            {...getOverrideProps(overrides, \\"maybe\\")}
+          >
+            <Radio
+              children=\\"Pick?\\"
+              value=\\"Pick?\\"
+              {...getOverrideProps(overrides, \\"maybeRadio0\\")}
+            ></Radio>
+          </RadioGroupField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid3\\")}
+        >
+          <ToggleButton
+            children=\\"Maybe slide\\"
+            isDisabled={false}
+            defaultPressed={false}
+            {...getOverrideProps(overrides, \\"maybeSlide\\")}
+          ></ToggleButton>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid4\\")}
+        >
+          <CheckboxField
+            label=\\"Maybe check\\"
+            name=\\"maybeCheck\\"
+            value=\\"true\\"
+            isDisabled={false}
+            defaultChecked={false}
+            onChange={async (e) => {
+              const value = e.target.checked;
+              const isValidResult = onValidate?.[\\"maybeCheck\\"]
+                ? await onValidate[\\"maybeCheck\\"](value)
+                : validateField(value, []);
+              setMaybeCheckFieldError({
+                ...maybeCheckFieldError,
+                ...isValidResult,
+              });
+              setFormValid(!maybeCheckFieldError.hasError);
+              setModelFields({ ...modelFields, maybeCheck: value });
+            }}
+            errorMessage={maybeCheckFieldError.errorMessage}
+            hasError={maybeCheckFieldError.hasError}
+            {...getOverrideProps(overrides, \\"maybeCheck\\")}
+          ></CheckboxField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid5\\")}
+        >
+          <TextField
+            label=\\"Timestamp\\"
+            isRequired={false}
+            isReadOnly={false}
+            type=\\"datetime-local\\"
+            onChange={async (e) => {
+              const value = Number(new Date(e.target.value));
+              const isValidResult = onValidate?.[\\"timestamp\\"]
+                ? await onValidate[\\"timestamp\\"](value)
+                : validateField(value, []);
+              setTimestampFieldError({
+                ...timestampFieldError,
+                ...isValidResult,
+              });
+              setFormValid(!timestampFieldError.hasError);
+              setModelFields({ ...modelFields, timestamp: value });
+            }}
+            errorMessage={timestampFieldError.errorMessage}
+            hasError={timestampFieldError.hasError}
+            {...getOverrideProps(overrides, \\"timestamp\\")}
+          ></TextField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid6\\")}
+        >
+          <TextField
+            label=\\"Ippy\\"
+            isRequired={false}
+            isReadOnly={false}
+            onChange={async (e) => {
+              const { value } = e.target;
+              const isValidResult = onValidate?.[\\"ippy\\"]
+                ? await onValidate[\\"ippy\\"](value)
+                : validateField(value, [{ type: \\"IpAddress\\" }]);
+              setIppyFieldError({ ...ippyFieldError, ...isValidResult });
+              setFormValid(!ippyFieldError.hasError);
+              setModelFields({ ...modelFields, ippy: value });
+            }}
+            errorMessage={ippyFieldError.errorMessage}
+            hasError={ippyFieldError.hasError}
+            {...getOverrideProps(overrides, \\"ippy\\")}
+          ></TextField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid7\\")}
+        >
+          <TextField
+            label=\\"Timeisnow\\"
+            isRequired={false}
+            isReadOnly={false}
+            type=\\"time\\"
+            onChange={async (e) => {
+              const { value } = e.target;
+              const isValidResult = onValidate?.[\\"timeisnow\\"]
+                ? await onValidate[\\"timeisnow\\"](value)
+                : validateField(value, []);
+              setTimeisnowFieldError({
+                ...timeisnowFieldError,
+                ...isValidResult,
+              });
+              setFormValid(!timeisnowFieldError.hasError);
+              setModelFields({ ...modelFields, timeisnow: value });
+            }}
+            errorMessage={timeisnowFieldError.errorMessage}
+            hasError={timeisnowFieldError.hasError}
+            {...getOverrideProps(overrides, \\"timeisnow\\")}
+          ></TextField>
+        </Grid>
+      </Grid>
+      <Flex
+        justifyContent=\\"space-between\\"
+        marginTop=\\"1rem\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Cancel\\"
+          type=\\"button\\"
+          onClick={() => {
+            onCancel && onCancel();
+          }}
+          {...getOverrideProps(overrides, \\"CancelButton\\")}
+        ></Button>
+        <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
+          <Button
+            children=\\"Clear\\"
+            type=\\"reset\\"
+            {...getOverrideProps(overrides, \\"ClearButton\\")}
+          ></Button>
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={!formValid}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </form>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests datastore form tests should render a form with multiple date types 2`] = `
+"import * as React from \\"react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { CheckboxFieldProps, GridProps, RadioGroupFieldProps, TextFieldProps, ToggleButtonProps } from \\"@aws-amplify/ui-react\\";
+export declare type InputGalleryCreateFormOverridesProps = {
+    InputGalleryCreateFormGrid: GridProps;
+    RowGrid0: GridProps;
+    num: TextFieldProps;
+    RowGrid1: GridProps;
+    rootbeer: TextFieldProps;
+    RowGrid2: GridProps;
+    maybe: RadioGroupFieldProps;
+    RowGrid3: GridProps;
+    maybeSlide: ToggleButtonProps;
+    RowGrid4: GridProps;
+    maybeCheck: CheckboxFieldProps;
+    RowGrid5: GridProps;
+    timestamp: TextFieldProps;
+    RowGrid6: GridProps;
+    ippy: TextFieldProps;
+    RowGrid7: GridProps;
+    timeisnow: TextFieldProps;
+} & EscapeHatchProps;
+export declare type InputGalleryCreateFormProps = React.PropsWithChildren<{
+    overrides?: InputGalleryCreateFormOverridesProps | undefined | null;
+} & {
+    onSubmitBefore?: (fields: Record<string, string>) => Record<string, string>;
+    onSubmitComplete?: ({ saveSuccessful, errorMessage }: {
+        saveSuccessful: boolean;
+        errorMessage?: string;
+    }) => void;
+    onCancel?: () => void;
+    onValidate?: Record<string, (value: any) => Promise<{
+        hasError: boolean;
+        errorMessage?: string;
+    }>>;
+}>;
+export default function InputGalleryCreateForm(props: InputGalleryCreateFormProps): React.ReactElement;
+"
+`;

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -36,6 +36,16 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });
+
+    it('should render a form with multiple date types', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/input-gallery-create',
+        'datastore/input-gallery',
+      );
+      expect(componentText).toContain('DataStore.save');
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
   });
 
   describe('custom form tests', () => {

--- a/packages/codegen-ui-react/lib/forms/event-targets.ts
+++ b/packages/codegen-ui-react/lib/forms/event-targets.ts
@@ -1,0 +1,79 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { DataFieldDataType } from '@aws-amplify/codegen-ui';
+import { factory, NodeFlags, VariableStatement, Expression, BindingName, SyntaxKind } from 'typescript';
+
+/*
+Builds the event target variable which is called value
+default case
+const { value } =  e.target;
+*/
+export const buildTargetVariable = (name: string, dataType?: DataFieldDataType): VariableStatement => {
+  let expression: Expression = factory.createPropertyAccessExpression(
+    factory.createIdentifier('e'),
+    factory.createIdentifier('target'),
+  );
+  let defaultIdentifier: string | BindingName = factory.createIdentifier('value');
+  switch (dataType) {
+    // const value = Number(new Date(e.target.value));
+    case 'AWSTimestamp':
+      expression = factory.createCallExpression(factory.createIdentifier('Number'), undefined, [
+        factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
+          factory.createPropertyAccessExpression(expression, factory.createIdentifier('value')),
+        ]),
+      ]);
+      break;
+    case 'Float':
+      // const value = Number(e.target.value);
+      expression = factory.createCallExpression(factory.createIdentifier('Number'), undefined, [
+        factory.createPropertyAccessExpression(expression, factory.createIdentifier('value')),
+      ]);
+      break;
+    case 'Int':
+      // const value = parseInt(e.target.value);
+      expression = factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [
+        factory.createPropertyAccessExpression(expression, factory.createIdentifier('value')),
+      ]);
+      break;
+    case 'Boolean':
+      if (name === 'RadioGroupField') {
+        // const value = e.target.value === 'Yes'
+        // this works around only two set Radio for boolean
+        expression = factory.createBinaryExpression(
+          factory.createPropertyAccessExpression(expression, factory.createIdentifier('value')),
+          factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+          factory.createStringLiteral('Yes'),
+        );
+      } else {
+        // SwitchField & CheckboxField
+        // const value = e.target.checked;
+        expression = factory.createPropertyAccessExpression(expression, factory.createIdentifier('checked'));
+      }
+      break;
+    default:
+      defaultIdentifier = factory.createObjectBindingPattern([
+        factory.createBindingElement(undefined, undefined, factory.createIdentifier('value'), undefined),
+      ]);
+      break;
+  }
+  return factory.createVariableStatement(
+    undefined,
+    factory.createVariableDeclarationList(
+      [factory.createVariableDeclaration(defaultIdentifier, undefined, undefined, expression)],
+      NodeFlags.Const,
+    ),
+  );
+};

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -289,6 +289,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
   private buildVariableStatements() {
     const statements: Statement[] = [];
     const elements: BindingElement[] = [];
+    const { formMetadata } = this.componentMetadata;
 
     // add in hooks for before/complete with ds and basic onSubmit with props
     elements.push(...buildMutationBindings(this.component));
@@ -326,8 +327,8 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
         ),
       ),
     );
-    if (this.componentMetadata.formMetadata?.onChangeFields.length) {
-      this.componentMetadata.formMetadata?.onChangeFields.forEach((field) => {
+    if (formMetadata && Object.keys(formMetadata.fieldConfigs).length) {
+      Object.keys(formMetadata.fieldConfigs).forEach((field) => {
         statements.push(
           buildStateMutationStatement(
             `${field}FieldError`,

--- a/packages/codegen-ui/example-schemas/datastore/input-gallery.json
+++ b/packages/codegen-ui/example-schemas/datastore/input-gallery.json
@@ -1,0 +1,116 @@
+{
+  "models": {
+    "InputGallery": {
+      "name": "InputGallery",
+      "fields": {
+          "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+          },
+          "num": {
+              "name": "num",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+          },
+          "rootbeer": {
+              "name": "rootbeer",
+              "isArray": false,
+              "type": "Float",
+              "isRequired": false,
+              "attributes": []
+          },
+          "maybe": {
+              "name": "maybe",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+          },
+          "maybeSlide": {
+              "name": "maybeSlide",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+          },
+          "maybeCheck": {
+              "name": "maybeCheck",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+          },
+          "timestamp": {
+              "name": "timestamp",
+              "isArray": false,
+              "type": "AWSTimestamp",
+              "isRequired": false,
+              "attributes": []
+          },
+          "ippy": {
+              "name": "ippy",
+              "isArray": false,
+              "type": "AWSIPAddress",
+              "isRequired": false,
+              "attributes": []
+          },
+          "timeisnow": {
+              "name": "timeisnow",
+              "isArray": false,
+              "type": "AWSTime",
+              "isRequired": false,
+              "attributes": []
+          },
+          "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+          },
+          "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+          }
+      },
+      "syncable": true,
+      "pluralName": "InputGalleries",
+      "attributes": [
+          {
+              "type": "model",
+              "properties": {}
+          },
+          {
+              "type": "auth",
+              "properties": {
+                  "rules": [
+                      {
+                          "allow": "private",
+                          "provider": "iam",
+                          "operations": [
+                              "create",
+                              "update",
+                              "delete",
+                              "read"
+                          ]
+                      }
+                  ]
+              }
+          }
+      ]
+  }
+  },
+  "enums": {},
+  "nonModels": {},
+  "version": "000000"
+}

--- a/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
+++ b/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
@@ -1,0 +1,41 @@
+{
+  "dataType": {
+    "dataSourceType": "DataStore",
+    "dataTypeName": "InputGallery"
+  },
+  "fields": {
+    "maybe": {
+      "inputType": {
+        "required": "false",
+        "type": "RadioGroupField",
+        "valueMappings": {
+          "bindingProperties": {},
+          "values": [
+            {
+              "value": {
+                "value": "Pick?"
+              }
+            }
+          ]
+        }
+      },
+      "label": "Maybe"
+    },
+    "maybeSlide": {
+      "inputType": {
+        "type": "ToggleButton"
+      }
+    },
+    "maybeCheck": {
+      "inputType": {
+        "type": "CheckboxField"
+      }
+    }
+  },
+  "formActionType": "create",
+  "name": "InputGalleryCreateForm",
+  "schemaVersion": "1.0",
+  "sectionalElements": {},
+  "style": {},
+  "id": "00001"
+}

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -37,6 +37,7 @@ describe('generateFormDefinition', () => {
     expect(formDefinition.elements).toStrictEqual({
       name: {
         componentType: 'TextField',
+        dataType: 'String',
         props: { label: 'Name', isRequired: true, isReadOnly: false },
         studioFormComponentType: 'TextField',
       },
@@ -80,6 +81,7 @@ describe('generateFormDefinition', () => {
     expect(formDefinition.elements).toStrictEqual({
       weight: {
         componentType: 'SliderField',
+        dataType: 'Float',
         props: { label: 'Weight', min: 1, max: 100, step: 2, isDisabled: false, isRequired: true },
       },
     });
@@ -377,6 +379,7 @@ it('should add read-only fields if it has overrides', () => {
   expect(formDefinition.elements).toStrictEqual({
     name: {
       componentType: 'TextField',
+      dataType: 'String',
       props: { label: 'Name', isRequired: true, isReadOnly: true },
       studioFormComponentType: 'TextField',
     },

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -44,6 +44,7 @@ describe('mapModelFieldsConfigs', () => {
     expect(formDefinition.elementMatrix).toStrictEqual([['name']]);
     expect(modelFieldsConfigs.name).toStrictEqual({
       label: 'Name',
+      dataType: 'String',
       inputType: { type: 'TextField', required: false, readOnly: false, name: 'name', value: 'true' },
     });
   });
@@ -156,6 +157,7 @@ describe('mapModelFieldsConfigs', () => {
     expect(formDefinition.elementMatrix).toStrictEqual([]);
     expect(modelFieldsConfigs).toStrictEqual({
       id: {
+        dataType: 'ID',
         inputType: {
           name: 'id',
           readOnly: false,
@@ -194,6 +196,7 @@ describe('mapModelFieldsConfigs', () => {
     expect(formDefinition.elementMatrix).toStrictEqual([]);
     expect(modelFieldsConfigs).toStrictEqual({
       name: {
+        dataType: 'String',
         inputType: {
           name: 'name',
           readOnly: true,
@@ -233,6 +236,9 @@ describe('mapModelFieldsConfigs', () => {
 
     expect(modelFieldsConfigs).toStrictEqual({
       city: {
+        dataType: {
+          enum: 'City',
+        },
         inputType: {
           name: 'city',
           readOnly: false,

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -119,6 +119,7 @@ export function getFormDefinitionInputElement(
     case 'EmailField':
       formDefinitionElement = {
         componentType: 'TextField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           descriptiveText: config.inputType?.descriptiveText ?? baseConfig?.inputType?.descriptiveText,
@@ -134,12 +135,11 @@ export function getFormDefinitionInputElement(
     case 'SwitchField':
       formDefinitionElement = {
         componentType: 'SwitchField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
-          defaultChecked: getFirstDefinedValue([
-            config.inputType?.defaultChecked,
-            baseConfig?.inputType?.defaultChecked,
-          ]),
+          defaultChecked:
+            getFirstDefinedValue([config.inputType?.defaultChecked, baseConfig?.inputType?.defaultChecked]) || false,
           isDisabled: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
         },
       };
@@ -149,6 +149,7 @@ export function getFormDefinitionInputElement(
     case 'PhoneNumberField':
       formDefinitionElement = {
         componentType: 'PhoneNumberField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           defaultCountryCode:
@@ -167,6 +168,7 @@ export function getFormDefinitionInputElement(
     case 'SelectField':
       formDefinitionElement = {
         componentType: 'SelectField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           descriptiveText: config.inputType?.descriptiveText ?? baseConfig?.inputType?.descriptiveText,
@@ -183,6 +185,7 @@ export function getFormDefinitionInputElement(
     case 'JSONField':
       formDefinitionElement = {
         componentType: 'TextAreaField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           descriptiveText: config.inputType?.descriptiveText ?? baseConfig?.inputType?.descriptiveText,
@@ -198,6 +201,7 @@ export function getFormDefinitionInputElement(
     case 'SliderField':
       formDefinitionElement = {
         componentType: 'SliderField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           min: getFirstDefinedValue([config.inputType?.minValue, baseConfig?.inputType?.minValue]),
@@ -214,6 +218,7 @@ export function getFormDefinitionInputElement(
     case 'StepperField':
       formDefinitionElement = {
         componentType: 'StepperField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           min: getFirstDefinedValue([config.inputType?.minValue, baseConfig?.inputType?.minValue]),
@@ -231,13 +236,12 @@ export function getFormDefinitionInputElement(
     case 'ToggleButton':
       formDefinitionElement = {
         componentType: 'ToggleButton',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           children: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           isDisabled: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
-          defaultPressed: getFirstDefinedValue([
-            config.inputType?.defaultChecked,
-            baseConfig?.inputType?.defaultChecked,
-          ]),
+          defaultPressed:
+            getFirstDefinedValue([config.inputType?.defaultChecked, baseConfig?.inputType?.defaultChecked]) || false,
         },
       };
       break;
@@ -245,16 +249,15 @@ export function getFormDefinitionInputElement(
     case 'CheckboxField':
       formDefinitionElement = {
         componentType: 'CheckboxField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           name: config.inputType?.name || baseConfig?.inputType?.name || FORM_DEFINITION_DEFAULTS.field.inputType.name,
           value:
             config.inputType?.value || baseConfig?.inputType?.value || FORM_DEFINITION_DEFAULTS.field.inputType.value,
           isDisabled: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
-          defaultChecked: getFirstDefinedValue([
-            config.inputType?.defaultChecked,
-            baseConfig?.inputType?.defaultChecked,
-          ]),
+          defaultChecked:
+            getFirstDefinedValue([config.inputType?.defaultChecked, baseConfig?.inputType?.defaultChecked]) || false,
         },
       };
       break;
@@ -262,6 +265,7 @@ export function getFormDefinitionInputElement(
     case 'RadioGroupField':
       formDefinitionElement = {
         componentType: 'RadioGroupField',
+        dataType: config?.dataType || baseConfig?.dataType,
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           name: config.inputType?.name || baseConfig?.inputType?.name || FORM_DEFINITION_DEFAULTS.field.inputType.name,

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -58,6 +58,7 @@ export function getFieldConfigFromModelField({
 
   const config: StudioGenericFieldConfig & { inputType: StudioFieldInputConfig } = {
     label: sentenceCase(fieldName),
+    dataType: field.dataType,
     inputType: {
       type: defaultComponent,
       required: field.required,

--- a/packages/codegen-ui/lib/types/form/fields.ts
+++ b/packages/codegen-ui/lib/types/form/fields.ts
@@ -16,6 +16,7 @@
 import { StudioFieldPosition } from './position';
 import { StudioFieldInputConfig } from './input-config';
 import { FieldValidationConfiguration } from './form-validation';
+import { DataFieldDataType } from '../data';
 
 /**
  * Field configurations for StudioForm
@@ -39,6 +40,7 @@ export type StudioGenericFieldConfig = {
    * The configuration for what type of input is used.
    */
   inputType?: StudioFieldInputConfig;
+  dataType?: DataFieldDataType;
 } & StudioFieldConfig;
 
 export type StudioFormFieldConfig = StudioGenericFieldConfig | ExcludedStudioFieldConfig;

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -14,10 +14,12 @@
   limitations under the License.
  */
 
+import { DataFieldDataType } from '../data';
 import { FieldValidationConfiguration } from './form-validation';
 import { StudioFormValueMappings } from './input-config';
 
 type FormDefinitionInputElementCommon = {
+  dataType?: DataFieldDataType;
   validations?: (FieldValidationConfiguration & { immutable?: true })[];
 };
 

--- a/packages/codegen-ui/lib/types/form/form-metadata.ts
+++ b/packages/codegen-ui/lib/types/form/form-metadata.ts
@@ -13,15 +13,19 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+import { DataFieldDataType } from '../data';
 import { FieldValidationConfiguration } from './form-validation';
+
+export type FieldConfigMetadata = {
+  hasChange: boolean;
+  // ex. name field has a string validation type where the rule is char length > 5
+  validationRules: FieldValidationConfiguration[];
+  // component field is of type AWSTimestamp will need to map this to date then get time from date
+  dataType?: DataFieldDataType;
+};
 
 export type FormMetadata = {
   id?: string;
   name: string;
-  fieldState: string;
-  onChangeFields: string[];
-  errorStateFields: string[];
-  // indicates the validation rule for that field
-  // ex. name field has a string validation type where the rule is char length > 5
-  onValidationFields?: { [field: string]: FieldValidationConfiguration[] };
+  fieldConfigs: Record<string, FieldConfigMetadata>;
 };

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -20,7 +20,7 @@ import { SectionalElement } from './sectional-element';
 import { FormDefinition, ModelFieldsConfigs, FieldTypeMapKeys } from './form-definition';
 import { StudioFieldInputConfig, StudioFormValueMappings } from './input-config';
 import { StudioFieldPosition } from './position';
-import { FormMetadata } from './form-metadata';
+import { FormMetadata, FieldConfigMetadata } from './form-metadata';
 
 /**
  * Data type definition for StudioForm
@@ -86,6 +86,7 @@ export type {
   StudioFormActionType,
   FormDefinition,
   FormMetadata,
+  FieldConfigMetadata,
   StudioFieldInputConfig,
   StudioGenericFieldConfig,
   StudioFormFields,

--- a/packages/test-generator/lib/generators/TestGenerator.ts
+++ b/packages/test-generator/lib/generators/TestGenerator.ts
@@ -119,7 +119,7 @@ export abstract class TestGenerator {
       try {
         if (this.params.writeToDisk) {
           const res = this.writeFormToDisk(schema as StudioForm);
-          if (res.formMetadata?.onValidationFields && Object.keys(res.formMetadata.onValidationFields).length) {
+          if (res.formMetadata?.fieldConfigs && Object.keys(res.formMetadata.fieldConfigs).length) {
             utilsFunctions.add('validation');
           }
         }


### PR DESCRIPTION
*Issue #, if available:*
 - `onChange` events need to handle casting to the correct types
*Description of changes:*
- add a casting check before validating value from event changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
