### PR TITLE
chore: change form validation, validate on submit, and init form integ test

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -26,7 +26,6 @@ export default function customDataForm(props) {
     ...rest
   } = props;
   const [modelFields, setModelFields] = useStateMutationAction({});
-  const [formValid, setFormValid] = useStateMutationAction(true);
   const [errors, setErrors] = useStateMutationAction({});
   const validations = {
     name: [],
@@ -35,10 +34,13 @@ export default function customDataForm(props) {
     category: [],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (onValidate?.[fieldName]) {
+      validationResponse = await onValidate[fieldName](
+        value,
+        validationResponse
+      );
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -46,6 +48,14 @@ export default function customDataForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         await customDataFormOnSubmit(modelFields);
       }}
       {...rest}
@@ -206,6 +216,16 @@ exports[`amplify form renderer tests custom form tests should render a custom ba
 "import * as React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, RadioGroupFieldProps, SelectFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type customDataFormInputValues = {
+    name: string;
+    email: string;
+    city: string;
+    category: string;
+};
 export declare type customDataFormOverridesProps = {
     customDataFormGrid: GridProps;
     RowGrid0: GridProps;
@@ -222,10 +242,9 @@ export declare type customDataFormProps = React.PropsWithChildren<{
 } & {
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
-        hasError: boolean;
-        errorMessage?: string;
-    }>>;
+    onValidate?: {
+        [field in keyof customDataFormInputValues]?: (value: customDataFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+    };
 }>;
 export default function customDataForm(props: customDataFormProps): React.ReactElement;
 "
@@ -257,16 +276,18 @@ export default function CustomWithSectionalElements(props) {
     ...rest
   } = props;
   const [modelFields, setModelFields] = useStateMutationAction({});
-  const [formValid, setFormValid] = useStateMutationAction(true);
   const [errors, setErrors] = useStateMutationAction({});
   const validations = {
     name: [],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (onValidate?.[fieldName]) {
+      validationResponse = await onValidate[fieldName](
+        value,
+        validationResponse
+      );
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -274,6 +295,14 @@ export default function CustomWithSectionalElements(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         await customWithSectionalElementsOnSubmit(modelFields);
       }}
       {...rest}
@@ -375,6 +404,13 @@ exports[`amplify form renderer tests custom form tests should render sectional e
 "import * as React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { DividerProps, GridProps, HeadingProps, TextFieldProps, TextProps } from \\"@aws-amplify/ui-react\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type CustomWithSectionalElementsInputValues = {
+    name: string;
+};
 export declare type CustomWithSectionalElementsOverridesProps = {
     CustomWithSectionalElementsGrid: GridProps;
     RowGrid0: GridProps;
@@ -391,10 +427,9 @@ export declare type CustomWithSectionalElementsProps = React.PropsWithChildren<{
 } & {
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
-        hasError: boolean;
-        errorMessage?: string;
-    }>>;
+    onValidate?: {
+        [field in keyof CustomWithSectionalElementsInputValues]?: (value: CustomWithSectionalElementsInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+    };
 }>;
 export default function CustomWithSectionalElements(props: CustomWithSectionalElementsProps): React.ReactElement;
 "
@@ -421,7 +456,6 @@ export default function myPostForm(props) {
     ...rest
   } = props;
   const [modelFields, setModelFields] = useStateMutationAction({});
-  const [formValid, setFormValid] = useStateMutationAction(true);
   const [errors, setErrors] = useStateMutationAction({});
   const validations = {
     caption: [],
@@ -430,10 +464,13 @@ export default function myPostForm(props) {
     profile_url: [{ type: \\"URL\\" }],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (onValidate?.[fieldName]) {
+      validationResponse = await onValidate[fieldName](
+        value,
+        validationResponse
+      );
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -441,6 +478,14 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         if (onSubmitBefore) {
           setModelFields(onSubmitBefore({ fields: modelFields }));
         }
@@ -585,6 +630,16 @@ exports[`amplify form renderer tests datastore form tests should generate a crea
 "import * as React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type myPostFormInputValues = {
+    caption: string;
+    username: string;
+    post_url: string;
+    profile_url: string;
+};
 export declare type myPostFormOverridesProps = {
     myPostFormGrid: GridProps;
     RowGrid0: GridProps;
@@ -605,10 +660,9 @@ export declare type myPostFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
-        hasError: boolean;
-        errorMessage?: string;
-    }>>;
+    onValidate?: {
+        [field in keyof myPostFormInputValues]?: (value: myPostFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+    };
 }>;
 export default function myPostForm(props: myPostFormProps): React.ReactElement;
 "
@@ -642,7 +696,6 @@ export default function myPostForm(props) {
     ...rest
   } = props;
   const [modelFields, setModelFields] = useStateMutationAction({});
-  const [formValid, setFormValid] = useStateMutationAction(true);
   const [errors, setErrors] = useStateMutationAction({});
   const validations = {
     TextAreaFieldbbd63464: [],
@@ -652,10 +705,13 @@ export default function myPostForm(props) {
     post_url: [{ type: \\"URL\\" }],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (onValidate?.[fieldName]) {
+      validationResponse = await onValidate[fieldName](
+        value,
+        validationResponse
+      );
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -663,6 +719,14 @@ export default function myPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         if (onSubmitBefore) {
           setModelFields(onSubmitBefore({ fields: modelFields }));
         }
@@ -830,6 +894,17 @@ exports[`amplify form renderer tests datastore form tests should generate a upda
 "import * as React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type myPostFormInputValues = {
+    TextAreaFieldbbd63464: string;
+    caption: string;
+    username: string;
+    profile_url: string;
+    post_url: string;
+};
 export declare type myPostFormOverridesProps = {
     myPostFormGrid: GridProps;
     RowGrid0: GridProps;
@@ -853,10 +928,9 @@ export declare type myPostFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
-        hasError: boolean;
-        errorMessage?: string;
-    }>>;
+    onValidate?: {
+        [field in keyof myPostFormInputValues]?: (value: myPostFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+    };
 }>;
 export default function myPostForm(props: myPostFormProps): React.ReactElement;
 "
@@ -892,7 +966,6 @@ export default function InputGalleryCreateForm(props) {
     ...rest
   } = props;
   const [modelFields, setModelFields] = useStateMutationAction({});
-  const [formValid, setFormValid] = useStateMutationAction(true);
   const [errors, setErrors] = useStateMutationAction({});
   const validations = {
     num: [],
@@ -905,10 +978,13 @@ export default function InputGalleryCreateForm(props) {
     timeisnow: [],
   };
   const runValidationTasks = async (fieldName, value) => {
-    const validationResponse = {
-      ...validateField(value, validations[fieldName]),
-      ...(await onValidate?.[fieldName]?.(value)),
-    };
+    let validationResponse = validateField(value, validations[fieldName]);
+    if (onValidate?.[fieldName]) {
+      validationResponse = await onValidate[fieldName](
+        value,
+        validationResponse
+      );
+    }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
@@ -916,6 +992,14 @@ export default function InputGalleryCreateForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
         if (onSubmitBefore) {
           setModelFields(onSubmitBefore({ fields: modelFields }));
         }
@@ -1153,6 +1237,20 @@ exports[`amplify form renderer tests datastore form tests should render a form w
 "import * as React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { CheckboxFieldProps, GridProps, RadioGroupFieldProps, TextFieldProps, ToggleButtonProps } from \\"@aws-amplify/ui-react\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type InputGalleryCreateFormInputValues = {
+    num: number;
+    rootbeer: number;
+    maybe: boolean;
+    maybeSlide: boolean;
+    maybeCheck: boolean;
+    timestamp: number;
+    ippy: string;
+    timeisnow: string;
+};
 export declare type InputGalleryCreateFormOverridesProps = {
     InputGalleryCreateFormGrid: GridProps;
     RowGrid0: GridProps;
@@ -1181,10 +1279,9 @@ export declare type InputGalleryCreateFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
-        hasError: boolean;
-        errorMessage?: string;
-    }>>;
+    onValidate?: {
+        [field in keyof InputGalleryCreateFormInputValues]?: (value: InputGalleryCreateFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+    };
 }>;
 export default function InputGalleryCreateForm(props: InputGalleryCreateFormProps): React.ReactElement;
 "

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -8,10 +8,9 @@ exports[`form-render utils should generate before & complete types if datastore 
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
-        hasError: boolean;
-        errorMessage?: string;
-    }>>;
+    onValidate?: {
+        [field in keyof mySampleFormInputValues]?: (value: mySampleFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+    };
 }"
 `;
 
@@ -19,9 +18,8 @@ exports[`form-render utils should generate regular onsubmit if dataSourceType is
 "{
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: Record<string, (value: any) => Promise<{
-        hasError: boolean;
-        errorMessage?: string;
-    }>>;
+    onValidate?: {
+        [field in keyof myCustomFormInputValues]?: (value: myCustomFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+    };
 }"
 `;

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -27,6 +27,7 @@ import { buildOpeningElementProperties } from '../react-component-render-helper'
 import { ImportCollection } from '../imports';
 import { getActionIdentifier } from '../workflow';
 import { buildDataStoreExpression } from '../forms';
+import { onSubmitValidationRun } from '../forms/form-renderer-helper';
 
 export default class FormRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -229,6 +230,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                   [],
                 ),
               ),
+              ...onSubmitValidationRun,
               ...this.getOnSubmitDSCall(),
             ],
             false,

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -60,11 +60,13 @@ import {
 import { RequiredKeys } from '../utils/type-utils';
 import {
   buildFormPropNode,
+  buildInputValuesTypeAliasDeclaration,
   buildMutationBindings,
   buildOverrideTypesBindings,
   buildStateMutationStatement,
   buildValidations,
   runValidationTasksFunction,
+  validationResponseTypeAliasDeclaration,
 } from './form-renderer-helper';
 
 export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
@@ -265,6 +267,8 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     this.importCollection.addMappedImport(ImportValue.ESCAPE_HATCH_PROPS);
 
     return [
+      validationResponseTypeAliasDeclaration,
+      buildInputValuesTypeAliasDeclaration(this.formComponent.name, this.componentMetadata.formMetadata?.fieldConfigs),
       overrideTypeAliasDeclaration,
       factory.createTypeAliasDeclaration(
         undefined,
@@ -333,7 +337,6 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     this.importCollection.addMappedImport(ImportValue.USE_STATE_MUTATION_ACTION);
 
     statements.push(buildStateMutationStatement('modelFields', factory.createObjectLiteralExpression()));
-    statements.push(buildStateMutationStatement('formValid', factory.createTrue()));
 
     statements.push(buildStateMutationStatement('errors', factory.createObjectLiteralExpression()));
 

--- a/packages/codegen-ui-react/lib/forms/typescript-type-map.ts
+++ b/packages/codegen-ui-react/lib/forms/typescript-type-map.ts
@@ -13,9 +13,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+import { KeywordTypeSyntaxKind, SyntaxKind } from 'typescript';
 
-export { default as FormCreate } from './form-create.json';
-export { default as FormUpdate } from './form-update.json';
-export { default as FormCustomCreate } from './form-custom-create.json';
-export { default as FormCustomUpdate } from './form-custom-update.json';
-export { default as CustomFormCreateDog } from './custom-form-create-dog.json';
+export const DATA_TYPE_TO_TYPESCRIPT_MAP: { [key: string]: KeywordTypeSyntaxKind } = {
+  Int: SyntaxKind.NumberKeyword,
+  Float: SyntaxKind.NumberKeyword,
+  Boolean: SyntaxKind.BooleanKeyword,
+  AWSTimestamp: SyntaxKind.NumberKeyword,
+};

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form-spec.cy.ts
@@ -1,0 +1,63 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+describe('Forms', () => {
+  before(() => {
+    cy.visit('http://localhost:3000/form-tests');
+  });
+
+  it('CustomFormCreateDog', () => {
+    const ErrorMessageMap = {
+      name: 'Name is required',
+      age: 'Age must be greater than 0',
+      validEmail: 'The value must be a valid email address',
+      customValidation: 'All dog emails are yahoo emails',
+    };
+    cy.get('#customFormCreateDog').within(() => {
+      const blurField = () => cy.contains('Register your dog').click();
+
+      // should validate on submit
+      cy.contains('Submit').click();
+      cy.contains(ErrorMessageMap.name);
+      cy.contains(ErrorMessageMap.age);
+      cy.contains(ErrorMessageMap.validEmail);
+
+      // validates on change & extends with onValidate prop
+      cy.get('input').eq(0).type('Spot');
+      blurField();
+      cy.get('input').eq(1).type('3');
+      blurField();
+      cy.get('input').eq(2).type('spot@gmail.com');
+      blurField();
+      cy.contains(ErrorMessageMap.name).should('not.exist');
+      cy.contains(ErrorMessageMap.age).should('not.exist');
+      cy.contains(ErrorMessageMap.validEmail).should('not.exist');
+      cy.contains(ErrorMessageMap.customValidation);
+
+      // clears and submits
+      cy.contains('Clear').click();
+      cy.get('input').eq(0).type('Spot');
+      blurField();
+      cy.get('input').eq(1).type('3');
+      blurField();
+      cy.get('input').eq(2).type('spot@yahoo.com');
+      blurField();
+      cy.contains('Submit').click();
+      cy.contains('name: Spot');
+      cy.contains('age: 3');
+      cy.contains('email: spot@yahoo.com');
+    });
+  });
+});

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
@@ -32,6 +32,7 @@ const EXPECTED_SUCCESSFUL_CASES = new Set([
   'FormUpdate',
   'FormCustomCreate',
   'FormCustomUpdate',
+  'CustomFormCreateDog',
   'ComponentWithDataBindingWithPredicate',
   'ComponentWithDataBindingWithoutPredicate',
   'ComponentWithSimplePropertyBinding',

--- a/packages/test-generator/integration-test-templates/src/App.tsx
+++ b/packages/test-generator/integration-test-templates/src/App.tsx
@@ -23,6 +23,7 @@ import SnippetTests from './SnippetTests'; // eslint-disable-line import/extensi
 import WorkflowTests from './WorkflowTests';
 import TwoWayBindingTests from './TwoWayBindingTests';
 import ActionBindingTests from './ActionBindingTests';
+import FormTests from './FormTests';
 import { DATA_STORE_MOCK_EXPORTS, AUTH_MOCK_EXPORTS } from './mock-utils';
 
 // use fake endpoint so useDataStoreBinding does not fail
@@ -60,6 +61,9 @@ const HomePage = () => {
         <li>
           <a href="/action-binding-tests">Action Binding Test</a>
         </li>
+        <li>
+          <a href="/form-tests">Form Tests</a>
+        </li>
       </ul>
     </div>
   );
@@ -77,6 +81,7 @@ export default function App() {
         <Route path="/workflow-tests" element={<WorkflowTests />} />
         <Route path="/two-way-binding-tests" element={<TwoWayBindingTests />} />
         <Route path="/action-binding-tests" element={<ActionBindingTests />} />
+        <Route path="/form-tests" element={<FormTests />} />
         <Route path="*" element={<HomePage />} />
       </Routes>
     </Router>

--- a/packages/test-generator/integration-test-templates/src/FormTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/FormTests.tsx
@@ -1,0 +1,50 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import '@aws-amplify/ui-react/styles.css';
+import { AmplifyProvider, View, Heading, Divider, Text } from '@aws-amplify/ui-react';
+import { useState } from 'react';
+import { CustomFormCreateDog } from './ui-components'; // eslint-disable-line import/extensions
+
+export default function FormTests() {
+  const [customFormCreateDogSubmitResults, setCustomFormCreateDogSubmitResults] = useState<any>({});
+  return (
+    <AmplifyProvider>
+      <Heading>Custom Form - CreateDog</Heading>
+      <View id="customFormCreateDog">
+        <CustomFormCreateDog
+          onSubmit={(r) => setCustomFormCreateDogSubmitResults(r)}
+          onValidate={{
+            email: (value, validationResponse) => {
+              console.log(value, validationResponse);
+              if (validationResponse.hasError) {
+                return validationResponse;
+              }
+              if (!value?.includes('yahoo.com')) {
+                return { hasError: true, errorMessage: 'All dog emails are yahoo emails' };
+              }
+              return { hasError: false };
+            },
+          }}
+        />
+        <View>{`name: ${customFormCreateDogSubmitResults.name}`}</View>
+        <Text>{`name: ${customFormCreateDogSubmitResults.name}`}</Text>
+        <Text>{`age: ${customFormCreateDogSubmitResults.age}`}</Text>
+        <Text>{`email: ${customFormCreateDogSubmitResults.email}`}</Text>
+      </View>
+      <Divider />
+    </AmplifyProvider>
+  );
+}

--- a/packages/test-generator/lib/forms/custom-form-create-dog.json
+++ b/packages/test-generator/lib/forms/custom-form-create-dog.json
@@ -1,0 +1,41 @@
+{
+    "id": "123",
+    "name": "CustomFormCreateDog",
+    "formActionType": "create",
+    "dataType": {
+      "dataSourceType": "Custom",
+      "dataTypeName": "Dog"
+    },
+    "fields": {
+        "name": {
+            "label": "Name",
+            "inputType": {
+                "type": "TextField"
+            },
+            "validations": [{"type": "Required", "validationMessage": "Name is required"}]
+        },
+        "age": {
+            "label": "Age",
+            "inputType": {
+                "type": "NumberField"
+            },
+            "validations": [{"type": "GreaterThanNum","numValues": ["0"], "validationMessage": "Age must be greater than 0"}]
+        },
+        "email": {
+            "label": "Email",
+            "inputType": {
+                "type": "EmailField"
+            },
+            "validations": [{"type": "Required", "validationMessage": "Email is required"}]
+        }
+    },
+    "sectionalElements": {
+        "formHeading": {
+            "type": "Heading",
+            "position": {"fixed": "first"},
+            "text": "Register your dog"
+        }
+    },
+    "style": {},
+    "schemaVersion": "1.0"
+  }


### PR DESCRIPTION
*Description of changes:*
- validate on submit
- change type of `onValidate` to allow non-async callback
- fix logic for how `onValidate` extends existing validations
- init form integ test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
