### PR TITLE
chore: add phone validation, change required validation, and fix regex

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -28,8 +28,8 @@ export default function CustomDataForm(props) {
   const [modelFields, setModelFields] = useStateMutationAction({});
   const [errors, setErrors] = useStateMutationAction({});
   const validations = {
-    name: [],
-    email: [],
+    name: [{ type: \\"Required\\" }],
+    email: [{ type: \\"Required\\" }],
     city: [],
     category: [],
   };
@@ -1008,7 +1008,7 @@ export default function InputGalleryCreateForm(props) {
   const validations = {
     num: [],
     rootbeer: [],
-    attend: [],
+    attend: [{ type: \\"Required\\" }],
     maybeSlide: [],
     maybeCheck: [],
     timestamp: [],

--- a/packages/codegen-ui-react/lib/__tests__/forms/validation.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/forms/validation.test.ts
@@ -20,7 +20,6 @@ describe('validateField tests', () => {
   it('should validate REQUIRED type', () => {
     expect(validateField('123', [{ type: ValidationTypes.REQUIRED, validationMessage: '' }])).toEqual({
       hasError: false,
-      errorMessage: 'The value is required',
     });
     expect(validateField('', [{ type: ValidationTypes.REQUIRED, validationMessage: '' }])).toEqual({
       hasError: true,
@@ -28,7 +27,6 @@ describe('validateField tests', () => {
     });
     expect(validateField(0, [{ type: ValidationTypes.REQUIRED, validationMessage: 'test' }])).toEqual({
       hasError: false,
-      errorMessage: 'test',
     });
   });
   it('should validate START_WITH type', () => {
@@ -91,19 +89,22 @@ describe('validateField tests', () => {
       validateField('123', [{ type: ValidationTypes.LESS_THAN_CHAR_LENGTH, numValues: [4], validationMessage: '' }]),
     ).toEqual({ hasError: false, errorMessage: 'The value must be shorter than 4' });
     expect(
-      validateField('', [{ type: ValidationTypes.LESS_THAN_CHAR_LENGTH, numValues: [0], validationMessage: '' }]),
-    ).toEqual({ hasError: true, errorMessage: 'The value must be shorter than 0' });
+      validateField('', [{ type: ValidationTypes.LESS_THAN_CHAR_LENGTH, numValues: [3], validationMessage: '' }]),
+    ).toEqual({ hasError: false });
+    expect(
+      validateField('23445', [{ type: ValidationTypes.LESS_THAN_CHAR_LENGTH, numValues: [3], validationMessage: '' }]),
+    ).toEqual({ hasError: true, errorMessage: 'The value must be shorter than 3' });
   });
   it('should validate GREATER_THAN_CHAR_LENGTH type', () => {
     expect(
       validateField('123', [{ type: ValidationTypes.GREATER_THAN_CHAR_LENGTH, numValues: [0], validationMessage: '' }]),
     ).toEqual({ hasError: false, errorMessage: 'The value must be longer than 0' });
     expect(
-      validateField('', [{ type: ValidationTypes.GREATER_THAN_CHAR_LENGTH, numValues: [0], validationMessage: '' }]),
-    ).toEqual({ hasError: true, errorMessage: 'The value must be longer than 0' });
+      validateField('', [{ type: ValidationTypes.GREATER_THAN_CHAR_LENGTH, numValues: [3], validationMessage: '' }]),
+    ).toEqual({ hasError: false });
     expect(
-      validateField('', [
-        { type: ValidationTypes.GREATER_THAN_CHAR_LENGTH, numValues: [1], validationMessage: 'test' },
+      validateField('df', [
+        { type: ValidationTypes.GREATER_THAN_CHAR_LENGTH, numValues: [3], validationMessage: 'test' },
       ]),
     ).toEqual({ hasError: true, errorMessage: 'test' });
   });
@@ -251,13 +252,12 @@ describe('validateField tests', () => {
       hasError: false,
       errorMessage: 'The value must be in a correct JSON format',
     });
-    expect(validateField('\\\\', [{ type: ValidationTypes.JSON, validationMessage: '' }])).toEqual({
-      hasError: true,
-      errorMessage: 'The value must be in a correct JSON format',
-    });
-    expect(validateField('', [{ type: ValidationTypes.JSON, validationMessage: 'test' }])).toEqual({
+    expect(validateField('\\\\', [{ type: ValidationTypes.JSON, validationMessage: 'test' }])).toEqual({
       hasError: true,
       errorMessage: 'test',
+    });
+    expect(validateField('', [{ type: ValidationTypes.JSON, validationMessage: 'test' }])).toEqual({
+      hasError: false,
     });
   });
   it('should validate IP_ADDRESS type', () => {
@@ -270,13 +270,12 @@ describe('validateField tests', () => {
         { type: ValidationTypes.IP_ADDRESS, validationMessage: '' },
       ]),
     ).toEqual({ hasError: false, errorMessage: 'The value must be an IPv4 or IPv6 address' });
-    expect(validateField('1.1', [{ type: ValidationTypes.IP_ADDRESS, validationMessage: '' }])).toEqual({
-      hasError: true,
-      errorMessage: 'The value must be an IPv4 or IPv6 address',
-    });
-    expect(validateField('', [{ type: ValidationTypes.IP_ADDRESS, validationMessage: 'test' }])).toEqual({
+    expect(validateField('1.1', [{ type: ValidationTypes.IP_ADDRESS, validationMessage: 'test' }])).toEqual({
       hasError: true,
       errorMessage: 'test',
+    });
+    expect(validateField('', [{ type: ValidationTypes.IP_ADDRESS, validationMessage: 'test' }])).toEqual({
+      hasError: false,
     });
   });
   it('should validate URL type', () => {
@@ -294,6 +293,33 @@ describe('validateField tests', () => {
     });
     expect(validateField('/aws.com', [{ type: ValidationTypes.URL, validationMessage: 'test' }])).toEqual({
       hasError: true,
+      errorMessage: 'test',
+    });
+  });
+
+  it('should validate Phone type', () => {
+    expect(validateField('kdj34324', [{ type: ValidationTypes.PHONE }])).toEqual({
+      hasError: true,
+      errorMessage: 'The value must be a valid phone number',
+    });
+
+    expect(validateField('2938493029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
+      hasError: false,
+      errorMessage: 'test',
+    });
+
+    expect(validateField('293 849 3029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
+      hasError: false,
+      errorMessage: 'test',
+    });
+
+    expect(validateField('293-849-3029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
+      hasError: false,
+      errorMessage: 'test',
+    });
+
+    expect(validateField('293 849-3029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
+      hasError: false,
       errorMessage: 'test',
     });
   });

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -14,6 +14,7 @@
   limitations under the License.
  */
 import { generateFormDefinition } from '../../generate-form-definition';
+import { ValidationTypes } from '../../types';
 
 describe('generateFormDefinition', () => {
   it('should map DataStore model fields', () => {
@@ -41,6 +42,7 @@ describe('generateFormDefinition', () => {
         dataType: 'String',
         props: { label: 'Name', isRequired: true, isReadOnly: false },
         studioFormComponentType: 'TextField',
+        validations: [{ type: ValidationTypes.REQUIRED, immutable: true }],
       },
     });
   });
@@ -86,6 +88,7 @@ describe('generateFormDefinition', () => {
         componentType: 'SliderField',
         dataType: 'Float',
         props: { label: 'Weight', min: 1, max: 100, step: 2, isDisabled: false, isRequired: true },
+        validations: [{ type: ValidationTypes.REQUIRED, immutable: true }],
       },
     });
   });
@@ -397,6 +400,7 @@ it('should add read-only fields if it has overrides', () => {
       dataType: 'String',
       props: { label: 'Name', isRequired: true, isReadOnly: true },
       studioFormComponentType: 'TextField',
+      validations: [{ type: ValidationTypes.REQUIRED, immutable: true }],
     },
   });
   expect(formDefinition.elementMatrix).toStrictEqual([['name']]);

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
@@ -39,7 +39,6 @@ describe('mapFormFieldConfig', () => {
           maxValue: 100,
           step: 1,
           readOnly: true,
-          required: true,
         },
       },
     };
@@ -70,7 +69,7 @@ describe('mapFormFieldConfig', () => {
 
     expect(formDefinition.elements.price).toStrictEqual({
       componentType: 'SliderField',
-      props: { label: 'Price', isDisabled: true, min: 0, max: 100, step: 1, isRequired: true },
+      props: { label: 'Price', isDisabled: true, min: 0, max: 100, step: 1, isRequired: false },
     });
   });
 
@@ -251,6 +250,28 @@ describe('getFormDefinitionInputElement', () => {
     });
   });
 
+  it('should add validation if field is required', () => {
+    const config = {
+      inputType: {
+        type: 'EmailField',
+        required: true,
+      },
+    };
+
+    expect(getFormDefinitionInputElement(config)).toStrictEqual({
+      componentType: 'TextField',
+      props: {
+        label: 'Label',
+        isRequired: true,
+      },
+      studioFormComponentType: 'EmailField',
+      validations: [
+        { type: ValidationTypes.REQUIRED, immutable: true },
+        { type: ValidationTypes.EMAIL, immutable: true },
+      ],
+    });
+  });
+
   it('should get SwitchField', () => {
     const config = {
       inputType: {
@@ -276,6 +297,7 @@ describe('getFormDefinitionInputElement', () => {
     expect(getFormDefinitionInputElement(config)).toStrictEqual({
       componentType: 'PhoneNumberField',
       props: { label: 'Label', defaultCountryCode: '+11' },
+      validations: [{ type: ValidationTypes.PHONE, immutable: true }],
     });
   });
 

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -95,7 +95,14 @@ function getRadioGroupFieldValueMappings(
 function getMergedValidations(
   componentType: string,
   validations: (FieldValidationConfiguration[] | undefined)[],
+  isRequired?: boolean,
 ): (FieldValidationConfiguration & { immutable?: true })[] | undefined {
+  const mergedValidations: (FieldValidationConfiguration & { immutable?: true })[] = [];
+
+  if (isRequired) {
+    mergedValidations.push({ type: ValidationTypes.REQUIRED, immutable: true });
+  }
+
   const ComponentTypeToDefaultValidations: {
     [componentType: string]: (FieldValidationConfiguration & { immutable: true })[];
   } = {
@@ -103,10 +110,14 @@ function getMergedValidations(
     URLField: [{ type: ValidationTypes.URL, immutable: true }],
     EmailField: [{ type: ValidationTypes.EMAIL, immutable: true }],
     JSONField: [{ type: ValidationTypes.JSON, immutable: true }],
+    PhoneNumberField: [{ type: ValidationTypes.PHONE, immutable: true }],
   };
 
-  const mergedValidations: (FieldValidationConfiguration & { immutable?: true })[] =
-    ComponentTypeToDefaultValidations[componentType] ?? [];
+  const defaultValidation = ComponentTypeToDefaultValidations[componentType];
+
+  if (defaultValidation) {
+    mergedValidations.push(...defaultValidation);
+  }
 
   validations.forEach((validationArray) => {
     if (validationArray) {
@@ -334,7 +345,11 @@ export function getFormDefinitionInputElement(
       throw new InvalidInputError(`componentType ${componentType} could not be mapped`);
   }
 
-  const mergedValidations = getMergedValidations(componentType, [baseConfig?.validations, config?.validations]);
+  const mergedValidations = getMergedValidations(
+    componentType,
+    [baseConfig?.validations, config?.validations],
+    isRequiredValue,
+  );
 
   formDefinitionElement.validations = mergedValidations;
   formDefinitionElement.dataType = config?.dataType || baseConfig?.dataType;

--- a/packages/codegen-ui/lib/types/form/form-validation.ts
+++ b/packages/codegen-ui/lib/types/form/form-validation.ts
@@ -30,6 +30,7 @@ export enum ValidationTypes {
   JSON = 'JSON',
   IP_ADDRESS = 'IpAddress',
   URL = 'URL',
+  PHONE = 'Phone',
 }
 
 export const ValidationTypeMapping: Record<'StringType' | 'NumberType', ValidationTypes[]> = {
@@ -88,7 +89,8 @@ export type GenericValidationType = {
     | ValidationTypes.EMAIL
     | ValidationTypes.JSON
     | ValidationTypes.IP_ADDRESS
-    | ValidationTypes.URL;
+    | ValidationTypes.URL
+    | ValidationTypes.PHONE;
 } & BaseValidation;
 
 export type FieldValidationConfiguration =

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form-spec.cy.ts
@@ -20,31 +20,37 @@ describe('Forms', () => {
 
   it('CustomFormCreateDog', () => {
     const ErrorMessageMap = {
-      name: 'Name is required',
+      name: 'Name must be longer than 1 character',
       age: 'Age must be greater than 0',
       validEmail: 'The value must be a valid email address',
       customValidation: 'All dog emails are yahoo emails',
+      ip: 'The value must be an IPv4 or IPv6 address',
     };
     cy.get('#customFormCreateDog').within(() => {
       const blurField = () => cy.contains('Register your dog').click();
 
-      // should validate on submit
+      // should not submit if required field empty
       cy.contains('Submit').click();
-      cy.contains(ErrorMessageMap.name);
-      cy.contains(ErrorMessageMap.age);
+      cy.contains('submitted: false');
+
+      // validates email
+      cy.get('input').eq(2).type('fdfdsfd');
       cy.contains(ErrorMessageMap.validEmail);
+      cy.contains('Clear').click();
 
       // validates on change & extends with onValidate prop
-      cy.get('input').eq(0).type('Spot');
+      cy.get('input').eq(0).type('S');
       blurField();
-      cy.get('input').eq(1).type('3');
+      cy.get('input').eq(1).type('-1');
       blurField();
       cy.get('input').eq(2).type('spot@gmail.com');
       blurField();
-      cy.contains(ErrorMessageMap.name).should('not.exist');
-      cy.contains(ErrorMessageMap.age).should('not.exist');
+      cy.get('input').eq(3).type('invalid ip');
+      cy.contains(ErrorMessageMap.name);
+      cy.contains(ErrorMessageMap.age);
       cy.contains(ErrorMessageMap.validEmail).should('not.exist');
       cy.contains(ErrorMessageMap.customValidation);
+      cy.contains(ErrorMessageMap.ip);
 
       // clears and submits
       cy.contains('Clear').click();
@@ -54,10 +60,14 @@ describe('Forms', () => {
       blurField();
       cy.get('input').eq(2).type('spot@yahoo.com');
       blurField();
+      cy.get('input').eq(3).type('192.0.2.146');
+      blurField();
       cy.contains('Submit').click();
+      cy.contains('submitted: true');
       cy.contains('name: Spot');
       cy.contains('age: 3');
       cy.contains('email: spot@yahoo.com');
+      cy.contains('ip: 192.0.2.146');
     });
   });
 });

--- a/packages/test-generator/integration-test-templates/src/FormTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/FormTests.tsx
@@ -28,7 +28,6 @@ export default function FormTests() {
           onSubmit={(r) => setCustomFormCreateDogSubmitResults(r)}
           onValidate={{
             email: (value, validationResponse) => {
-              console.log(value, validationResponse);
               if (validationResponse.hasError) {
                 return validationResponse;
               }
@@ -39,10 +38,12 @@ export default function FormTests() {
             },
           }}
         />
+        <View>{`submitted: ${!!Object.keys(customFormCreateDogSubmitResults).length}`}</View>
         <View>{`name: ${customFormCreateDogSubmitResults.name}`}</View>
         <Text>{`name: ${customFormCreateDogSubmitResults.name}`}</Text>
         <Text>{`age: ${customFormCreateDogSubmitResults.age}`}</Text>
         <Text>{`email: ${customFormCreateDogSubmitResults.email}`}</Text>
+        <Text>{`ip: ${customFormCreateDogSubmitResults.ip}`}</Text>
       </View>
       <Divider />
     </AmplifyProvider>

--- a/packages/test-generator/lib/forms/custom-form-create-dog.json
+++ b/packages/test-generator/lib/forms/custom-form-create-dog.json
@@ -12,7 +12,7 @@
             "inputType": {
                 "type": "TextField"
             },
-            "validations": [{"type": "Required", "validationMessage": "Name is required"}]
+            "validations": [{"type": "GreaterThanChar", "numValues": ["1"], "validationMessage": "Name must be longer than 1 character"}]
         },
         "age": {
             "label": "Age",
@@ -25,8 +25,14 @@
             "label": "Email",
             "inputType": {
                 "type": "EmailField"
-            },
-            "validations": [{"type": "Required", "validationMessage": "Email is required"}]
+            }
+        },
+        "ip": {
+            "label": "IP Address",
+            "inputType": {
+                "type": "IPAddressField",
+                "required": true
+            }
         }
     },
     "sectionalElements": {


### PR DESCRIPTION
*Description of changes:*
- Add validation for `PhoneNumberField` (bare bones according to AWSPhone scalar spec)
- Add validation for required fields.
- Do not run validations other than `Required` if input is empty
- Fix validation regex that were not generating correctly in cx project


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
