### PR TITLE
fix: do not assume related model or field is in datastore schema

### DIFF
--- a/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
@@ -783,3 +783,84 @@ export const schemaWithNonModels: Schema = {
   },
   version: '38a1a46479c6cd75d21439d7f3122c1d',
 };
+
+export const schemaWithAssumptions: Schema = {
+  models: {
+    User: {
+      name: 'User',
+      fields: {
+        friends: {
+          name: 'friends',
+          isArray: true,
+          type: {
+            model: 'Friend',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: 'friendId',
+          },
+        },
+        posts: {
+          name: 'posts',
+          isArray: true,
+          type: {
+            model: 'Post',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: 'userPostsId',
+          },
+        },
+      },
+      syncable: true,
+      pluralName: 'Users',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['id'],
+          },
+        },
+      ],
+    },
+    Event: {
+      name: 'Post',
+      fields: {
+        name: {
+          name: 'name',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+      },
+      syncable: true,
+      pluralName: 'Posts',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['id'],
+          },
+        },
+      ],
+    },
+  },
+  enums: {},
+  nonModels: {},
+  version: 'version',
+};

--- a/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
@@ -15,7 +15,12 @@
  */
 import { getGenericFromDataStore } from '../generic-from-datastore';
 import { HasManyRelationshipType } from '../types';
-import { schemaWithEnums, schemaWithNonModels, schemaWithRelationships } from './__utils__/mock-schemas';
+import {
+  schemaWithEnums,
+  schemaWithNonModels,
+  schemaWithRelationships,
+  schemaWithAssumptions,
+} from './__utils__/mock-schemas';
 
 describe('getGenericFromDataStore', () => {
   it('should map fields', () => {
@@ -116,6 +121,23 @@ describe('getGenericFromDataStore', () => {
         },
       },
       Misc: { fields: { quotes: { dataType: 'String', required: false, readOnly: false, isArray: true } } },
+    });
+  });
+
+  it('should handle schema with assumed associated fields and modldkjld', () => {
+    const genericSchema = getGenericFromDataStore(schemaWithAssumptions);
+    const userFields = genericSchema.models.User.fields;
+
+    expect(userFields.friends.relationship).toStrictEqual({
+      type: 'HAS_MANY',
+      relatedModelName: 'Friend',
+      relatedModelField: 'friendId',
+    });
+
+    expect(userFields.posts.relationship).toStrictEqual({
+      type: 'HAS_MANY',
+      relatedModelName: 'Post',
+      relatedModelField: 'userPostsId',
     });
   });
 });

--- a/packages/codegen-ui/lib/generic-from-datastore.ts
+++ b/packages/codegen-ui/lib/generic-from-datastore.ts
@@ -75,11 +75,12 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
           let modelRelationship: GenericDataRelationshipType | undefined;
 
           if (relationshipType === 'HAS_MANY' && 'associatedWith' in field.association) {
-            const associatedModel = dataStoreSchema.models[field.type.model];
+            const associatedModel = dataStoreSchema.models[relatedModelName];
             const associatedFieldName = field.association.associatedWith;
-            const associatedField = associatedModel.fields[associatedFieldName];
+            const associatedField = associatedModel?.fields[associatedFieldName];
             // if the associated model is a join table, update relatedModelName to the actual related model
             if (
+              associatedField &&
               typeof associatedField.type === 'object' &&
               'model' in associatedField.type &&
               associatedField.type.model === model.name
@@ -95,7 +96,7 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
               }
               // if the associated model is not a join table, note implicit relationship for associated field
             } else {
-              addRelationship(fieldsWithImplicitRelationships, associatedModel.name, associatedFieldName, {
+              addRelationship(fieldsWithImplicitRelationships, relatedModelName, associatedFieldName, {
                 type: 'HAS_ONE',
                 relatedModelName: model.name,
               });


### PR DESCRIPTION
*Description of changes:*
The `getGenericFromDataStore` was throwing when there is an associated field spelled out, but it does not actually exist in the schema.
This PR handles when the field is missing. For good measure, it also handles if an associated model were to be missing, although that has not been raised as an issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
