### PR TITLE
chore: add model prop to update form

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -442,8 +442,8 @@ import {
   getOverrideProps,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
 import { Post } from \\"../models\\";
+import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
 import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function myPostForm(props) {
@@ -675,8 +675,8 @@ import {
   getOverrideProps,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
 import { Post } from \\"../models\\";
+import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
 import {
   Button,
   Flex,
@@ -688,6 +688,7 @@ import { DataStore } from \\"aws-amplify\\";
 export default function myPostForm(props) {
   const {
     id,
+    post,
     onSubmitBefore,
     onSubmitComplete,
     onCancel,
@@ -697,6 +698,14 @@ export default function myPostForm(props) {
   } = props;
   const [modelFields, setModelFields] = useStateMutationAction({});
   const [errors, setErrors] = useStateMutationAction({});
+  const [postRecord, setPostRecord] = useStateMutationAction(post);
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = id ? await DataStore.query(Post, id) : post;
+      setPostRecord(record);
+    };
+    queryData();
+  }, [id, post]);
   const validations = {
     TextAreaFieldbbd63464: [],
     caption: [],
@@ -731,9 +740,8 @@ export default function myPostForm(props) {
           setModelFields(onSubmitBefore({ fields: modelFields }));
         }
         try {
-          const original = await DataStore.query(Post, id);
           await DataStore.save(
-            Post.copyOf(original, (updated) => {
+            Post.copyOf(postRecord, (updated) => {
               Object.assign(updated, modelFields);
             })
           );
@@ -921,6 +929,7 @@ export default function myPostForm(props) {
 exports[`amplify form renderer tests datastore form tests should generate a update form 2`] = `
 "import * as React from \\"react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../models\\";
 import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
 export declare type ValidationResponse = {
     hasError: boolean;
@@ -949,7 +958,8 @@ export declare type myPostFormOverridesProps = {
 export declare type myPostFormProps = React.PropsWithChildren<{
     overrides?: myPostFormOverridesProps | undefined | null;
 } & {
-    id: string;
+    id?: string;
+    post?: Post;
     onSubmitBefore?: (fields: Record<string, string>) => Record<string, string>;
     onSubmitComplete?: ({ saveSuccessful, errorMessage }: {
         saveSuccessful: boolean;
@@ -971,8 +981,8 @@ import {
   getOverrideProps,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
 import { InputGallery } from \\"../models\\";
+import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
 import {
   Button,
   CheckboxField,

--- a/packages/codegen-ui-react/lib/helpers/index.ts
+++ b/packages/codegen-ui-react/lib/helpers/index.ts
@@ -1,0 +1,16 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+export const lowerCaseFirst = (input: string) => input.charAt(0).toLowerCase() + input.slice(1);

--- a/packages/codegen-ui-react/lib/utils/generate-react-hooks.ts
+++ b/packages/codegen-ui-react/lib/utils/generate-react-hooks.ts
@@ -1,0 +1,35 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import ts, { factory, SyntaxKind } from 'typescript';
+
+export const addUseEffectWrapper = (statements: ts.Statement[], dependencies: string[]) => {
+  return factory.createExpressionStatement(
+    factory.createCallExpression(factory.createIdentifier('React.useEffect'), undefined, [
+      factory.createArrowFunction(
+        undefined,
+        undefined,
+        [],
+        undefined,
+        factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+        factory.createBlock(statements, true),
+      ),
+      factory.createArrayLiteralExpression(
+        dependencies.map((dependency) => factory.createIdentifier(dependency)),
+        false,
+      ),
+    ]),
+  );
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- adds optional `currentModel` prop to update Form component
- makes `id` prop optional

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
