### PR TITLE
fix: remove pascal case from theme names

### DIFF
--- a/packages/codegen-ui/lib/validation-helper.ts
+++ b/packages/codegen-ui/lib/validation-helper.ts
@@ -17,6 +17,10 @@ import * as yup from 'yup';
 import { InvalidInputError } from './errors';
 import { StudioGenericEvent, StudioSchema } from './types';
 
+const alphaNumString = () => {
+  return yup.string().matches(/^[a-zA-Z0-9]*$/, { message: 'Expected an alphanumeric string' });
+};
+
 const pascalCaseAlphaNumString = () => {
   return yup
     .string()
@@ -173,7 +177,7 @@ const studioThemeValuesSchema: any = yup.object({
 });
 
 const studioThemeSchema = yup.object({
-  name: pascalCaseAlphaNumString().required(),
+  name: alphaNumString().required(),
   id: yup.string().nullable(),
   values: yup.array(studioThemeValuesSchema).required(),
   overrides: yup.array(studioThemeValuesSchema).nullable(),


### PR DESCRIPTION
fix: remove pascal case from themes as the default theme name is "studioTheme"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
