### PR TITLE
chore: support button element as input type and form def element

### DIFF
--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -176,7 +176,6 @@ export type FormDefinitionInputElement = (
   | FormDefinitionCheckboxFieldElement
   | FormDefinitionRadioGroupFieldElement
   | FormDefinitionPasswordFieldElement
-  | FormDefinitionButtonElement
 ) &
   FormDefinitionInputElementCommon;
 
@@ -200,4 +199,7 @@ export type FormDefinitionSectionalElement =
   | FormDefinitionTextElement
   | FormDefinitionDividerElement;
 
-export type FormDefinitionElement = FormDefinitionInputElement | FormDefinitionSectionalElement;
+export type FormDefinitionElement =
+  | FormDefinitionInputElement
+  | FormDefinitionSectionalElement
+  | FormDefinitionButtonElement;

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -66,6 +66,7 @@ export type FormInputType =
   | 'StepperField'
   | 'SwitchField'
   | 'ToggleButton'
+  | 'Button'
   | 'CheckboxField'
   | 'RadioGroupField'
   | 'PhoneNumberField'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
we need to support the new button element as:
- an input type to support button shape being interactive
- form definition element since its a new element type and is causing build errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
