### PR TITLE
chore: change form validation, validate on submit, and init form integ test

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -35,10 +35,10 @@ export default function customDataForm(props) {
     category: [],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (!validationResponse.hasError) {
+      validationResponse = (await onValidate?.[fieldName]?.(value)) ?? {};
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -46,6 +46,14 @@ export default function customDataForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         await customDataFormOnSubmit(modelFields);
       }}
       {...rest}
@@ -222,7 +230,10 @@ export declare type customDataFormProps = React.PropsWithChildren<{
 } & {
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
+    onValidate?: Record<string, (value: any) => {
+        hasError: boolean;
+        errorMessage?: string;
+    } | Promise<{
         hasError: boolean;
         errorMessage?: string;
     }>>;
@@ -263,10 +274,10 @@ export default function CustomWithSectionalElements(props) {
     name: [],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (!validationResponse.hasError) {
+      validationResponse = (await onValidate?.[fieldName]?.(value)) ?? {};
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -274,6 +285,14 @@ export default function CustomWithSectionalElements(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         await customWithSectionalElementsOnSubmit(modelFields);
       }}
       {...rest}
@@ -391,7 +410,10 @@ export declare type CustomWithSectionalElementsProps = React.PropsWithChildren<{
 } & {
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
+    onValidate?: Record<string, (value: any) => {
+        hasError: boolean;
+        errorMessage?: string;
+    } | Promise<{
         hasError: boolean;
         errorMessage?: string;
     }>>;
@@ -430,10 +452,10 @@ export default function myPostForm(props) {
     profile_url: [{ type: \\"URL\\" }],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (!validationResponse.hasError) {
+      validationResponse = (await onValidate?.[fieldName]?.(value)) ?? {};
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -441,6 +463,14 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         if (onSubmitBefore) {
           setModelFields(onSubmitBefore({ fields: modelFields }));
         }
@@ -605,7 +635,10 @@ export declare type myPostFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
+    onValidate?: Record<string, (value: any) => {
+        hasError: boolean;
+        errorMessage?: string;
+    } | Promise<{
         hasError: boolean;
         errorMessage?: string;
     }>>;
@@ -652,10 +685,10 @@ export default function myPostForm(props) {
     post_url: [{ type: \\"URL\\" }],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (!validationResponse.hasError) {
+      validationResponse = (await onValidate?.[fieldName]?.(value)) ?? {};
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -663,6 +696,14 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         if (onSubmitBefore) {
           setModelFields(onSubmitBefore({ fields: modelFields }));
         }
@@ -853,7 +894,10 @@ export declare type myPostFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
+    onValidate?: Record<string, (value: any) => {
+        hasError: boolean;
+        errorMessage?: string;
+    } | Promise<{
         hasError: boolean;
         errorMessage?: string;
     }>>;
@@ -905,10 +949,10 @@ export default function InputGalleryCreateForm(props) {
     timeisnow: [],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (!validationResponse.hasError) {
+      validationResponse = (await onValidate?.[fieldName]?.(value)) ?? {};
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -916,6 +960,14 @@ export default function InputGalleryCreateForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         if (onSubmitBefore) {
           setModelFields(onSubmitBefore({ fields: modelFields }));
         }
@@ -1181,7 +1233,10 @@ export declare type InputGalleryCreateFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
+    onValidate?: Record<string, (value: any) => {
+        hasError: boolean;
+        errorMessage?: string;
+    } | Promise<{
         hasError: boolean;
         errorMessage?: string;
     }>>;

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -8,7 +8,10 @@ exports[`form-render utils should generate before & complete types if datastore 
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
+    onValidate?: Record<string, (value: any) => {
+        hasError: boolean;
+        errorMessage?: string;
+    } | Promise<{
         hasError: boolean;
         errorMessage?: string;
     }>>;
@@ -19,7 +22,10 @@ exports[`form-render utils should generate regular onsubmit if dataSourceType is
 "{
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
+    onValidate?: Record<string, (value: any) => {
+        hasError: boolean;
+        errorMessage?: string;
+    } | Promise<{
         hasError: boolean;
         errorMessage?: string;
     }>>;

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -27,6 +27,7 @@ import { buildOpeningElementProperties } from '../react-component-render-helper'
 import { ImportCollection } from '../imports';
 import { getActionIdentifier } from '../workflow';
 import { buildDataStoreExpression } from '../forms';
+import { onSubmitValidationRun } from '../forms/form-renderer-helper';
 
 export default class FormRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -229,6 +230,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                   [],
                 ),
               ),
+              ...onSubmitValidationRun,
               ...this.getOnSubmitDSCall(),
             ],
             false,

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form-spec.cy.ts
@@ -1,0 +1,63 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+describe('Forms', () => {
+  before(() => {
+    cy.visit('http://localhost:3000/form-tests');
+  });
+
+  it('CustomFormCreateDog', () => {
+    const ErrorMessageMap = {
+      name: 'Name is required',
+      age: 'Age must be greater than 0',
+      validEmail: 'The value must be a valid email address',
+      customValidation: 'All dog emails are yahoo emails',
+    };
+    cy.get('#customFormCreateDog').within(() => {
+      const blurField = () => cy.contains('Register your dog').click();
+
+      // should validate on submit
+      cy.contains('Submit').click();
+      cy.contains(ErrorMessageMap.name);
+      cy.contains(ErrorMessageMap.age);
+      cy.contains(ErrorMessageMap.validEmail);
+
+      // validates on change & extends with onValidate prop
+      cy.get('input').eq(0).type('Spot');
+      blurField();
+      cy.get('input').eq(1).type('3');
+      blurField();
+      cy.get('input').eq(2).type('spot@gmail.com');
+      blurField();
+      cy.contains(ErrorMessageMap.name).should('not.exist');
+      cy.contains(ErrorMessageMap.age).should('not.exist');
+      cy.contains(ErrorMessageMap.validEmail).should('not.exist');
+      cy.contains(ErrorMessageMap.customValidation);
+
+      // clears and submits
+      cy.contains('Clear').click();
+      cy.get('input').eq(0).type('Spot');
+      blurField();
+      cy.get('input').eq(1).type('3');
+      blurField();
+      cy.get('input').eq(2).type('spot@yahoo.com');
+      blurField();
+      cy.contains('Submit').click();
+      cy.contains('name: Spot');
+      cy.contains('age: 3');
+      cy.contains('email: spot@yahoo.com');
+    });
+  });
+});

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
@@ -32,6 +32,7 @@ const EXPECTED_SUCCESSFUL_CASES = new Set([
   'FormUpdate',
   'FormCustomCreate',
   'FormCustomUpdate',
+  'CustomFormCreateDog',
   'ComponentWithDataBindingWithPredicate',
   'ComponentWithDataBindingWithoutPredicate',
   'ComponentWithSimplePropertyBinding',

--- a/packages/test-generator/integration-test-templates/src/App.tsx
+++ b/packages/test-generator/integration-test-templates/src/App.tsx
@@ -23,6 +23,7 @@ import SnippetTests from './SnippetTests'; // eslint-disable-line import/extensi
 import WorkflowTests from './WorkflowTests';
 import TwoWayBindingTests from './TwoWayBindingTests';
 import ActionBindingTests from './ActionBindingTests';
+import FormTests from './FormTests';
 import { DATA_STORE_MOCK_EXPORTS, AUTH_MOCK_EXPORTS } from './mock-utils';
 
 // use fake endpoint so useDataStoreBinding does not fail
@@ -60,6 +61,9 @@ const HomePage = () => {
         <li>
           <a href="/action-binding-tests">Action Binding Test</a>
         </li>
+        <li>
+          <a href="/form-tests">Form Tests</a>
+        </li>
       </ul>
     </div>
   );
@@ -77,6 +81,7 @@ export default function App() {
         <Route path="/workflow-tests" element={<WorkflowTests />} />
         <Route path="/two-way-binding-tests" element={<TwoWayBindingTests />} />
         <Route path="/action-binding-tests" element={<ActionBindingTests />} />
+        <Route path="/form-tests" element={<FormTests />} />
         <Route path="*" element={<HomePage />} />
       </Routes>
     </Router>

--- a/packages/test-generator/integration-test-templates/src/FormTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/FormTests.tsx
@@ -1,0 +1,46 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import '@aws-amplify/ui-react/styles.css';
+import { AmplifyProvider, View, Heading, Divider, Text } from '@aws-amplify/ui-react';
+import { useState } from 'react';
+import { CustomFormCreateDog } from './ui-components'; // eslint-disable-line import/extensions
+
+export default function FormTests() {
+  const [customFormCreateDogSubmitResults, setCustomFormCreateDogSubmitResults] = useState<any>({});
+  return (
+    <AmplifyProvider>
+      <Heading>Custom Form - CreateDog</Heading>
+      <View id="customFormCreateDog">
+        <CustomFormCreateDog
+          onSubmit={(r) => setCustomFormCreateDogSubmitResults(r)}
+          onValidate={{
+            email: async (value) => {
+              if (!value?.includes('yahoo.com')) {
+                return { hasError: true, errorMessage: 'All dog emails are yahoo emails' };
+              }
+              return { hasError: false };
+            },
+          }}
+        />
+        <View>{`name: ${customFormCreateDogSubmitResults.name}`}</View>
+        <Text>{`name: ${customFormCreateDogSubmitResults.name}`}</Text>
+        <Text>{`age: ${customFormCreateDogSubmitResults.age}`}</Text>
+        <Text>{`email: ${customFormCreateDogSubmitResults.email}`}</Text>
+      </View>
+      <Divider />
+    </AmplifyProvider>
+  );
+}

--- a/packages/test-generator/lib/forms/custom-form-create-dog.json
+++ b/packages/test-generator/lib/forms/custom-form-create-dog.json
@@ -1,0 +1,41 @@
+{
+    "id": "123",
+    "name": "CustomFormCreateDog",
+    "formActionType": "create",
+    "dataType": {
+      "dataSourceType": "Custom",
+      "dataTypeName": "Dog"
+    },
+    "fields": {
+        "name": {
+            "label": "Name",
+            "inputType": {
+                "type": "TextField"
+            },
+            "validations": [{"type": "Required", "validationMessage": "Name is required"}]
+        },
+        "age": {
+            "label": "Age",
+            "inputType": {
+                "type": "NumberField"
+            },
+            "validations": [{"type": "GreaterThanNum","numValues": ["0"], "validationMessage": "Age must be greater than 0"}]
+        },
+        "email": {
+            "label": "Email",
+            "inputType": {
+                "type": "EmailField"
+            },
+            "validations": [{"type": "Required", "validationMessage": "Email is required"}]
+        }
+    },
+    "sectionalElements": {
+        "formHeading": {
+            "type": "Heading",
+            "position": {"fixed": "first"},
+            "text": "Register your dog"
+        }
+    },
+    "style": {},
+    "schemaVersion": "1.0"
+  }

--- a/packages/test-generator/lib/forms/index.ts
+++ b/packages/test-generator/lib/forms/index.ts
@@ -18,3 +18,4 @@ export { default as FormCreate } from './form-create.json';
 export { default as FormUpdate } from './form-update.json';
 export { default as FormCustomCreate } from './form-custom-create.json';
 export { default as FormCustomUpdate } from './form-custom-update.json';
+export { default as CustomFormCreateDog } from './custom-form-create-dog.json';


### PR DESCRIPTION
*Description of changes:*
- validate on submit
- change type of `onValidate` to allow non-async callback
- fix logic for how `onValidate` extends existing validations
- init form integ test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
