### PR TITLE
fix: remove @aws-amplify/codegen-ui-react as import source

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -7,7 +7,7 @@ import {
   getOverrideProps,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
+import { validateField } from \\"./utils\\";
 import {
   Button,
   Flex,
@@ -257,7 +257,7 @@ import {
   getOverrideProps,
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
+import { validateField } from \\"./utils\\";
 import {
   Button,
   Divider,
@@ -443,7 +443,7 @@ import {
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
+import { validateField } from \\"./utils\\";
 import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function MyPostForm(props) {
@@ -676,7 +676,7 @@ import {
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
+import { validateField } from \\"./utils\\";
 import {
   Button,
   Flex,
@@ -982,7 +982,7 @@ import {
   useStateMutationAction,
 } from \\"@aws-amplify/ui-react/internal\\";
 import { InputGallery } from \\"../models\\";
-import { validateField } from \\"@aws-amplify/codegen-ui-react\\";
+import { validateField } from \\"./utils\\";
 import {
   Button,
   CheckboxField,

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -119,12 +119,6 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     const { printer, file } = buildPrinter(this.fileName, this.renderConfig);
 
-    // remove the utils import as the component will need to import it from codegen-ui-react directly
-    if (this.importCollection.hasMappedImport(ImportSource.UTILS)) {
-      this.importCollection.removeImportSource(ImportSource.UTILS);
-      this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD_CODEGEN);
-    }
-
     const imports = this.importCollection.buildImportStatements();
 
     let importsText = '';

--- a/packages/codegen-ui-react/lib/imports/import-collection.ts
+++ b/packages/codegen-ui-react/lib/imports/import-collection.ts
@@ -37,10 +37,6 @@ export class ImportCollection {
     }
   }
 
-  hasMappedImport(source: ImportSource) {
-    return this.#collection.has(source);
-  }
-
   removeImportSource(packageImport: ImportSource) {
     this.#collection.delete(packageImport);
   }

--- a/packages/codegen-ui-react/lib/imports/import-mapping.ts
+++ b/packages/codegen-ui-react/lib/imports/import-mapping.ts
@@ -16,7 +16,6 @@
 export enum ImportSource {
   REACT = 'react',
   UI_REACT = '@aws-amplify/ui-react',
-  CODEGEN_UI_REACT = '@aws-amplify/codegen-ui-react',
   UI_REACT_INTERNAL = '@aws-amplify/ui-react/internal',
   AMPLIFY_DATASTORE = '@aws-amplify/datastore',
   LOCAL_MODELS = '../models',
@@ -71,5 +70,4 @@ export const ImportMapping: Record<ImportValue, ImportSource> = {
   [ImportValue.USE_EFFECT]: ImportSource.REACT,
   [ImportValue.FORMATTER]: ImportSource.UTILS,
   [ImportValue.VALIDATE_FIELD]: ImportSource.UTILS,
-  [ImportValue.VALIDATE_FIELD_CODEGEN]: ImportSource.CODEGEN_UI_REACT,
 };


### PR DESCRIPTION
By removing this import generated forms can now use the utils file for
validateField use. This shouldn't be an issue for UI as that does not
render the import source for the files and we can decide the import
value in the UI code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
