### PR TITLE
chore: change form cta visible property to excluded

### DIFF
--- a/packages/codegen-ui/lib/generate-form-definition/helpers/map-cta.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/map-cta.ts
@@ -14,7 +14,49 @@
   limitations under the License.
  */
 import { FORM_DEFINITION_DEFAULTS } from './defaults';
-import { StudioFormCTA, ButtonConfig } from '../../types';
+import { StudioFormCTA, ButtonConfig, StudioFormCTAButton, FormDefinitionButtonElement } from '../../types';
+
+function getButtonElement(
+  key: 'cancel' | 'clear' | 'submit',
+  override?: StudioFormCTAButton,
+): FormDefinitionButtonElement | undefined {
+  if (override && 'excluded' in override) {
+    return undefined;
+  }
+
+  const ButtonMap = {
+    cancel: {
+      name: 'CancelButton',
+      type: 'button',
+    },
+    clear: {
+      name: 'ClearButton',
+      type: 'reset',
+    },
+    submit: {
+      name: 'SubmitButton',
+      type: 'submit',
+      variation: 'primary',
+    },
+  };
+
+  const { cta: defaults } = FORM_DEFINITION_DEFAULTS;
+
+  const element: FormDefinitionButtonElement = {
+    name: ButtonMap[key].name,
+    componentType: 'Button',
+    props: {
+      children: override?.children ?? defaults[key].label,
+      type: ButtonMap[key].type,
+    },
+  };
+
+  if (key === 'submit') {
+    element.props.variation = ButtonMap[key].variation;
+  }
+
+  return element;
+}
 
 export function mapButtons(buttons: StudioFormCTA): ButtonConfig {
   const defaults = FORM_DEFINITION_DEFAULTS.cta;
@@ -25,39 +67,11 @@ export function mapButtons(buttons: StudioFormCTA): ButtonConfig {
     buttonConfigs: {},
   };
 
-  if (buttons.clear?.visible !== false) {
-    buttonMapping.buttonConfigs.clear = {
-      name: 'ClearButton',
-      componentType: 'Button',
-      props: {
-        children: buttons.clear?.children ? buttons.clear.children : defaults.clear.label,
-        type: 'reset',
-      },
-    };
-  }
+  const keys: (keyof ButtonConfig['buttonConfigs'])[] = ['submit', 'cancel', 'clear'];
 
-  if (buttons.cancel?.visible !== false) {
-    buttonMapping.buttonConfigs.cancel = {
-      name: 'CancelButton',
-      componentType: 'Button',
-      props: {
-        children: buttons.cancel?.children ? buttons.cancel.children : defaults.cancel.label,
-        type: 'button',
-      },
-    };
-  }
-
-  if (buttons.submit?.visible !== false) {
-    buttonMapping.buttonConfigs.submit = {
-      name: 'SubmitButton',
-      componentType: 'Button',
-      props: {
-        children: buttons.submit?.children ? buttons.submit.children : defaults.submit.label,
-        type: 'submit',
-        variation: 'primary',
-      },
-    };
-  }
+  keys.forEach((key) => {
+    buttonMapping.buttonConfigs[key] = getButtonElement(key, buttons[key]);
+  });
 
   return buttonMapping;
 }

--- a/packages/codegen-ui/lib/types/form/form-cta.ts
+++ b/packages/codegen-ui/lib/types/form/form-cta.ts
@@ -14,15 +14,12 @@
   limitations under the License.
  */
 import { StudioFieldPosition } from './position';
-import { FormDefinitionButtonElement } from './form-definition-element';
 
-type StudioFormCTAButton = {
-  visible?: boolean;
-
-  children?: string;
-
-  position?: StudioFieldPosition;
-};
+export type StudioFormCTAButton =
+  | {
+      excluded: true;
+    }
+  | { children?: string; position?: StudioFieldPosition };
 
 /**
  * Configuration for each of the specified CTA's
@@ -38,14 +35,4 @@ export type StudioFormCTA = {
   cancel?: StudioFormCTAButton;
 
   submit?: StudioFormCTAButton;
-};
-
-export type ButtonConfig = {
-  buttonConfigs: {
-    submit?: FormDefinitionButtonElement;
-    cancel?: FormDefinitionButtonElement;
-    clear?: FormDefinitionButtonElement;
-  };
-  position: string;
-  buttonMatrix: string[][];
 };

--- a/packages/codegen-ui/lib/types/form/form-definition.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition.ts
@@ -14,11 +14,20 @@
   limitations under the License.
  */
 import { StudioFormStyle } from './style';
-import { FormDefinitionElement } from './form-definition-element';
+import { FormDefinitionElement, FormDefinitionButtonElement } from './form-definition-element';
 import { StudioGenericFieldConfig } from './fields';
-import { ButtonConfig } from './form-cta';
 
 export type ModelFieldsConfigs = { [key: string]: StudioGenericFieldConfig };
+
+export type ButtonConfig = {
+  buttonConfigs: {
+    submit?: FormDefinitionButtonElement;
+    cancel?: FormDefinitionButtonElement;
+    clear?: FormDefinitionButtonElement;
+  };
+  position: string;
+  buttonMatrix: string[][];
+};
 
 export type FormDefinition = {
   form: {

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -17,7 +17,7 @@
 import { StudioFormStyle } from './style';
 import { StudioFormFields, StudioFormFieldConfig, StudioGenericFieldConfig } from './fields';
 import { SectionalElement } from './sectional-element';
-import { FormDefinition, ModelFieldsConfigs, FieldTypeMapKeys } from './form-definition';
+import { FormDefinition, ModelFieldsConfigs, FieldTypeMapKeys, ButtonConfig } from './form-definition';
 import { StudioFieldInputConfig, StudioFormValueMappings } from './input-config';
 import { StudioFieldPosition } from './position';
 import { StudioFormCTA } from './form-cta';
@@ -98,4 +98,5 @@ export type {
   StudioFieldPosition,
   FieldTypeMapKeys,
   StudioFormValueMappings,
+  ButtonConfig,
 };


### PR DESCRIPTION
*Description of changes:*
- Change `visible` property to `excluded` for `StudioFormCTAButton`.
- Move some logic/ types around - no functional changes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
