### PR TITLE
feat: add support for nested json

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3,11 +3,8 @@
 exports[`amplify form renderer tests custom form tests should render a custom backed form 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import {
-  getOverrideProps,
-  useStateMutationAction,
-} from \\"@aws-amplify/ui-react/internal\\";
-import { validateField } from \\"./utils\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Flex,
@@ -25,8 +22,11 @@ export default function CustomDataForm(props) {
     overrides,
     ...rest
   } = props;
-  const [modelFields, setModelFields] = useStateMutationAction({});
-  const [errors, setErrors] = useStateMutationAction({});
+  const [name, setName] = React.useState(undefined);
+  const [email, setEmail] = React.useState(undefined);
+  const [city, setCity] = React.useState(undefined);
+  const [category, setCategory] = React.useState(undefined);
+  const [errors, setErrors] = React.useState({});
   const validations = {
     name: [{ type: \\"Required\\" }],
     email: [{ type: \\"Required\\" }],
@@ -35,11 +35,9 @@ export default function CustomDataForm(props) {
   };
   const runValidationTasks = async (fieldName, value) => {
     let validationResponse = validateField(value, validations[fieldName]);
-    if (onValidate?.[fieldName]) {
-      validationResponse = await onValidate[fieldName](
-        value,
-        validationResponse
-      );
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
     }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
@@ -48,6 +46,12 @@ export default function CustomDataForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const modelFields = {
+          name,
+          email,
+          city,
+          category,
+        };
         const validationResponses = await Promise.all(
           Object.keys(validations).map((fieldName) =>
             runValidationTasks(fieldName, modelFields[fieldName])
@@ -80,7 +84,7 @@ export default function CustomDataForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"name\\", value);
-              setModelFields({ ...modelFields, name: value });
+              setName(value);
             }}
             errorMessage={errors.name?.errorMessage}
             hasError={errors.name?.hasError}
@@ -100,7 +104,7 @@ export default function CustomDataForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"email\\", value);
-              setModelFields({ ...modelFields, email: value });
+              setEmail(value);
             }}
             errorMessage={errors.email?.errorMessage}
             hasError={errors.email?.hasError}
@@ -118,7 +122,7 @@ export default function CustomDataForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"city\\", value);
-              setModelFields({ ...modelFields, city: value });
+              setCity(value);
             }}
             errorMessage={errors.city?.errorMessage}
             hasError={errors.city?.hasError}
@@ -155,7 +159,7 @@ export default function CustomDataForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"category\\", value);
-              setModelFields({ ...modelFields, category: value });
+              setCategory(value);
             }}
             errorMessage={errors.category?.errorMessage}
             hasError={errors.category?.hasError}
@@ -221,11 +225,12 @@ export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
 };
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type CustomDataFormInputValues = {
-    name: string;
-    email: string;
-    city: string;
-    category: string;
+    name?: ValidationFunction<string>;
+    email?: ValidationFunction<string>;
+    city?: ValidationFunction<string>;
+    category?: ValidationFunction<string>;
 };
 export declare type CustomDataFormOverridesProps = {
     CustomDataFormGrid?: GridProps;
@@ -243,22 +248,238 @@ export declare type CustomDataFormProps = React.PropsWithChildren<{
 } & {
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: {
-        [field in keyof CustomDataFormInputValues]?: (value: CustomDataFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
-    };
+    onValidate?: CustomDataFormInputValues;
 }>;
 export default function CustomDataForm(props: CustomDataFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests custom form tests should render nested json fields 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Button, Flex, Grid, Heading, TextField } from \\"@aws-amplify/ui-react\\";
+export default function NestedJson(props) {
+  const {
+    onSubmit: nestedJsonOnSubmit,
+    onCancel,
+    onValidate,
+    overrides,
+    ...rest
+  } = props;
+  const [firstName, setFirstName] = React.useState(undefined);
+  const [lastName, setLastName] = React.useState(undefined);
+  const [bio, setBio] = React.useState({});
+  const [errors, setErrors] = React.useState({});
+  const validations = {
+    firstName: [],
+    lastName: [],
+    \\"bio.favoriteQuote\\": [],
+    \\"bio.favoriteAnimal\\": [],
+  };
+  const runValidationTasks = async (fieldName, value) => {
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  return (
+    <form
+      onSubmit={async (event) => {
+        event.preventDefault();
+        const modelFields = {
+          firstName,
+          lastName,
+          bio,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).map((fieldName) =>
+            runValidationTasks(fieldName, modelFields[fieldName])
+          )
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        await nestedJsonOnSubmit(modelFields);
+      }}
+      {...rest}
+      {...getOverrideProps(overrides, \\"NestedJson\\")}
+    >
+      <Grid
+        columnGap=\\"15px\\"
+        rowGap=\\"15px\\"
+        padding=\\"20px\\"
+        {...getOverrideProps(overrides, \\"NestedJsonGrid\\")}
+      >
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid0\\")}
+        >
+          <TextField
+            label=\\"firstName\\"
+            onChange={async (e) => {
+              const { value } = e.target;
+              await runValidationTasks(\\"firstName\\", value);
+              setFirstName(value);
+            }}
+            errorMessage={errors.firstName?.errorMessage}
+            hasError={errors.firstName?.hasError}
+            {...getOverrideProps(overrides, \\"firstName\\")}
+          ></TextField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid1\\")}
+        >
+          <TextField
+            label=\\"lastName\\"
+            onChange={async (e) => {
+              const { value } = e.target;
+              await runValidationTasks(\\"lastName\\", value);
+              setLastName(value);
+            }}
+            errorMessage={errors.lastName?.errorMessage}
+            hasError={errors.lastName?.hasError}
+            {...getOverrideProps(overrides, \\"lastName\\")}
+          ></TextField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid2\\")}
+        >
+          <Heading
+            level={3}
+            children=\\"bio\\"
+            {...getOverrideProps(overrides, \\"bio\\")}
+          ></Heading>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid3\\")}
+        >
+          <TextField
+            label=\\"favoriteQuote\\"
+            onChange={async (e) => {
+              const { value } = e.target;
+              await runValidationTasks(\\"bio.favoriteQuote\\", value);
+              setBio({ ...bio, favoriteQuote: value });
+            }}
+            errorMessage={errors[\\"bio.favoriteQuote\\"]?.errorMessage}
+            hasError={errors[\\"bio.favoriteQuote\\"]?.hasError}
+            {...getOverrideProps(overrides, \\"bio.favoriteQuote\\")}
+          ></TextField>
+        </Grid>
+        <Grid
+          columnGap=\\"inherit\\"
+          rowGap=\\"inherit\\"
+          templateColumns=\\"repeat(1, auto)\\"
+          {...getOverrideProps(overrides, \\"RowGrid4\\")}
+        >
+          <TextField
+            label=\\"favoriteAnimal\\"
+            onChange={async (e) => {
+              const { value } = e.target;
+              await runValidationTasks(\\"bio.favoriteAnimal\\", value);
+              setBio({ ...bio, favoriteAnimal: value });
+            }}
+            errorMessage={errors[\\"bio.favoriteAnimal\\"]?.errorMessage}
+            hasError={errors[\\"bio.favoriteAnimal\\"]?.hasError}
+            {...getOverrideProps(overrides, \\"bio.favoriteAnimal\\")}
+          ></TextField>
+        </Grid>
+      </Grid>
+      <Flex
+        justifyContent=\\"space-between\\"
+        marginTop=\\"1rem\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Clear\\"
+          type=\\"reset\\"
+          {...getOverrideProps(overrides, \\"ClearButton\\")}
+        ></Button>
+        <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
+          <Button
+            children=\\"Cancel\\"
+            type=\\"button\\"
+            onClick={() => {
+              onCancel && onCancel();
+            }}
+            {...getOverrideProps(overrides, \\"CancelButton\\")}
+          ></Button>
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </form>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests custom form tests should render nested json fields 2`] = `
+"import * as React from \\"react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { GridProps, HeadingProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type NestedJsonInputValues = {
+    firstName?: ValidationFunction<string>;
+    lastName?: ValidationFunction<string>;
+    bio?: {
+        favoriteQuote?: ValidationFunction<string>;
+        favoriteAnimal?: ValidationFunction<string>;
+    };
+};
+export declare type NestedJsonOverridesProps = {
+    NestedJsonGrid?: GridProps;
+    RowGrid0?: GridProps;
+    firstName?: TextFieldProps;
+    RowGrid1?: GridProps;
+    lastName?: TextFieldProps;
+    RowGrid2?: GridProps;
+    bio?: HeadingProps;
+    RowGrid3?: GridProps;
+    \\"bio.favoriteQuote\\"?: TextFieldProps;
+    RowGrid4?: GridProps;
+    \\"bio.favoriteAnimal\\"?: TextFieldProps;
+} & EscapeHatchProps;
+export declare type NestedJsonProps = React.PropsWithChildren<{
+    overrides?: NestedJsonOverridesProps | undefined | null;
+} & {
+    onSubmit: (fields: Record<string, string>) => void;
+    onCancel?: () => void;
+    onValidate?: NestedJsonInputValues;
+}>;
+export default function NestedJson(props: NestedJsonProps): React.ReactElement;
 "
 `;
 
 exports[`amplify form renderer tests custom form tests should render sectional elements 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import {
-  getOverrideProps,
-  useStateMutationAction,
-} from \\"@aws-amplify/ui-react/internal\\";
-import { validateField } from \\"./utils\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Divider,
@@ -276,18 +497,16 @@ export default function CustomWithSectionalElements(props) {
     overrides,
     ...rest
   } = props;
-  const [modelFields, setModelFields] = useStateMutationAction({});
-  const [errors, setErrors] = useStateMutationAction({});
+  const [name, setName] = React.useState(undefined);
+  const [errors, setErrors] = React.useState({});
   const validations = {
     name: [],
   };
   const runValidationTasks = async (fieldName, value) => {
     let validationResponse = validateField(value, validations[fieldName]);
-    if (onValidate?.[fieldName]) {
-      validationResponse = await onValidate[fieldName](
-        value,
-        validationResponse
-      );
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
     }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
@@ -296,6 +515,9 @@ export default function CustomWithSectionalElements(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const modelFields = {
+          name,
+        };
         const validationResponses = await Promise.all(
           Object.keys(validations).map((fieldName) =>
             runValidationTasks(fieldName, modelFields[fieldName])
@@ -338,7 +560,7 @@ export default function CustomWithSectionalElements(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"name\\", value);
-              setModelFields({ ...modelFields, name: value });
+              setName(value);
             }}
             errorMessage={errors.name?.errorMessage}
             hasError={errors.name?.hasError}
@@ -410,8 +632,9 @@ export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
 };
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type CustomWithSectionalElementsInputValues = {
-    name: string;
+    name?: ValidationFunction<string>;
 };
 export declare type CustomWithSectionalElementsOverridesProps = {
     CustomWithSectionalElementsGrid?: GridProps;
@@ -429,9 +652,7 @@ export declare type CustomWithSectionalElementsProps = React.PropsWithChildren<{
 } & {
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: {
-        [field in keyof CustomWithSectionalElementsInputValues]?: (value: CustomWithSectionalElementsInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
-    };
+    onValidate?: CustomWithSectionalElementsInputValues;
 }>;
 export default function CustomWithSectionalElements(props: CustomWithSectionalElementsProps): React.ReactElement;
 "
@@ -440,12 +661,9 @@ export default function CustomWithSectionalElements(props: CustomWithSectionalEl
 exports[`amplify form renderer tests datastore form tests should generate a create form 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import {
-  getOverrideProps,
-  useStateMutationAction,
-} from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { Post } from \\"../models\\";
-import { validateField } from \\"./utils\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function MyPostForm(props) {
@@ -457,8 +675,11 @@ export default function MyPostForm(props) {
     overrides,
     ...rest
   } = props;
-  const [modelFields, setModelFields] = useStateMutationAction({});
-  const [errors, setErrors] = useStateMutationAction({});
+  const [caption, setCaption] = React.useState(undefined);
+  const [username, setUsername] = React.useState(undefined);
+  const [post_url, setPost_url] = React.useState(undefined);
+  const [profile_url, setProfile_url] = React.useState(undefined);
+  const [errors, setErrors] = React.useState({});
   const validations = {
     caption: [],
     username: [],
@@ -467,11 +688,9 @@ export default function MyPostForm(props) {
   };
   const runValidationTasks = async (fieldName, value) => {
     let validationResponse = validateField(value, validations[fieldName]);
-    if (onValidate?.[fieldName]) {
-      validationResponse = await onValidate[fieldName](
-        value,
-        validationResponse
-      );
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
     }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
@@ -480,6 +699,12 @@ export default function MyPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const modelFields = {
+          caption,
+          username,
+          post_url,
+          profile_url,
+        };
         const validationResponses = await Promise.all(
           Object.keys(validations).map((fieldName) =>
             runValidationTasks(fieldName, modelFields[fieldName])
@@ -555,7 +780,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"caption\\", value);
-              setModelFields({ ...modelFields, caption: value });
+              setCaption(value);
             }}
             errorMessage={errors.caption?.errorMessage}
             hasError={errors.caption?.hasError}
@@ -575,7 +800,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"username\\", value);
-              setModelFields({ ...modelFields, username: value });
+              setUsername(value);
             }}
             errorMessage={errors.username?.errorMessage}
             hasError={errors.username?.hasError}
@@ -595,7 +820,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"post_url\\", value);
-              setModelFields({ ...modelFields, post_url: value });
+              setPost_url(value);
             }}
             errorMessage={errors.post_url?.errorMessage}
             hasError={errors.post_url?.hasError}
@@ -615,7 +840,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"profile_url\\", value);
-              setModelFields({ ...modelFields, profile_url: value });
+              setProfile_url(value);
             }}
             errorMessage={errors.profile_url?.errorMessage}
             hasError={errors.profile_url?.hasError}
@@ -637,11 +862,12 @@ export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
 };
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type MyPostFormInputValues = {
-    caption: string;
-    username: string;
-    post_url: string;
-    profile_url: string;
+    caption?: ValidationFunction<string>;
+    username?: ValidationFunction<string>;
+    post_url?: ValidationFunction<string>;
+    profile_url?: ValidationFunction<string>;
 };
 export declare type MyPostFormOverridesProps = {
     MyPostFormGrid?: GridProps;
@@ -663,9 +889,7 @@ export declare type MyPostFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: {
-        [field in keyof MyPostFormInputValues]?: (value: MyPostFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
-    };
+    onValidate?: MyPostFormInputValues;
 }>;
 export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
 "
@@ -674,12 +898,9 @@ export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
 exports[`amplify form renderer tests datastore form tests should generate a update form 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import {
-  getOverrideProps,
-  useStateMutationAction,
-} from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { Post } from \\"../models\\";
-import { validateField } from \\"./utils\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Flex,
@@ -699,9 +920,14 @@ export default function MyPostForm(props) {
     overrides,
     ...rest
   } = props;
-  const [modelFields, setModelFields] = useStateMutationAction({});
-  const [errors, setErrors] = useStateMutationAction({});
-  const [postRecord, setPostRecord] = useStateMutationAction(post);
+  const [TextAreaFieldbbd63464, setTextAreaFieldbbd63464] =
+    React.useState(undefined);
+  const [caption, setCaption] = React.useState(undefined);
+  const [username, setUsername] = React.useState(undefined);
+  const [profile_url, setProfile_url] = React.useState(undefined);
+  const [post_url, setPost_url] = React.useState(undefined);
+  const [errors, setErrors] = React.useState({});
+  const [postRecord, setPostRecord] = React.useState(post);
   React.useEffect(() => {
     const queryData = async () => {
       const record = id ? await DataStore.query(Post, id) : post;
@@ -718,11 +944,9 @@ export default function MyPostForm(props) {
   };
   const runValidationTasks = async (fieldName, value) => {
     let validationResponse = validateField(value, validations[fieldName]);
-    if (onValidate?.[fieldName]) {
-      validationResponse = await onValidate[fieldName](
-        value,
-        validationResponse
-      );
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
     }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
@@ -731,6 +955,13 @@ export default function MyPostForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const modelFields = {
+          TextAreaFieldbbd63464,
+          caption,
+          username,
+          profile_url,
+          post_url,
+        };
         const validationResponses = await Promise.all(
           Object.keys(validations).map((fieldName) =>
             runValidationTasks(fieldName, modelFields[fieldName])
@@ -808,7 +1039,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"TextAreaFieldbbd63464\\", value);
-              setModelFields({ ...modelFields, TextAreaFieldbbd63464: value });
+              setTextAreaFieldbbd63464(value);
             }}
             errorMessage={errors.TextAreaFieldbbd63464?.errorMessage}
             hasError={errors.TextAreaFieldbbd63464?.hasError}
@@ -828,7 +1059,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"caption\\", value);
-              setModelFields({ ...modelFields, caption: value });
+              setCaption(value);
             }}
             errorMessage={errors.caption?.errorMessage}
             hasError={errors.caption?.hasError}
@@ -848,7 +1079,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"username\\", value);
-              setModelFields({ ...modelFields, username: value });
+              setUsername(value);
             }}
             errorMessage={errors.username?.errorMessage}
             hasError={errors.username?.hasError}
@@ -868,7 +1099,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"profile_url\\", value);
-              setModelFields({ ...modelFields, profile_url: value });
+              setProfile_url(value);
             }}
             errorMessage={errors.profile_url?.errorMessage}
             hasError={errors.profile_url?.hasError}
@@ -888,7 +1119,7 @@ export default function MyPostForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"post_url\\", value);
-              setModelFields({ ...modelFields, post_url: value });
+              setPost_url(value);
             }}
             errorMessage={errors.post_url?.errorMessage}
             hasError={errors.post_url?.hasError}
@@ -932,19 +1163,20 @@ export default function MyPostForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate a update form 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
 };
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type MyPostFormInputValues = {
-    TextAreaFieldbbd63464: string;
-    caption: string;
-    username: string;
-    profile_url: string;
-    post_url: string;
+    TextAreaFieldbbd63464?: ValidationFunction<string>;
+    caption?: ValidationFunction<string>;
+    username?: ValidationFunction<string>;
+    profile_url?: ValidationFunction<string>;
+    post_url?: ValidationFunction<string>;
 };
 export declare type MyPostFormOverridesProps = {
     MyPostFormGrid?: GridProps;
@@ -970,9 +1202,7 @@ export declare type MyPostFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: {
-        [field in keyof MyPostFormInputValues]?: (value: MyPostFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
-    };
+    onValidate?: MyPostFormInputValues;
 }>;
 export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
 "
@@ -981,12 +1211,9 @@ export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
 exports[`amplify form renderer tests datastore form tests should render a form with multiple date types 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import {
-  getOverrideProps,
-  useStateMutationAction,
-} from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { InputGallery } from \\"../models\\";
-import { validateField } from \\"./utils\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   CheckboxField,
@@ -1007,8 +1234,15 @@ export default function InputGalleryCreateForm(props) {
     overrides,
     ...rest
   } = props;
-  const [modelFields, setModelFields] = useStateMutationAction({});
-  const [errors, setErrors] = useStateMutationAction({});
+  const [num, setNum] = React.useState(undefined);
+  const [rootbeer, setRootbeer] = React.useState(undefined);
+  const [attend, setAttend] = React.useState(undefined);
+  const [maybeSlide, setMaybeSlide] = React.useState(undefined);
+  const [maybeCheck, setMaybeCheck] = React.useState(undefined);
+  const [timestamp, setTimestamp] = React.useState(undefined);
+  const [ippy, setIppy] = React.useState(undefined);
+  const [timeisnow, setTimeisnow] = React.useState(undefined);
+  const [errors, setErrors] = React.useState({});
   const validations = {
     num: [],
     rootbeer: [],
@@ -1021,11 +1255,9 @@ export default function InputGalleryCreateForm(props) {
   };
   const runValidationTasks = async (fieldName, value) => {
     let validationResponse = validateField(value, validations[fieldName]);
-    if (onValidate?.[fieldName]) {
-      validationResponse = await onValidate[fieldName](
-        value,
-        validationResponse
-      );
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
     }
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
@@ -1034,6 +1266,16 @@ export default function InputGalleryCreateForm(props) {
     <form
       onSubmit={async (event) => {
         event.preventDefault();
+        const modelFields = {
+          num,
+          rootbeer,
+          attend,
+          maybeSlide,
+          maybeCheck,
+          timestamp,
+          ippy,
+          timeisnow,
+        };
         const validationResponses = await Promise.all(
           Object.keys(validations).map((fieldName) =>
             runValidationTasks(fieldName, modelFields[fieldName])
@@ -1082,7 +1324,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const value = parseInt(e.target.value);
               await runValidationTasks(\\"num\\", value);
-              setModelFields({ ...modelFields, num: value });
+              setNum(value);
             }}
             errorMessage={errors.num?.errorMessage}
             hasError={errors.num?.hasError}
@@ -1103,7 +1345,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const value = Number(e.target.value);
               await runValidationTasks(\\"rootbeer\\", value);
-              setModelFields({ ...modelFields, rootbeer: value });
+              setRootbeer(value);
             }}
             errorMessage={errors.rootbeer?.errorMessage}
             hasError={errors.rootbeer?.hasError}
@@ -1124,7 +1366,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const value = e.target.value === \\"true\\";
               await runValidationTasks(\\"attend\\", value);
-              setModelFields({ ...modelFields, attend: value });
+              setAttend(value);
             }}
             errorMessage={errors.attend?.errorMessage}
             hasError={errors.attend?.hasError}
@@ -1155,7 +1397,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const value = e.target.checked;
               await runValidationTasks(\\"maybeSlide\\", value);
-              setModelFields({ ...modelFields, maybeSlide: value });
+              setMaybeSlide(value);
             }}
             errorMessage={errors.maybeSlide?.errorMessage}
             hasError={errors.maybeSlide?.hasError}
@@ -1177,7 +1419,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const value = e.target.checked;
               await runValidationTasks(\\"maybeCheck\\", value);
-              setModelFields({ ...modelFields, maybeCheck: value });
+              setMaybeCheck(value);
             }}
             errorMessage={errors.maybeCheck?.errorMessage}
             hasError={errors.maybeCheck?.hasError}
@@ -1198,7 +1440,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const value = Number(new Date(e.target.value));
               await runValidationTasks(\\"timestamp\\", value);
-              setModelFields({ ...modelFields, timestamp: value });
+              setTimestamp(value);
             }}
             errorMessage={errors.timestamp?.errorMessage}
             hasError={errors.timestamp?.hasError}
@@ -1218,7 +1460,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"ippy\\", value);
-              setModelFields({ ...modelFields, ippy: value });
+              setIppy(value);
             }}
             errorMessage={errors.ippy?.errorMessage}
             hasError={errors.ippy?.hasError}
@@ -1239,7 +1481,7 @@ export default function InputGalleryCreateForm(props) {
             onChange={async (e) => {
               const { value } = e.target;
               await runValidationTasks(\\"timeisnow\\", value);
-              setModelFields({ ...modelFields, timeisnow: value });
+              setTimeisnow(value);
             }}
             errorMessage={errors.timeisnow?.errorMessage}
             hasError={errors.timeisnow?.hasError}
@@ -1289,15 +1531,16 @@ export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
 };
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type InputGalleryCreateFormInputValues = {
-    num: number;
-    rootbeer: number;
-    attend: boolean;
-    maybeSlide: boolean;
-    maybeCheck: boolean;
-    timestamp: number;
-    ippy: string;
-    timeisnow: string;
+    num?: ValidationFunction<number>;
+    rootbeer?: ValidationFunction<number>;
+    attend?: ValidationFunction<boolean>;
+    maybeSlide?: ValidationFunction<boolean>;
+    maybeCheck?: ValidationFunction<boolean>;
+    timestamp?: ValidationFunction<number>;
+    ippy?: ValidationFunction<string>;
+    timeisnow?: ValidationFunction<string>;
 };
 export declare type InputGalleryCreateFormOverridesProps = {
     InputGalleryCreateFormGrid?: GridProps;
@@ -1327,9 +1570,7 @@ export declare type InputGalleryCreateFormProps = React.PropsWithChildren<{
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: {
-        [field in keyof InputGalleryCreateFormInputValues]?: (value: InputGalleryCreateFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
-    };
+    onValidate?: InputGalleryCreateFormInputValues;
 }>;
 export default function InputGalleryCreateForm(props: InputGalleryCreateFormProps): React.ReactElement;
 "

--- a/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
+++ b/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
@@ -22,15 +22,15 @@ import {
   StudioForm,
   StudioView,
 } from '@aws-amplify/codegen-ui';
-import { createPrinter, createSourceFile, EmitHint } from 'typescript';
+import { createPrinter, createSourceFile, EmitHint, NewLineKind, Node } from 'typescript';
 import { AmplifyFormRenderer } from '../../amplify-ui-renderers/amplify-form-renderer';
 import { AmplifyRenderer } from '../../amplify-ui-renderers/amplify-renderer';
 import { AmplifyViewRenderer } from '../../amplify-ui-renderers/amplify-view-renderer';
 import { ModuleKind, ReactRenderConfig, ScriptKind, ScriptTarget } from '../../react-render-config';
 import { loadSchemaFromJSONFile } from './example-schema';
-import { transpile } from '../../react-studio-template-renderer-helper';
+import { defaultRenderConfig, transpile } from '../../react-studio-template-renderer-helper';
 
-export const defaultCLIRenderConfig: ReactRenderConfig = {
+export const defaultCLIRenderConfig = {
   module: ModuleKind.ES2020,
   target: ScriptTarget.ES2020,
   script: ScriptKind.JSX,
@@ -103,4 +103,18 @@ export const renderTableJsxElement = (
   const tableNode = printer.printNode(EmitHint.Unspecified, tableJsx, file);
 
   return transpile(tableNode, {}).componentText;
+};
+
+export const genericPrinter = (node: Node): string => {
+  const file = createSourceFile(
+    'sampleFileName.js',
+    '',
+    defaultCLIRenderConfig.target,
+    false,
+    defaultRenderConfig.script,
+  );
+  const printer = createPrinter({
+    newLine: NewLineKind.LineFeed,
+  });
+  return printer.printNode(EmitHint.Unspecified, node, file);
 };

--- a/packages/codegen-ui-react/lib/__tests__/forms/__snapshots__/form-state.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/forms/__snapshots__/form-state.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`nested state should generate state structure for nested keyPath 1`] = `"{ ...bio, favoriteAnimal: { ...bio?.favoriteAnimal, animalMeta: { ...bio?.favoriteAnimal?.animalMeta, family: { ...bio?.favoriteAnimal?.animalMeta?.family, genus: value } } } }"`;
+
+exports[`nested state should generate value for 2nd level deep object 1`] = `"{ ...bio, firstName: \\"John C\\" }"`;
+
+exports[`set field state should generate state call for nested object 1`] = `"setBio({ ...bio, favoriteAnimal: { ...bio?.favoriteAnimal, animalMeta: { ...bio?.favoriteAnimal?.animalMeta, family: { ...bio?.favoriteAnimal?.animalMeta?.family, genus: \\"hello World\\" } } } })"`;
+
+exports[`set field state should generate state call for non-nested objects 1`] = `"setFirstName(\\"john c\\")"`;

--- a/packages/codegen-ui-react/lib/__tests__/forms/__snapshots__/type-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/forms/__snapshots__/type-helper.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should generate nested object should generate type for nested object 1`] = `
+"export declare type myCreateFormInputValues = {
+    firstName?: ValidationFunction<string>;
+    isExplorer?: ValidationFunction<boolean>;
+    bio?: {
+        favoriteAnimal?: {
+            animalMeta?: {
+                family?: {
+                    genus?: ValidationFunction<string>;
+                };
+                earliestRecord?: ValidationFunction<number>;
+            };
+        };
+    };
+};"
+`;
+
+exports[`should generate nested object should generate type for non nested object 1`] = `
+"export declare type myCreateFormInputValues = {
+    firstName?: ValidationFunction<string>;
+    isExplorer?: ValidationFunction<boolean>;
+};"
+`;

--- a/packages/codegen-ui-react/lib/__tests__/forms/form-state.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/forms/form-state.test.ts
@@ -1,0 +1,59 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { factory } from 'typescript';
+import { buildNestedStateSet, setFieldState } from '../../forms/form-state';
+import { genericPrinter } from '../__utils__';
+
+describe('nested state', () => {
+  it('should generate state structure for nested keyPath', () => {
+    const state = buildNestedStateSet(
+      ['bio', 'favoriteAnimal', 'animalMeta', 'family', 'genus'],
+      ['bio'],
+      factory.createIdentifier('value'),
+    );
+    const response = genericPrinter(state);
+    expect(response).toMatchSnapshot();
+  });
+
+  it('should generate value for 2nd level deep object', () => {
+    const state = buildNestedStateSet(['bio', 'firstName'], ['bio'], factory.createStringLiteral('John C'));
+    const response = genericPrinter(state);
+    expect(response).toMatchSnapshot();
+  });
+
+  it('should throw error for 1 level deep path', () => {
+    expect(() => buildNestedStateSet(['firstName'], ['firstName'], factory.createStringLiteral('John C'))).toThrowError(
+      'keyPath needs a length larger than 1 to build nested state object',
+    );
+  });
+});
+
+describe('set field state', () => {
+  it('should generate state call for nested object', () => {
+    const fieldStateSetter = setFieldState(
+      'bio.favoriteAnimal.animalMeta.family.genus',
+      factory.createStringLiteral('hello World'),
+    );
+    const response = genericPrinter(fieldStateSetter);
+    expect(response).toMatchSnapshot();
+  });
+
+  it('should generate state call for non-nested objects', () => {
+    const fieldStateSetter = setFieldState('firstName', factory.createStringLiteral('john c'));
+    const response = genericPrinter(fieldStateSetter);
+    expect(response).toMatchSnapshot();
+  });
+});

--- a/packages/codegen-ui-react/lib/__tests__/forms/type-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/forms/type-helper.test.ts
@@ -1,0 +1,61 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { FieldConfigMetadata } from '@aws-amplify/codegen-ui';
+import { generateOnValidationType } from '../../forms/type-helper';
+import { genericPrinter } from '../__utils__';
+
+describe('should generate nested object', () => {
+  it('should generate type for nested object', () => {
+    const fieldConfigs: Record<string, FieldConfigMetadata> = {
+      'bio.favoriteAnimal.animalMeta.family.genus': {
+        dataType: 'String',
+        validationRules: [],
+      },
+      'bio.favoriteAnimal.animalMeta.earliestRecord': {
+        dataType: 'AWSTimestamp',
+        validationRules: [],
+      },
+      firstName: {
+        dataType: 'String',
+        validationRules: [],
+      },
+      isExplorer: {
+        dataType: 'Boolean',
+        validationRules: [],
+      },
+    };
+    const types = generateOnValidationType('myCreateForm', fieldConfigs);
+    const response = genericPrinter(types);
+    expect(response).toMatchSnapshot();
+  });
+
+  it('should generate type for non nested object', () => {
+    const fieldConfigs: Record<string, FieldConfigMetadata> = {
+      firstName: {
+        dataType: 'String',
+        validationRules: [],
+      },
+      isExplorer: {
+        dataType: 'Boolean',
+        validationRules: [],
+      },
+    };
+    const types = generateOnValidationType('myCreateForm', fieldConfigs);
+    const response = genericPrinter(types);
+    expect(response).toMatchSnapshot();
+  });
+});

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -8,9 +8,7 @@ exports[`form-render utils should generate before & complete types if datastore 
         errorMessage?: string;
     }) => void;
     onCancel?: () => void;
-    onValidate?: {
-        [field in keyof mySampleFormInputValues]?: (value: mySampleFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
-    };
+    onValidate?: mySampleFormInputValues;
 }"
 `;
 
@@ -18,8 +16,6 @@ exports[`form-render utils should generate regular onsubmit if dataSourceType is
 "{
     onSubmit: (fields: Record<string, string>) => void;
     onCancel?: () => void;
-    onValidate?: {
-        [field in keyof myCustomFormInputValues]?: (value: myCustomFormInputValues[field], validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
-    };
+    onValidate?: myCustomFormInputValues;
 }"
 `;

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -64,5 +64,11 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });
+
+    it('should render nested json fields', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer('forms/bio-nested-create', undefined);
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
   });
 });

--- a/packages/codegen-ui-react/lib/__tests__/utils/fetch-by-path.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/utils/fetch-by-path.test.ts
@@ -1,0 +1,39 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { fetchByPath } from '../../utils/json-path-fetch';
+
+describe('fetch by path util', () => {
+  const nestedObj = {
+    levelOne: {
+      levelTwo: {
+        levelThree: {
+          bingo: (value: string) => `Winner Winner ${value}!`,
+        },
+      },
+    },
+  };
+  it('should fetch value from nested object', () => {
+    const fn: Function = fetchByPath(nestedObj, 'levelOne.levelTwo.levelThree.bingo');
+    const result = fn('helloWorld');
+    expect(result).toEqual('Winner Winner helloWorld!');
+  });
+
+  it('should return undefined if value does not exist in nested object', () => {
+    const result = fetchByPath(nestedObj, 'levelOne.levelTwo.nonExistentLevel');
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -27,7 +27,7 @@ import { buildOpeningElementProperties } from '../react-component-render-helper'
 import { ImportCollection } from '../imports';
 import { getActionIdentifier } from '../workflow';
 import { buildDataStoreExpression } from '../forms';
-import { onSubmitValidationRun } from '../forms/form-renderer-helper';
+import { onSubmitValidationRun, buildModelFieldObject } from '../forms/form-renderer-helper';
 
 export default class FormRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -190,6 +190,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
   }
 
   private getFormOnSubmitAttribute(): JsxAttribute {
+    const { formMetadata } = this.componentMetadata;
     return factory.createJsxAttribute(
       factory.createIdentifier('onSubmit'),
       factory.createJsxExpression(
@@ -222,6 +223,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                   [],
                 ),
               ),
+              buildModelFieldObject(formMetadata?.fieldConfigs),
               ...onSubmitValidationRun,
               ...this.getOnSubmitDSCall(),
             ],

--- a/packages/codegen-ui-react/lib/forms/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-state.ts
@@ -1,0 +1,174 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { FieldConfigMetadata, DataFieldDataType } from '@aws-amplify/codegen-ui';
+import {
+  factory,
+  Statement,
+  Expression,
+  NodeFlags,
+  Identifier,
+  SyntaxKind,
+  ObjectLiteralExpression,
+  CallExpression,
+} from 'typescript';
+
+export const capitalizeFirstLetter = (val: string) => {
+  return val.charAt(0).toUpperCase() + val.slice(1);
+};
+
+export const getSetNameIdentifier = (value: string): Identifier => {
+  return factory.createIdentifier(`set${capitalizeFirstLetter(value)}`);
+};
+
+export const getDefaultValueExpression = (name: string, dataType?: DataFieldDataType): Expression => {
+  // it's a nonModel or relationship object
+  if (dataType && typeof dataType === 'object' && !('enum' in dataType)) {
+    return factory.createObjectLiteralExpression();
+  }
+  // the name itself is a nested json object
+  if (name.split('.').length > 1) {
+    return factory.createObjectLiteralExpression();
+  }
+  return factory.createIdentifier('undefined');
+};
+
+/**
+ * iterates field configs to create useState hooks for each field
+ * populates the default values as undefined if it as a nested object, relationship model or nonModel
+ * the default is an empty object
+ * @param fieldConfigs
+ * @returns
+ */
+export const getUseStateHooks = (fieldConfigs: Record<string, FieldConfigMetadata>): Statement[] => {
+  const stateNames = new Set<string>();
+  return Object.entries(fieldConfigs).reduce<Statement[]>((acc, [name, { dataType }]) => {
+    const stateName = name.split('.')[0];
+    if (!stateNames.has(stateName)) {
+      acc.push(buildUseStateExpression(stateName, getDefaultValueExpression(name, dataType)));
+      stateNames.add(stateName);
+    }
+    return acc;
+  }, []);
+};
+
+/**
+ * const [name, setName] = React.useState({default_expression});
+ *
+ * name is the value we are looking to set
+ * defaultValue is is the value to set for the useState
+ * @param name
+ * @param defaultValue
+ * @returns
+ */
+export const buildUseStateExpression = (name: string, defaultValue: Expression): Statement => {
+  return factory.createVariableStatement(
+    undefined,
+    factory.createVariableDeclarationList(
+      [
+        factory.createVariableDeclaration(
+          factory.createArrayBindingPattern([
+            factory.createBindingElement(undefined, undefined, factory.createIdentifier(name), undefined),
+            factory.createBindingElement(undefined, undefined, getSetNameIdentifier(name), undefined),
+          ]),
+          undefined,
+          undefined,
+          factory.createCallExpression(
+            factory.createPropertyAccessExpression(
+              factory.createIdentifier('React'),
+              factory.createIdentifier('useState'),
+            ),
+            undefined,
+            [defaultValue],
+          ),
+        ),
+      ],
+      NodeFlags.Const,
+    ),
+  );
+};
+
+/**
+ * turns ['myNestedObject', 'value', 'nestedValue', 'leaf']
+ *
+ * into myNestedObject?.value?.nestedValue?.leaf
+ *
+ * @param values
+ * @returns
+ */
+export const buildAccessChain = (values: string[]): Expression => {
+  if (values.length < 0) {
+    throw new Error('Need at least one value in the values array');
+  }
+  if (values.length > 1) {
+    const [parent, child, ...rest] = values;
+    let propChain = factory.createPropertyAccessChain(
+      factory.createIdentifier(parent),
+      factory.createToken(SyntaxKind.QuestionDotToken),
+      factory.createIdentifier(child),
+    );
+    if (rest.length) {
+      rest.forEach((value) => {
+        propChain = factory.createPropertyAccessChain(
+          propChain,
+          factory.createToken(SyntaxKind.QuestionDotToken),
+          factory.createIdentifier(value),
+        );
+      });
+    }
+    return propChain;
+  }
+  return factory.createIdentifier(values[0]);
+};
+
+export const buildNestedStateSet = (
+  keyPath: string[],
+  currentKeyPath: string[],
+  value: Expression,
+  index = 1,
+): ObjectLiteralExpression => {
+  if (keyPath.length <= 1) {
+    throw new Error('keyPath needs a length larger than 1 to build nested state object');
+  }
+  const currentKey = keyPath[index];
+  // the value of the index is what decides if we have reached the leaf property of the nested object
+  if (keyPath.length - 1 === index) {
+    return factory.createObjectLiteralExpression([
+      factory.createSpreadAssignment(buildAccessChain(currentKeyPath)),
+      factory.createPropertyAssignment(factory.createIdentifier(currentKey), value),
+    ]);
+  }
+  const currentSpreadAssignment = buildAccessChain(currentKeyPath);
+  currentKeyPath.push(currentKey);
+  return factory.createObjectLiteralExpression([
+    factory.createSpreadAssignment(currentSpreadAssignment),
+    factory.createPropertyAssignment(
+      factory.createIdentifier(currentKey),
+      buildNestedStateSet(keyPath, currentKeyPath, value, index + 1),
+    ),
+  ]);
+};
+
+// updating state
+export const setFieldState = (name: string, value: Expression): CallExpression => {
+  if (name.split('.').length > 1) {
+    const keyPath = name.split('.');
+    return factory.createCallExpression(getSetNameIdentifier(keyPath[0]), undefined, [
+      buildNestedStateSet(keyPath, [keyPath[0]], value),
+    ]);
+  }
+  return factory.createCallExpression(getSetNameIdentifier(name), undefined, [value]);
+};

--- a/packages/codegen-ui-react/lib/forms/type-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/type-helper.ts
@@ -1,0 +1,215 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { FieldConfigMetadata, DataFieldDataType } from '@aws-amplify/codegen-ui';
+import { factory, SyntaxKind, KeywordTypeSyntaxKind, TypeElement, PropertySignature, TypeNode } from 'typescript';
+import { DATA_TYPE_TO_TYPESCRIPT_MAP } from './typescript-type-map';
+
+type Node<T> = {
+  [n: string]: T | Node<T>;
+};
+/**
+ * based on the provided dataType (appsync scalar)
+ * converst to the correct typescript type
+ * default assumption is string type
+ *
+ * @param dataType
+ * @returns
+ */
+const getSyntaxKindType = (dataType?: DataFieldDataType) => {
+  let typescriptType = SyntaxKind.StringKeyword;
+  if (dataType && typeof dataType === 'string' && dataType in DATA_TYPE_TO_TYPESCRIPT_MAP) {
+    typescriptType = DATA_TYPE_TO_TYPESCRIPT_MAP[dataType];
+  }
+  return typescriptType;
+};
+
+const getInputValuesTypeName = (formName: string): string => {
+  return `${formName}InputValues`;
+};
+
+/**
+ * given the nested json paths rejoin them into one object
+ * where the leafs are the types ex. string | number | boolean
+ * src: https://stackoverflow.com/questions/70218560/creating-a-nested-object-from-entries
+ *
+ * @param nestedPaths
+ */
+export const generateObjectFromPaths = (
+  object: Node<KeywordTypeSyntaxKind>,
+  [key, value]: [fieldName: string, dataType?: DataFieldDataType],
+) => {
+  const keys = key.split('.');
+  const last = keys.pop() ?? '';
+  // eslint-disable-next-line no-return-assign, no-param-reassign
+  keys.reduce((o: any, k: string) => (o[k] ??= {}), object)[last] = getSyntaxKindType(value);
+  return object;
+};
+
+export const generateTypeNodeFromObject = (obj: Node<KeywordTypeSyntaxKind>): PropertySignature[] => {
+  return Object.keys(obj).map<PropertySignature>((key) => {
+    const child = obj[key];
+    const value: TypeNode =
+      typeof child === 'object' && Object.keys(obj[key]).length
+        ? factory.createTypeLiteralNode(generateTypeNodeFromObject(child))
+        : factory.createTypeReferenceNode(factory.createIdentifier('ValidationFunction'), [
+            factory.createKeywordTypeNode(child as KeywordTypeSyntaxKind),
+          ]);
+    return factory.createPropertySignature(
+      undefined,
+      factory.createIdentifier(key),
+      factory.createToken(SyntaxKind.QuestionToken),
+      value,
+    );
+  });
+};
+
+/**
+ * 
+ * export declare type MyPostCreateFormInputValues = {
+    caption: ValidationFunction<string>;
+    username: ValidationFunction<string>;
+    post_url: ValidationFunction<string>;
+    profile_url: ValidationFunction<string>;
+    status: ValidationFunction<string>;
+    bio: {
+        favoriteQuote: ValidationFunction<string>;
+        favoiteAnimal: {
+            genus: ValidationFunction<string>;
+            }
+        };
+    };
+ *
+ *
+ * @param formName
+ * @param fieldConfigs
+ * @returns
+ */
+export const generateOnValidationType = (formName: string, fieldConfigs: Record<string, FieldConfigMetadata>) => {
+  const nestedPaths: [fieldName: string, dataType?: DataFieldDataType][] = [];
+  const typeNodes: TypeElement[] = [];
+  Object.entries(fieldConfigs).forEach(([fieldName, { dataType }]) => {
+    const hasNestedFieldPath = fieldName.split('.').length > 1;
+    if (hasNestedFieldPath) {
+      nestedPaths.push([fieldName, dataType]);
+    } else {
+      typeNodes.push(
+        factory.createPropertySignature(
+          undefined,
+          factory.createIdentifier(fieldName),
+          factory.createToken(SyntaxKind.QuestionToken),
+          factory.createTypeReferenceNode(factory.createIdentifier('ValidationFunction'), [
+            factory.createKeywordTypeNode(getSyntaxKindType(dataType)),
+          ]),
+        ),
+      );
+    }
+  });
+
+  if (nestedPaths.length) {
+    const nestedObj = nestedPaths.reduce(generateObjectFromPaths, {});
+    const nestedTypeNodes = generateTypeNodeFromObject(nestedObj);
+    typeNodes.push(...nestedTypeNodes);
+  }
+  return factory.createTypeAliasDeclaration(
+    undefined,
+    [factory.createModifier(SyntaxKind.ExportKeyword), factory.createModifier(SyntaxKind.DeclareKeyword)],
+    factory.createIdentifier(getInputValuesTypeName(formName)),
+    undefined,
+    factory.createTypeLiteralNode(typeNodes),
+  );
+};
+
+/**
+ * export declare type ValidationResponse = {
+ *  hasError: boolean;
+ *  errorMessage?: string;
+ * };
+ */
+export const validationResponseType = factory.createTypeAliasDeclaration(
+  undefined,
+  [factory.createModifier(SyntaxKind.ExportKeyword), factory.createModifier(SyntaxKind.DeclareKeyword)],
+  factory.createIdentifier('ValidationResponse'),
+  undefined,
+  factory.createTypeLiteralNode([
+    factory.createPropertySignature(
+      undefined,
+      factory.createIdentifier('hasError'),
+      undefined,
+      factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword),
+    ),
+    factory.createPropertySignature(
+      undefined,
+      factory.createIdentifier('errorMessage'),
+      factory.createToken(SyntaxKind.QuestionToken),
+      factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+    ),
+  ]),
+);
+
+/**
+ * onValidate?: {formTypeName}
+ *
+ * @param formName
+ * @returns
+ */
+export const buildOnValidateType = (formName: string) => {
+  return factory.createPropertySignature(
+    undefined,
+    factory.createIdentifier('onValidate'),
+    factory.createToken(SyntaxKind.QuestionToken),
+    factory.createTypeReferenceNode(factory.createIdentifier(getInputValuesTypeName(formName)), undefined),
+  );
+};
+
+/**
+ * export declare type ValidationFunction<T> =
+ *  (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+ */
+export const validationFunctionType = factory.createTypeAliasDeclaration(
+  undefined,
+  [factory.createModifier(SyntaxKind.ExportKeyword), factory.createModifier(SyntaxKind.DeclareKeyword)],
+  factory.createIdentifier('ValidationFunction'),
+  [factory.createTypeParameterDeclaration(factory.createIdentifier('T'), undefined, undefined)],
+  factory.createFunctionTypeNode(
+    undefined,
+    [
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        undefined,
+        factory.createIdentifier('value'),
+        undefined,
+        factory.createTypeReferenceNode(factory.createIdentifier('T'), undefined),
+        undefined,
+      ),
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        undefined,
+        factory.createIdentifier('validationResponse'),
+        undefined,
+        factory.createTypeReferenceNode(factory.createIdentifier('ValidationResponse'), undefined),
+        undefined,
+      ),
+    ],
+    factory.createUnionTypeNode([
+      factory.createTypeReferenceNode(factory.createIdentifier('ValidationResponse'), undefined),
+      factory.createTypeReferenceNode(factory.createIdentifier('Promise'), [
+        factory.createTypeReferenceNode(factory.createIdentifier('ValidationResponse'), undefined),
+      ]),
+    ]),
+  ),
+);

--- a/packages/codegen-ui-react/lib/imports/import-mapping.ts
+++ b/packages/codegen-ui-react/lib/imports/import-mapping.ts
@@ -46,6 +46,7 @@ export enum ImportValue {
   VALIDATE_FIELD = 'validateField',
   VALIDATE_FIELD_CODEGEN = 'validateField',
   FORMATTER = 'formatter',
+  FETCH_BY_PATH = 'fetchByPath',
 }
 
 export const ImportMapping: Record<ImportValue, ImportSource> = {
@@ -70,4 +71,5 @@ export const ImportMapping: Record<ImportValue, ImportSource> = {
   [ImportValue.USE_EFFECT]: ImportSource.REACT,
   [ImportValue.FORMATTER]: ImportSource.UTILS,
   [ImportValue.VALIDATE_FIELD]: ImportSource.UTILS,
+  [ImportValue.FETCH_BY_PATH]: ImportSource.UTILS,
 };

--- a/packages/codegen-ui-react/lib/index.ts
+++ b/packages/codegen-ui-react/lib/index.ts
@@ -29,3 +29,4 @@ export * from './react-index-studio-template-renderer';
 export * from './react-utils-studio-template-renderer';
 export * from './react-required-dependency-provider';
 export * from './utils/forms/validation';
+export { fetchByPath } from './utils/json-path-fetch';

--- a/packages/codegen-ui-react/lib/react-component-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-renderer.ts
@@ -129,7 +129,7 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
     ];
 
     if (this.componentMetadata.formMetadata) {
-      attributes.push(...addFormAttributes(this.component, this.componentMetadata));
+      attributes.push(...addFormAttributes(this.component, this.componentMetadata.formMetadata));
     }
 
     this.addPropsSpreadAttributes(attributes);

--- a/packages/codegen-ui-react/lib/react-utils-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-utils-studio-template-renderer.ts
@@ -22,9 +22,10 @@ import { ReactOutputManager } from './react-output-manager';
 import { RequiredKeys } from './utils/type-utils';
 import { transpile, buildPrinter, defaultRenderConfig } from './react-studio-template-renderer-helper';
 import { generateValidationFunction } from './utils/forms/validation';
+import { getFetchByPathNodeFunction } from './utils/json-path-fetch';
 import { generateFormatUtil } from './utils/string-formatter';
 
-export type UtilTemplateType = 'validation' | 'formatter';
+export type UtilTemplateType = 'validation' | 'formatter' | 'fetchByPath';
 
 export class ReactUtilsStudioTemplateRenderer extends StudioTemplateRenderer<
   string,
@@ -66,6 +67,8 @@ export class ReactUtilsStudioTemplateRenderer extends StudioTemplateRenderer<
         utilsStatements.push(...generateValidationFunction());
       } else if (util === 'formatter') {
         utilsStatements.push(...generateFormatUtil());
+      } else if (util === 'fetchByPath') {
+        utilsStatements.push(getFetchByPathNodeFunction());
       }
     });
 

--- a/packages/codegen-ui-react/lib/utils/json-path-fetch.ts
+++ b/packages/codegen-ui-react/lib/utils/json-path-fetch.ts
@@ -1,0 +1,232 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { factory, NodeFlags, SyntaxKind, VariableStatement } from 'typescript';
+
+/**
+ * does not support array types within objects as it's currently not supported
+ *
+ * ref: https://stackoverflow.com/questions/45942118/lodash-return-array-of-values-if-the-path-is-valid
+ *
+ * @param input object input
+ * @param path dot notation path for the provided input
+ * @param accumlator array
+ * @returns returns value at the end of object
+ */
+export const fetchByPath = <T extends Record<string, any>>(input: T, path: string, accumlator: any[] = []) => {
+  const currentPath = path.split('.');
+  const head = currentPath.shift();
+  if (input && head && input[head] !== undefined) {
+    if (!currentPath.length) {
+      accumlator.push(input[head]);
+    } else {
+      fetchByPath(input[head], currentPath.join('.'), accumlator);
+    }
+  }
+  return accumlator[0];
+};
+
+/**
+ * get the generated output of the fetchByPath function in TS AST
+ *
+ * @returns VariableStatement
+ */
+export const getFetchByPathNodeFunction = (): VariableStatement => {
+  return factory.createVariableStatement(
+    [factory.createModifier(SyntaxKind.ExportKeyword)],
+    factory.createVariableDeclarationList(
+      [
+        factory.createVariableDeclaration(
+          factory.createIdentifier('fetchByPath'),
+          undefined,
+          undefined,
+          factory.createArrowFunction(
+            undefined,
+            [
+              factory.createTypeParameterDeclaration(
+                factory.createIdentifier('T'),
+                factory.createTypeReferenceNode(factory.createIdentifier('Record'), [
+                  factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+                  factory.createKeywordTypeNode(SyntaxKind.AnyKeyword),
+                ]),
+                undefined,
+              ),
+            ],
+            [
+              factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                factory.createIdentifier('input'),
+                undefined,
+                factory.createTypeReferenceNode(factory.createIdentifier('T'), undefined),
+                undefined,
+              ),
+              factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                factory.createIdentifier('path'),
+                undefined,
+                undefined,
+                factory.createStringLiteral(''),
+              ),
+              factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                factory.createIdentifier('accumlator'),
+                undefined,
+                factory.createArrayTypeNode(factory.createKeywordTypeNode(SyntaxKind.AnyKeyword)),
+                factory.createArrayLiteralExpression([], false),
+              ),
+            ],
+            undefined,
+            factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+            factory.createBlock(
+              [
+                factory.createVariableStatement(
+                  undefined,
+                  factory.createVariableDeclarationList(
+                    [
+                      factory.createVariableDeclaration(
+                        factory.createIdentifier('currentPath'),
+                        undefined,
+                        undefined,
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('path'),
+                            factory.createIdentifier('split'),
+                          ),
+                          undefined,
+                          [factory.createStringLiteral('.')],
+                        ),
+                      ),
+                    ],
+                    NodeFlags.Const,
+                  ),
+                ),
+                factory.createVariableStatement(
+                  undefined,
+                  factory.createVariableDeclarationList(
+                    [
+                      factory.createVariableDeclaration(
+                        factory.createIdentifier('head'),
+                        undefined,
+                        undefined,
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('currentPath'),
+                            factory.createIdentifier('shift'),
+                          ),
+                          undefined,
+                          [],
+                        ),
+                      ),
+                    ],
+                    NodeFlags.Const,
+                  ),
+                ),
+                factory.createIfStatement(
+                  factory.createBinaryExpression(
+                    factory.createBinaryExpression(
+                      factory.createIdentifier('input'),
+                      factory.createToken(SyntaxKind.AmpersandAmpersandToken),
+                      factory.createIdentifier('head'),
+                    ),
+                    factory.createToken(SyntaxKind.AmpersandAmpersandToken),
+                    factory.createBinaryExpression(
+                      factory.createElementAccessExpression(
+                        factory.createIdentifier('input'),
+                        factory.createIdentifier('head'),
+                      ),
+                      factory.createToken(SyntaxKind.ExclamationEqualsEqualsToken),
+                      factory.createIdentifier('undefined'),
+                    ),
+                  ),
+                  factory.createBlock(
+                    [
+                      factory.createIfStatement(
+                        factory.createPrefixUnaryExpression(
+                          SyntaxKind.ExclamationToken,
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('currentPath'),
+                            factory.createIdentifier('length'),
+                          ),
+                        ),
+                        factory.createBlock(
+                          [
+                            factory.createExpressionStatement(
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('accumlator'),
+                                  factory.createIdentifier('push'),
+                                ),
+                                undefined,
+                                [
+                                  factory.createElementAccessExpression(
+                                    factory.createIdentifier('input'),
+                                    factory.createIdentifier('head'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                          true,
+                        ),
+                        factory.createBlock(
+                          [
+                            factory.createExpressionStatement(
+                              factory.createCallExpression(factory.createIdentifier('fetchByPath'), undefined, [
+                                factory.createElementAccessExpression(
+                                  factory.createIdentifier('input'),
+                                  factory.createIdentifier('head'),
+                                ),
+                                factory.createCallExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('currentPath'),
+                                    factory.createIdentifier('join'),
+                                  ),
+                                  undefined,
+                                  [factory.createStringLiteral('.')],
+                                ),
+                                factory.createIdentifier('accumlator'),
+                              ]),
+                            ),
+                          ],
+                          true,
+                        ),
+                      ),
+                    ],
+                    true,
+                  ),
+                  undefined,
+                ),
+                factory.createReturnStatement(
+                  factory.createElementAccessExpression(
+                    factory.createIdentifier('accumlator'),
+                    factory.createNumericLiteral('0'),
+                  ),
+                ),
+              ],
+              true,
+            ),
+          ),
+        ),
+      ],
+      NodeFlags.Const,
+    ),
+  );
+};

--- a/packages/codegen-ui/example-schemas/forms/bio-nested-create.json
+++ b/packages/codegen-ui/example-schemas/forms/bio-nested-create.json
@@ -1,0 +1,59 @@
+{
+  "cta" : { },
+  "dataType" : {
+    "dataSourceType" : "Custom",
+    "dataTypeName" : "JSON"
+  },
+  "fields" : {
+    "firstName" : {
+      "inputType" : {
+        "type" : "TextField"
+      },
+      "label" : "firstName",
+      "position" : {
+        "fixed" : "first"
+      }
+    },
+    "lastName" : {
+      "inputType" : {
+        "type" : "TextField"
+      },
+      "label" : "lastName",
+      "position" : {
+        "below" : "firstName"
+      }
+    },
+    "bio.favoriteQuote" : {
+      "inputType" : {
+        "type" : "TextField"
+      },
+      "label" : "favoriteQuote",
+      "position" : {
+        "below" : "bio"
+      }
+    },
+    "bio.favoriteAnimal" : {
+      "inputType" : {
+        "type" : "TextField"
+      },
+      "label" : "favoriteAnimal",
+      "position" : {
+        "below" : "bio.favoriteQuote"
+      }
+    }
+  },
+  "formActionType" : "create",
+  "name" : "NestedJson",
+  "sectionalElements" : {
+    "bio" : {
+      "level" : 3,
+      "position" : {
+        "below" : "lastName"
+      },
+      "text" : "bio",
+      "type" : "Heading"
+    }
+  },
+  "style" : { },
+  "id" : "f-BD6Fl4FX8B6XL7Il9a"
+}

--- a/packages/codegen-ui/lib/types/form/form-metadata.ts
+++ b/packages/codegen-ui/lib/types/form/form-metadata.ts
@@ -17,7 +17,6 @@ import { DataFieldDataType } from '../data';
 import { FieldValidationConfiguration } from './form-validation';
 
 export type FieldConfigMetadata = {
-  hasChange: boolean;
   // ex. name field has a string validation type where the rule is char length > 5
   validationRules: FieldValidationConfiguration[];
   // component field is of type AWSTimestamp will need to map this to date then get time from date

--- a/packages/codegen-ui/lib/utils/form-component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/form-component-metadata.ts
@@ -39,7 +39,6 @@ export const mapFormMetadata = (form: StudioForm, formDefinition: FormDefinition
     fieldConfigs: inputElementEntries.reduce<Record<string, FieldConfigMetadata>>((configs, [name, config]) => {
       const updatedConfigs = configs;
       const metadata: FieldConfigMetadata = {
-        hasChange: true,
         validationRules: [],
         isArray: config.componentType === 'ArrayField',
       };

--- a/packages/test-generator/lib/generators/TestGenerator.ts
+++ b/packages/test-generator/lib/generators/TestGenerator.ts
@@ -20,6 +20,7 @@ import {
   ScriptKind,
   ReactRenderConfig,
   ReactOutputConfig,
+  UtilTemplateType,
 } from '@aws-amplify/codegen-ui-react';
 import log from 'loglevel';
 import * as ComponentSchemas from '../components';
@@ -67,7 +68,7 @@ export abstract class TestGenerator {
 
   generate = (testCases: TestCase[]) => {
     const renderErrors: { [key: string]: any } = {};
-    const utilsFunctions = new Set<string>();
+    const utilsFunctions = new Set<UtilTemplateType>();
 
     const generateComponent = (testCase: TestCase) => {
       const { name, schema } = testCase;
@@ -121,6 +122,7 @@ export abstract class TestGenerator {
           const res = this.writeFormToDisk(schema as StudioForm);
           if (res.formMetadata?.fieldConfigs && Object.keys(res.formMetadata.fieldConfigs).length) {
             utilsFunctions.add('validation');
+            utilsFunctions.add('fetchByPath');
           }
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- onChange behavior changes
    - refactor useMutation to useState
    - each field now has it’s own useState
    - for nested Objects it will use the react docs recommendation for setting nested state docs: [https://beta.reactjs.org/learn/updating-objects-in-state#updating-a-nested-object](https://beta.reactjs.org/learn/updating-objects-in-state#updating-a-nested-object)
- nested json has nested validation object types
- there is a fetch util now that will fetch the validation function from the nested object if it exists
- for everything else needed to support nested json it will refer to using flat paths
    - validation variable
    - error state
    - overrides (tbd to see we can get back to this at a later date)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
