### PR TITLE
fix: test all configured validations for field

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/forms/validation.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/forms/validation.test.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { ValidationTypes } from '@aws-amplify/codegen-ui/lib/types/form/form-validation';
+import { FieldValidationConfiguration, ValidationTypes } from '@aws-amplify/codegen-ui/lib/types/form/form-validation';
 import { validateField } from '../../utils/forms/validation';
 
 describe('validateField tests', () => {
@@ -41,14 +41,13 @@ describe('validateField tests', () => {
     });
     expect(
       validateField('aardvark', [{ type: ValidationTypes.START_WITH, strValues: ['a', 'b'], validationMessage: '' }]),
-    ).toEqual({ hasError: false, errorMessage: 'The value must start with a, b' });
+    ).toEqual({ hasError: false });
   });
   it('should validate END_WITH type', () => {
     expect(
       validateField('abc', [{ type: ValidationTypes.END_WITH, strValues: ['c'], validationMessage: 'test' }]),
     ).toEqual({
       hasError: false,
-      errorMessage: 'test',
     });
     expect(
       validateField('abc', [{ type: ValidationTypes.END_WITH, strValues: ['e', 'f'], validationMessage: '' }]),
@@ -61,12 +60,11 @@ describe('validateField tests', () => {
     expect(validateField('abc', [{ type: ValidationTypes.CONTAINS, strValues: ['a'], validationMessage: '' }])).toEqual(
       {
         hasError: false,
-        errorMessage: 'The value must contain a',
       },
     );
     expect(
       validateField('abcd', [{ type: ValidationTypes.CONTAINS, strValues: ['a', 'e'], validationMessage: '' }]),
-    ).toEqual({ hasError: false, errorMessage: 'The value must contain a, e' });
+    ).toEqual({ hasError: false });
     expect(
       validateField('abc', [{ type: ValidationTypes.CONTAINS, strValues: ['d'], validationMessage: 'test' }]),
     ).toEqual({ hasError: true, errorMessage: 'test' });
@@ -74,7 +72,7 @@ describe('validateField tests', () => {
   it('should validate NOT_CONTAINS type', () => {
     expect(
       validateField('abc', [{ type: ValidationTypes.NOT_CONTAINS, strValues: ['4'], validationMessage: '' }]),
-    ).toEqual({ hasError: false, errorMessage: 'The value must not contain 4' });
+    ).toEqual({ hasError: false });
     expect(
       validateField('abc', [{ type: ValidationTypes.NOT_CONTAINS, strValues: ['d', 'a'], validationMessage: '' }]),
     ).toEqual({ hasError: true, errorMessage: 'The value must not contain d, a' });
@@ -87,7 +85,7 @@ describe('validateField tests', () => {
   it('should validate LESS_THAN_CHAR_LENGTH type', () => {
     expect(
       validateField('123', [{ type: ValidationTypes.LESS_THAN_CHAR_LENGTH, numValues: [4], validationMessage: '' }]),
-    ).toEqual({ hasError: false, errorMessage: 'The value must be shorter than 4' });
+    ).toEqual({ hasError: false });
     expect(
       validateField('', [{ type: ValidationTypes.LESS_THAN_CHAR_LENGTH, numValues: [3], validationMessage: '' }]),
     ).toEqual({ hasError: false });
@@ -98,7 +96,7 @@ describe('validateField tests', () => {
   it('should validate GREATER_THAN_CHAR_LENGTH type', () => {
     expect(
       validateField('123', [{ type: ValidationTypes.GREATER_THAN_CHAR_LENGTH, numValues: [0], validationMessage: '' }]),
-    ).toEqual({ hasError: false, errorMessage: 'The value must be longer than 0' });
+    ).toEqual({ hasError: false });
     expect(
       validateField('', [{ type: ValidationTypes.GREATER_THAN_CHAR_LENGTH, numValues: [3], validationMessage: '' }]),
     ).toEqual({ hasError: false });
@@ -112,7 +110,6 @@ describe('validateField tests', () => {
     expect(validateField(1, [{ type: ValidationTypes.LESS_THAN_NUM, numValues: [10], validationMessage: '' }])).toEqual(
       {
         hasError: false,
-        errorMessage: 'The value must be less than 10',
       },
     );
     expect(validateField(2, [{ type: ValidationTypes.LESS_THAN_NUM, numValues: [1], validationMessage: '' }])).toEqual({
@@ -131,7 +128,6 @@ describe('validateField tests', () => {
       validateField(1, [{ type: ValidationTypes.GREATER_THAN_NUM, numValues: [0], validationMessage: '' }]),
     ).toEqual({
       hasError: false,
-      errorMessage: 'The value must be greater than 0',
     });
     expect(
       validateField(2, [{ type: ValidationTypes.GREATER_THAN_NUM, numValues: [3], validationMessage: '' }]),
@@ -148,7 +144,6 @@ describe('validateField tests', () => {
       validateField(1, [{ type: ValidationTypes.EQUAL_TO_NUM, numValues: [1, 2], validationMessage: '' }]),
     ).toEqual({
       hasError: false,
-      errorMessage: 'The value must be equal to 1 or 2',
     });
     expect(validateField(2, [{ type: ValidationTypes.EQUAL_TO_NUM, numValues: [3], validationMessage: '' }])).toEqual({
       hasError: true,
@@ -164,7 +159,7 @@ describe('validateField tests', () => {
     const endDate2 = new Date('3000-01-09').toDateString();
     expect(
       validateField(startDate, [{ type: ValidationTypes.BE_AFTER, strValues: [endDate1], validationMessage: '' }]),
-    ).toEqual({ hasError: false, errorMessage: `The value must be after ${endDate1}` });
+    ).toEqual({ hasError: false });
     expect(
       validateField(startDate, [{ type: ValidationTypes.BE_AFTER, strValues: [endDate2], validationMessage: '' }]),
     ).toEqual({ hasError: true, errorMessage: `The value must be after ${endDate2}` });
@@ -178,7 +173,7 @@ describe('validateField tests', () => {
       validateField(startTime, [
         { type: ValidationTypes.BE_AFTER, strValues: [endTime1.toString()], validationMessage: '' },
       ]),
-    ).toEqual({ hasError: false, errorMessage: `The value must be after ${endTime1}` });
+    ).toEqual({ hasError: false });
     expect(
       validateField(endTime1, [
         { type: ValidationTypes.BE_AFTER, strValues: [startTime.toString()], validationMessage: '' },
@@ -199,7 +194,7 @@ describe('validateField tests', () => {
       validateField(startDate, [
         { type: ValidationTypes.BE_BEFORE, strValues: [endDate1.toString()], validationMessage: '' },
       ]),
-    ).toEqual({ hasError: false, errorMessage: `The value must be before ${endDate1}` });
+    ).toEqual({ hasError: false });
     expect(
       validateField(startDate, [
         { type: ValidationTypes.BE_BEFORE, strValues: [endDate2.toString()], validationMessage: '' },
@@ -217,7 +212,7 @@ describe('validateField tests', () => {
       validateField(startTime, [
         { type: ValidationTypes.BE_BEFORE, strValues: [endTime1.toString()], validationMessage: '' },
       ]),
-    ).toEqual({ hasError: false, errorMessage: `The value must be before ${endTime1}` });
+    ).toEqual({ hasError: false });
     expect(
       validateField(endTime1, [
         { type: ValidationTypes.BE_BEFORE, strValues: [startTime.toString()], validationMessage: '' },
@@ -232,7 +227,6 @@ describe('validateField tests', () => {
   it('should validate EMAIL type', () => {
     expect(validateField('ab-cd@amazon.com', [{ type: ValidationTypes.EMAIL, validationMessage: '' }])).toEqual({
       hasError: false,
-      errorMessage: 'The value must be a valid email address',
     });
     expect(validateField('@amazon.com', [{ type: ValidationTypes.EMAIL, validationMessage: '' }])).toEqual({
       hasError: true,
@@ -246,11 +240,9 @@ describe('validateField tests', () => {
   it('should validate JSON type', () => {
     expect(validateField('{}', [{ type: ValidationTypes.JSON, validationMessage: '' }])).toEqual({
       hasError: false,
-      errorMessage: 'The value must be in a correct JSON format',
     });
     expect(validateField('{"name": "test"}', [{ type: ValidationTypes.JSON, validationMessage: '' }])).toEqual({
       hasError: false,
-      errorMessage: 'The value must be in a correct JSON format',
     });
     expect(validateField('\\\\', [{ type: ValidationTypes.JSON, validationMessage: 'test' }])).toEqual({
       hasError: true,
@@ -263,13 +255,12 @@ describe('validateField tests', () => {
   it('should validate IP_ADDRESS type', () => {
     expect(validateField('192.168.1.1', [{ type: ValidationTypes.IP_ADDRESS, validationMessage: '' }])).toEqual({
       hasError: false,
-      errorMessage: 'The value must be an IPv4 or IPv6 address',
     });
     expect(
       validateField('2001:0db8:85a3:0000:0000:8a2e:0370:7334', [
         { type: ValidationTypes.IP_ADDRESS, validationMessage: '' },
       ]),
-    ).toEqual({ hasError: false, errorMessage: 'The value must be an IPv4 or IPv6 address' });
+    ).toEqual({ hasError: false });
     expect(validateField('1.1', [{ type: ValidationTypes.IP_ADDRESS, validationMessage: 'test' }])).toEqual({
       hasError: true,
       errorMessage: 'test',
@@ -281,11 +272,9 @@ describe('validateField tests', () => {
   it('should validate URL type', () => {
     expect(validateField('http://amazon.com', [{ type: ValidationTypes.URL, validationMessage: '' }])).toEqual({
       hasError: false,
-      errorMessage: 'The value must be a valid URL that begins with a schema (i.e. http:// or mailto:)',
     });
     expect(validateField('mailto:amazon.com', [{ type: ValidationTypes.URL, validationMessage: '' }])).toEqual({
       hasError: false,
-      errorMessage: 'The value must be a valid URL that begins with a schema (i.e. http:// or mailto:)',
     });
     expect(validateField('.amazon.com', [{ type: ValidationTypes.URL, validationMessage: '' }])).toEqual({
       hasError: true,
@@ -305,22 +294,37 @@ describe('validateField tests', () => {
 
     expect(validateField('2938493029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
       hasError: false,
-      errorMessage: 'test',
     });
 
     expect(validateField('293 849 3029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
       hasError: false,
-      errorMessage: 'test',
     });
 
     expect(validateField('293-849-3029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
       hasError: false,
-      errorMessage: 'test',
     });
 
     expect(validateField('293 849-3029', [{ type: ValidationTypes.PHONE, validationMessage: 'test' }])).toEqual({
       hasError: false,
-      errorMessage: 'test',
+    });
+  });
+
+  it('should test value against all configured validations', () => {
+    const validationList: FieldValidationConfiguration[] = [
+      { type: ValidationTypes.START_WITH, strValues: ['he'], validationMessage: 'startFailed' },
+      { type: ValidationTypes.END_WITH, strValues: ['o'], validationMessage: 'endFailed' },
+    ];
+
+    expect(validateField('hello', validationList)).toEqual({
+      hasError: false,
+    });
+    expect(validateField('hey', validationList)).toEqual({
+      hasError: true,
+      errorMessage: 'endFailed',
+    });
+    expect(validateField('yes', validationList)).toEqual({
+      hasError: true,
+      errorMessage: 'startFailed',
     });
   });
 });

--- a/packages/codegen-ui-react/lib/utils/forms/validation.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/validation.ts
@@ -2,11 +2,14 @@
 import ts, { factory } from 'typescript';
 
 type ValidationResponse = { hasError: boolean; errorMessage?: string };
+type FieldValidationConfiguration = {
+  type: string;
+  strValues?: string[];
+  numValues?: number[];
+  validationMessage?: string;
+};
 
-export const validateField = (
-  value: any,
-  validations: { type: string; strValues?: string[]; numValues?: number[]; validationMessage?: string }[],
-): ValidationResponse => {
+export const validateField = (value: any, validations: FieldValidationConfiguration[]): ValidationResponse => {
   for (const validation of validations) {
     if (value === undefined || value === '') {
       if (validation.type === 'Required') {
@@ -21,126 +24,132 @@ export const validateField = (
       }
     }
 
-    if (validation.numValues?.length) {
-      switch (validation.type) {
-        case 'LessThanChar':
-          return {
-            hasError: !(value.length < validation.numValues[0]),
-            errorMessage: validation.validationMessage || `The value must be shorter than ${validation.numValues[0]}`,
-          };
-        case 'GreaterThanChar':
-          return {
-            hasError: !(value.length > validation.numValues[0]),
-            errorMessage: validation.validationMessage || `The value must be longer than ${validation.numValues[0]}`,
-          };
-        case 'LessThanNum':
-          return {
-            hasError: !(value < validation.numValues[0]),
-            errorMessage: validation.validationMessage || `The value must be less than ${validation.numValues[0]}`,
-          };
-        case 'GreaterThanNum':
-          return {
-            hasError: !(value > validation.numValues[0]),
-            errorMessage: validation.validationMessage || `The value must be greater than ${validation.numValues[0]}`,
-          };
-        case 'EqualTo':
-          return {
-            hasError: !validation.numValues.some((el) => el === value),
-            errorMessage:
-              validation.validationMessage || `The value must be equal to ${validation.numValues.join(' or ')}`,
-          };
-        default:
-      }
-    } else if (validation.strValues?.length) {
-      switch (validation.type) {
-        case 'StartWith':
-          return {
-            hasError: !validation.strValues.some((el: any) => value.startsWith(el)),
-            errorMessage:
-              validation.validationMessage || `The value must start with ${validation.strValues.join(', ')}`,
-          };
-        case 'EndWith':
-          return {
-            hasError: !validation.strValues.some((el: any) => value.endsWith(el)),
-            errorMessage: validation.validationMessage || `The value must end with ${validation.strValues.join(', ')}`,
-          };
-        case 'Contains':
-          return {
-            hasError: !validation.strValues.some((el: any) => value.includes(el)),
-            errorMessage: validation.validationMessage || `The value must contain ${validation.strValues.join(', ')}`,
-          };
-        case 'NotContains':
-          return {
-            hasError: !validation.strValues.every((el: any) => !value.includes(el)),
-            errorMessage:
-              validation.validationMessage || `The value must not contain ${validation.strValues.join(', ')}`,
-          };
-        case 'BeAfter':
-          const afterTimeValue = parseInt(validation.strValues[0]);
-          const afterTimeValidator = Number.isNaN(afterTimeValue) ? validation.strValues[0] : afterTimeValue;
-          return {
-            hasError: !(new Date(value) > new Date(afterTimeValidator)),
-            errorMessage: validation.validationMessage || `The value must be after ${validation.strValues[0]}`,
-          };
-        case 'BeBefore':
-          const beforeTimeValue = parseInt(validation.strValues[0]);
-          const beforeTimevalue = Number.isNaN(beforeTimeValue) ? validation.strValues[0] : beforeTimeValue;
-          return {
-            hasError: !(new Date(value) < new Date(beforeTimevalue)),
-            errorMessage: validation.validationMessage || `The value must be before ${validation.strValues[0]}`,
-          };
-      }
-    }
-    switch (validation.type) {
-      case 'Email':
-        const EMAIL_ADDRESS_REGEX =
-          /^[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
-        return {
-          hasError: !EMAIL_ADDRESS_REGEX.test(value),
-          errorMessage: validation.validationMessage || 'The value must be a valid email address',
-        };
-      case 'JSON':
-        let isInvalidJSON = false;
-        try {
-          JSON.parse(value);
-        } catch (e) {
-          isInvalidJSON = true;
-        }
-        return {
-          hasError: isInvalidJSON,
-          errorMessage: validation.validationMessage || 'The value must be in a correct JSON format',
-        };
-      case 'IpAddress':
-        const IPV_4 = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/;
-        const IPV_6 =
-          /^(?:(?:[a-fA-F\d]{1,4}:){7}(?:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,2}|:)|(?:[a-fA-F\d]{1,4}:){4}(?:(?::[a-fA-F\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,3}|:)|(?:[a-fA-F\d]{1,4}:){3}(?:(?::[a-fA-F\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,4}|:)|(?:[a-fA-F\d]{1,4}:){2}(?:(?::[a-fA-F\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,5}|:)|(?:[a-fA-F\d]{1,4}:){1}(?:(?::[a-fA-F\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,6}|:)|(?::(?:(?::[a-fA-F\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,7}|:)))(?:%[0-9a-zA-Z]{1,})?$/;
-        return {
-          hasError: !(IPV_4.test(value) || IPV_6.test(value)),
-          errorMessage: validation.validationMessage || 'The value must be an IPv4 or IPv6 address',
-        };
-      case 'URL':
-        let isInvalidUrl = false;
-        try {
-          new URL(value);
-        } catch (e) {
-          isInvalidUrl = true;
-        }
-        return {
-          hasError: isInvalidUrl,
-          errorMessage:
-            validation.validationMessage ||
-            'The value must be a valid URL that begins with a schema (i.e. http:// or mailto:)',
-        };
-      case 'Phone':
-        const PHONE = /^\+?\d[\d\s-]+$/;
-        return {
-          hasError: !PHONE.test(value),
-          errorMessage: validation.validationMessage || 'The value must be a valid phone number',
-        };
-      default:
+    const validationResult = checkValidation(value, validation);
+
+    if (validationResult?.hasError) {
+      return validationResult;
     }
   }
   return { hasError: false };
+};
+
+const checkValidation = (value: any, validation: FieldValidationConfiguration) => {
+  if (validation.numValues?.length) {
+    switch (validation.type) {
+      case 'LessThanChar':
+        return {
+          hasError: !(value.length < validation.numValues[0]),
+          errorMessage: validation.validationMessage || `The value must be shorter than ${validation.numValues[0]}`,
+        };
+      case 'GreaterThanChar':
+        return {
+          hasError: !(value.length > validation.numValues[0]),
+          errorMessage: validation.validationMessage || `The value must be longer than ${validation.numValues[0]}`,
+        };
+      case 'LessThanNum':
+        return {
+          hasError: !(value < validation.numValues[0]),
+          errorMessage: validation.validationMessage || `The value must be less than ${validation.numValues[0]}`,
+        };
+      case 'GreaterThanNum':
+        return {
+          hasError: !(value > validation.numValues[0]),
+          errorMessage: validation.validationMessage || `The value must be greater than ${validation.numValues[0]}`,
+        };
+      case 'EqualTo':
+        return {
+          hasError: !validation.numValues.some((el) => el === value),
+          errorMessage:
+            validation.validationMessage || `The value must be equal to ${validation.numValues.join(' or ')}`,
+        };
+      default:
+    }
+  } else if (validation.strValues?.length) {
+    switch (validation.type) {
+      case 'StartWith':
+        return {
+          hasError: !validation.strValues.some((el: any) => value.startsWith(el)),
+          errorMessage: validation.validationMessage || `The value must start with ${validation.strValues.join(', ')}`,
+        };
+      case 'EndWith':
+        return {
+          hasError: !validation.strValues.some((el: any) => value.endsWith(el)),
+          errorMessage: validation.validationMessage || `The value must end with ${validation.strValues.join(', ')}`,
+        };
+      case 'Contains':
+        return {
+          hasError: !validation.strValues.some((el: any) => value.includes(el)),
+          errorMessage: validation.validationMessage || `The value must contain ${validation.strValues.join(', ')}`,
+        };
+      case 'NotContains':
+        return {
+          hasError: !validation.strValues.every((el: any) => !value.includes(el)),
+          errorMessage: validation.validationMessage || `The value must not contain ${validation.strValues.join(', ')}`,
+        };
+      case 'BeAfter':
+        const afterTimeValue = parseInt(validation.strValues[0]);
+        const afterTimeValidator = Number.isNaN(afterTimeValue) ? validation.strValues[0] : afterTimeValue;
+        return {
+          hasError: !(new Date(value) > new Date(afterTimeValidator)),
+          errorMessage: validation.validationMessage || `The value must be after ${validation.strValues[0]}`,
+        };
+      case 'BeBefore':
+        const beforeTimeValue = parseInt(validation.strValues[0]);
+        const beforeTimevalue = Number.isNaN(beforeTimeValue) ? validation.strValues[0] : beforeTimeValue;
+        return {
+          hasError: !(new Date(value) < new Date(beforeTimevalue)),
+          errorMessage: validation.validationMessage || `The value must be before ${validation.strValues[0]}`,
+        };
+    }
+  }
+  switch (validation.type) {
+    case 'Email':
+      const EMAIL_ADDRESS_REGEX =
+        /^[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
+      return {
+        hasError: !EMAIL_ADDRESS_REGEX.test(value),
+        errorMessage: validation.validationMessage || 'The value must be a valid email address',
+      };
+    case 'JSON':
+      let isInvalidJSON = false;
+      try {
+        JSON.parse(value);
+      } catch (e) {
+        isInvalidJSON = true;
+      }
+      return {
+        hasError: isInvalidJSON,
+        errorMessage: validation.validationMessage || 'The value must be in a correct JSON format',
+      };
+    case 'IpAddress':
+      const IPV_4 = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/;
+      const IPV_6 =
+        /^(?:(?:[a-fA-F\d]{1,4}:){7}(?:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,2}|:)|(?:[a-fA-F\d]{1,4}:){4}(?:(?::[a-fA-F\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,3}|:)|(?:[a-fA-F\d]{1,4}:){3}(?:(?::[a-fA-F\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,4}|:)|(?:[a-fA-F\d]{1,4}:){2}(?:(?::[a-fA-F\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,5}|:)|(?:[a-fA-F\d]{1,4}:){1}(?:(?::[a-fA-F\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,6}|:)|(?::(?:(?::[a-fA-F\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,7}|:)))(?:%[0-9a-zA-Z]{1,})?$/;
+      return {
+        hasError: !(IPV_4.test(value) || IPV_6.test(value)),
+        errorMessage: validation.validationMessage || 'The value must be an IPv4 or IPv6 address',
+      };
+    case 'URL':
+      let isInvalidUrl = false;
+      try {
+        new URL(value);
+      } catch (e) {
+        isInvalidUrl = true;
+      }
+      return {
+        hasError: isInvalidUrl,
+        errorMessage:
+          validation.validationMessage ||
+          'The value must be a valid URL that begins with a schema (i.e. http:// or mailto:)',
+      };
+    case 'Phone':
+      const PHONE = /^\+?\d[\d\s-]+$/;
+      return {
+        hasError: !PHONE.test(value),
+        errorMessage: validation.validationMessage || 'The value must be a valid phone number',
+      };
+    default:
+  }
 };
 
 // AST-viewer does not escape backslashes, so it generates the wrong regex
@@ -174,6 +183,38 @@ export const generateValidationFunction = () => {
         ),
       ]),
     ),
+    factory.createTypeAliasDeclaration(
+      undefined,
+      undefined,
+      factory.createIdentifier('FieldValidationConfiguration'),
+      undefined,
+      factory.createTypeLiteralNode([
+        factory.createPropertySignature(
+          undefined,
+          factory.createIdentifier('type'),
+          undefined,
+          factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ),
+        factory.createPropertySignature(
+          undefined,
+          factory.createIdentifier('strValues'),
+          factory.createToken(ts.SyntaxKind.QuestionToken),
+          factory.createArrayTypeNode(factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
+        ),
+        factory.createPropertySignature(
+          undefined,
+          factory.createIdentifier('numValues'),
+          factory.createToken(ts.SyntaxKind.QuestionToken),
+          factory.createArrayTypeNode(factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)),
+        ),
+        factory.createPropertySignature(
+          undefined,
+          factory.createIdentifier('validationMessage'),
+          factory.createToken(ts.SyntaxKind.QuestionToken),
+          factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ),
+      ]),
+    ),
     factory.createVariableStatement(
       [factory.createModifier(ts.SyntaxKind.ExportKeyword)],
       factory.createVariableDeclarationList(
@@ -202,32 +243,10 @@ export const generateValidationFunction = () => {
                   factory.createIdentifier('validations'),
                   undefined,
                   factory.createArrayTypeNode(
-                    factory.createTypeLiteralNode([
-                      factory.createPropertySignature(
-                        undefined,
-                        factory.createIdentifier('type'),
-                        undefined,
-                        factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-                      ),
-                      factory.createPropertySignature(
-                        undefined,
-                        factory.createIdentifier('strValues'),
-                        factory.createToken(ts.SyntaxKind.QuestionToken),
-                        factory.createArrayTypeNode(factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
-                      ),
-                      factory.createPropertySignature(
-                        undefined,
-                        factory.createIdentifier('numValues'),
-                        factory.createToken(ts.SyntaxKind.QuestionToken),
-                        factory.createArrayTypeNode(factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)),
-                      ),
-                      factory.createPropertySignature(
-                        undefined,
-                        factory.createIdentifier('validationMessage'),
-                        factory.createToken(ts.SyntaxKind.QuestionToken),
-                        factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-                      ),
-                    ]),
+                    factory.createTypeReferenceNode(
+                      factory.createIdentifier('FieldValidationConfiguration'),
+                      undefined,
+                    ),
                   ),
                   undefined,
                 ),
@@ -326,1097 +345,107 @@ export const generateValidationFunction = () => {
                           ),
                           undefined,
                         ),
-                        factory.createIfStatement(
-                          factory.createPropertyAccessChain(
-                            factory.createPropertyAccessExpression(
-                              factory.createIdentifier('validation'),
-                              factory.createIdentifier('numValues'),
-                            ),
-                            factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                            factory.createIdentifier('length'),
-                          ),
-                          factory.createBlock(
+                        factory.createVariableStatement(
+                          undefined,
+                          factory.createVariableDeclarationList(
                             [
-                              factory.createSwitchStatement(
-                                factory.createPropertyAccessExpression(
+                              factory.createVariableDeclaration(
+                                factory.createIdentifier('validationResult'),
+                                undefined,
+                                undefined,
+                                factory.createCallExpression(factory.createIdentifier('checkValidation'), undefined, [
+                                  factory.createIdentifier('value'),
                                   factory.createIdentifier('validation'),
-                                  factory.createIdentifier('type'),
-                                ),
-                                factory.createCaseBlock([
-                                  factory.createCaseClause(factory.createStringLiteral('LessThanChar'), [
-                                    factory.createReturnStatement(
-                                      factory.createObjectLiteralExpression(
-                                        [
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('hasError'),
-                                            factory.createPrefixUnaryExpression(
-                                              ts.SyntaxKind.ExclamationToken,
-                                              factory.createParenthesizedExpression(
-                                                factory.createBinaryExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createIdentifier('value'),
-                                                    factory.createIdentifier('length'),
-                                                  ),
-                                                  factory.createToken(ts.SyntaxKind.LessThanToken),
-                                                  factory.createElementAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('numValues'),
-                                                    ),
-                                                    factory.createNumericLiteral('0'),
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('errorMessage'),
-                                            factory.createBinaryExpression(
-                                              factory.createPropertyAccessExpression(
-                                                factory.createIdentifier('validation'),
-                                                factory.createIdentifier('validationMessage'),
-                                              ),
-                                              factory.createToken(ts.SyntaxKind.BarBarToken),
-                                              factory.createTemplateExpression(
-                                                factory.createTemplateHead(
-                                                  'The value must be shorter than ',
-                                                  'The value must be shorter than ',
-                                                ),
-                                                [
-                                                  factory.createTemplateSpan(
-                                                    factory.createElementAccessExpression(
-                                                      factory.createPropertyAccessExpression(
-                                                        factory.createIdentifier('validation'),
-                                                        factory.createIdentifier('numValues'),
-                                                      ),
-                                                      factory.createNumericLiteral('0'),
-                                                    ),
-                                                    factory.createTemplateTail('', ''),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                        true,
-                                      ),
-                                    ),
-                                  ]),
-                                  factory.createCaseClause(factory.createStringLiteral('GreaterThanChar'), [
-                                    factory.createReturnStatement(
-                                      factory.createObjectLiteralExpression(
-                                        [
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('hasError'),
-                                            factory.createPrefixUnaryExpression(
-                                              ts.SyntaxKind.ExclamationToken,
-                                              factory.createParenthesizedExpression(
-                                                factory.createBinaryExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createIdentifier('value'),
-                                                    factory.createIdentifier('length'),
-                                                  ),
-                                                  factory.createToken(ts.SyntaxKind.GreaterThanToken),
-                                                  factory.createElementAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('numValues'),
-                                                    ),
-                                                    factory.createNumericLiteral('0'),
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('errorMessage'),
-                                            factory.createBinaryExpression(
-                                              factory.createPropertyAccessExpression(
-                                                factory.createIdentifier('validation'),
-                                                factory.createIdentifier('validationMessage'),
-                                              ),
-                                              factory.createToken(ts.SyntaxKind.BarBarToken),
-                                              factory.createTemplateExpression(
-                                                factory.createTemplateHead(
-                                                  'The value must be longer than ',
-                                                  'The value must be longer than ',
-                                                ),
-                                                [
-                                                  factory.createTemplateSpan(
-                                                    factory.createElementAccessExpression(
-                                                      factory.createPropertyAccessExpression(
-                                                        factory.createIdentifier('validation'),
-                                                        factory.createIdentifier('numValues'),
-                                                      ),
-                                                      factory.createNumericLiteral('0'),
-                                                    ),
-                                                    factory.createTemplateTail('', ''),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                        true,
-                                      ),
-                                    ),
-                                  ]),
-                                  factory.createCaseClause(factory.createStringLiteral('LessThanNum'), [
-                                    factory.createReturnStatement(
-                                      factory.createObjectLiteralExpression(
-                                        [
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('hasError'),
-                                            factory.createPrefixUnaryExpression(
-                                              ts.SyntaxKind.ExclamationToken,
-                                              factory.createParenthesizedExpression(
-                                                factory.createBinaryExpression(
-                                                  factory.createIdentifier('value'),
-                                                  factory.createToken(ts.SyntaxKind.LessThanToken),
-                                                  factory.createElementAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('numValues'),
-                                                    ),
-                                                    factory.createNumericLiteral('0'),
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('errorMessage'),
-                                            factory.createBinaryExpression(
-                                              factory.createPropertyAccessExpression(
-                                                factory.createIdentifier('validation'),
-                                                factory.createIdentifier('validationMessage'),
-                                              ),
-                                              factory.createToken(ts.SyntaxKind.BarBarToken),
-                                              factory.createTemplateExpression(
-                                                factory.createTemplateHead(
-                                                  'The value must be less than ',
-                                                  'The value must be less than ',
-                                                ),
-                                                [
-                                                  factory.createTemplateSpan(
-                                                    factory.createElementAccessExpression(
-                                                      factory.createPropertyAccessExpression(
-                                                        factory.createIdentifier('validation'),
-                                                        factory.createIdentifier('numValues'),
-                                                      ),
-                                                      factory.createNumericLiteral('0'),
-                                                    ),
-                                                    factory.createTemplateTail('', ''),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                        true,
-                                      ),
-                                    ),
-                                  ]),
-                                  factory.createCaseClause(factory.createStringLiteral('GreaterThanNum'), [
-                                    factory.createReturnStatement(
-                                      factory.createObjectLiteralExpression(
-                                        [
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('hasError'),
-                                            factory.createPrefixUnaryExpression(
-                                              ts.SyntaxKind.ExclamationToken,
-                                              factory.createParenthesizedExpression(
-                                                factory.createBinaryExpression(
-                                                  factory.createIdentifier('value'),
-                                                  factory.createToken(ts.SyntaxKind.GreaterThanToken),
-                                                  factory.createElementAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('numValues'),
-                                                    ),
-                                                    factory.createNumericLiteral('0'),
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('errorMessage'),
-                                            factory.createBinaryExpression(
-                                              factory.createPropertyAccessExpression(
-                                                factory.createIdentifier('validation'),
-                                                factory.createIdentifier('validationMessage'),
-                                              ),
-                                              factory.createToken(ts.SyntaxKind.BarBarToken),
-                                              factory.createTemplateExpression(
-                                                factory.createTemplateHead(
-                                                  'The value must be greater than ',
-                                                  'The value must be greater than ',
-                                                ),
-                                                [
-                                                  factory.createTemplateSpan(
-                                                    factory.createElementAccessExpression(
-                                                      factory.createPropertyAccessExpression(
-                                                        factory.createIdentifier('validation'),
-                                                        factory.createIdentifier('numValues'),
-                                                      ),
-                                                      factory.createNumericLiteral('0'),
-                                                    ),
-                                                    factory.createTemplateTail('', ''),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                        true,
-                                      ),
-                                    ),
-                                  ]),
-                                  factory.createCaseClause(factory.createStringLiteral('EqualTo'), [
-                                    factory.createReturnStatement(
-                                      factory.createObjectLiteralExpression(
-                                        [
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('hasError'),
-                                            factory.createPrefixUnaryExpression(
-                                              ts.SyntaxKind.ExclamationToken,
-                                              factory.createCallExpression(
-                                                factory.createPropertyAccessExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createIdentifier('validation'),
-                                                    factory.createIdentifier('numValues'),
-                                                  ),
-                                                  factory.createIdentifier('some'),
-                                                ),
-                                                undefined,
-                                                [
-                                                  factory.createArrowFunction(
-                                                    undefined,
-                                                    undefined,
-                                                    [
-                                                      factory.createParameterDeclaration(
-                                                        undefined,
-                                                        undefined,
-                                                        undefined,
-                                                        factory.createIdentifier('el'),
-                                                        undefined,
-                                                        undefined,
-                                                        undefined,
-                                                      ),
-                                                    ],
-                                                    undefined,
-                                                    factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                                    factory.createBinaryExpression(
-                                                      factory.createIdentifier('el'),
-                                                      factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
-                                                      factory.createIdentifier('value'),
-                                                    ),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ),
-                                          factory.createPropertyAssignment(
-                                            factory.createIdentifier('errorMessage'),
-                                            factory.createBinaryExpression(
-                                              factory.createPropertyAccessExpression(
-                                                factory.createIdentifier('validation'),
-                                                factory.createIdentifier('validationMessage'),
-                                              ),
-                                              factory.createToken(ts.SyntaxKind.BarBarToken),
-                                              factory.createTemplateExpression(
-                                                factory.createTemplateHead(
-                                                  'The value must be equal to ',
-                                                  'The value must be equal to ',
-                                                ),
-                                                [
-                                                  factory.createTemplateSpan(
-                                                    factory.createCallExpression(
-                                                      factory.createPropertyAccessExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createIdentifier('validation'),
-                                                          factory.createIdentifier('numValues'),
-                                                        ),
-                                                        factory.createIdentifier('join'),
-                                                      ),
-                                                      undefined,
-                                                      [factory.createStringLiteral(' or ')],
-                                                    ),
-                                                    factory.createTemplateTail('', ''),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                        true,
-                                      ),
-                                    ),
-                                  ]),
-                                  factory.createDefaultClause([]),
                                 ]),
                               ),
                             ],
-                            true,
-                          ),
-                          factory.createIfStatement(
-                            factory.createPropertyAccessChain(
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier('validation'),
-                                factory.createIdentifier('strValues'),
-                              ),
-                              factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                              factory.createIdentifier('length'),
-                            ),
-                            factory.createBlock(
-                              [
-                                factory.createSwitchStatement(
-                                  factory.createPropertyAccessExpression(
-                                    factory.createIdentifier('validation'),
-                                    factory.createIdentifier('type'),
-                                  ),
-                                  factory.createCaseBlock([
-                                    factory.createCaseClause(factory.createStringLiteral('StartWith'), [
-                                      factory.createReturnStatement(
-                                        factory.createObjectLiteralExpression(
-                                          [
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('hasError'),
-                                              factory.createPrefixUnaryExpression(
-                                                ts.SyntaxKind.ExclamationToken,
-                                                factory.createCallExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('strValues'),
-                                                    ),
-                                                    factory.createIdentifier('some'),
-                                                  ),
-                                                  undefined,
-                                                  [
-                                                    factory.createArrowFunction(
-                                                      undefined,
-                                                      undefined,
-                                                      [
-                                                        factory.createParameterDeclaration(
-                                                          undefined,
-                                                          undefined,
-                                                          undefined,
-                                                          factory.createIdentifier('el'),
-                                                          undefined,
-                                                          factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-                                                          undefined,
-                                                        ),
-                                                      ],
-                                                      undefined,
-                                                      factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                                      factory.createCallExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createIdentifier('value'),
-                                                          factory.createIdentifier('startsWith'),
-                                                        ),
-                                                        undefined,
-                                                        [factory.createIdentifier('el')],
-                                                      ),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('errorMessage'),
-                                              factory.createBinaryExpression(
-                                                factory.createPropertyAccessExpression(
-                                                  factory.createIdentifier('validation'),
-                                                  factory.createIdentifier('validationMessage'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.BarBarToken),
-                                                factory.createTemplateExpression(
-                                                  factory.createTemplateHead(
-                                                    'The value must start with ',
-                                                    'The value must start with ',
-                                                  ),
-                                                  [
-                                                    factory.createTemplateSpan(
-                                                      factory.createCallExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createPropertyAccessExpression(
-                                                            factory.createIdentifier('validation'),
-                                                            factory.createIdentifier('strValues'),
-                                                          ),
-                                                          factory.createIdentifier('join'),
-                                                        ),
-                                                        undefined,
-                                                        [factory.createStringLiteral(', ')],
-                                                      ),
-                                                      factory.createTemplateTail('', ''),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ],
-                                          true,
-                                        ),
-                                      ),
-                                    ]),
-                                    factory.createCaseClause(factory.createStringLiteral('EndWith'), [
-                                      factory.createReturnStatement(
-                                        factory.createObjectLiteralExpression(
-                                          [
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('hasError'),
-                                              factory.createPrefixUnaryExpression(
-                                                ts.SyntaxKind.ExclamationToken,
-                                                factory.createCallExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('strValues'),
-                                                    ),
-                                                    factory.createIdentifier('some'),
-                                                  ),
-                                                  undefined,
-                                                  [
-                                                    factory.createArrowFunction(
-                                                      undefined,
-                                                      undefined,
-                                                      [
-                                                        factory.createParameterDeclaration(
-                                                          undefined,
-                                                          undefined,
-                                                          undefined,
-                                                          factory.createIdentifier('el'),
-                                                          undefined,
-                                                          factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-                                                          undefined,
-                                                        ),
-                                                      ],
-                                                      undefined,
-                                                      factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                                      factory.createCallExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createIdentifier('value'),
-                                                          factory.createIdentifier('endsWith'),
-                                                        ),
-                                                        undefined,
-                                                        [factory.createIdentifier('el')],
-                                                      ),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('errorMessage'),
-                                              factory.createBinaryExpression(
-                                                factory.createPropertyAccessExpression(
-                                                  factory.createIdentifier('validation'),
-                                                  factory.createIdentifier('validationMessage'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.BarBarToken),
-                                                factory.createTemplateExpression(
-                                                  factory.createTemplateHead(
-                                                    'The value must end with ',
-                                                    'The value must end with ',
-                                                  ),
-                                                  [
-                                                    factory.createTemplateSpan(
-                                                      factory.createCallExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createPropertyAccessExpression(
-                                                            factory.createIdentifier('validation'),
-                                                            factory.createIdentifier('strValues'),
-                                                          ),
-                                                          factory.createIdentifier('join'),
-                                                        ),
-                                                        undefined,
-                                                        [factory.createStringLiteral(', ')],
-                                                      ),
-                                                      factory.createTemplateTail('', ''),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ],
-                                          true,
-                                        ),
-                                      ),
-                                    ]),
-                                    factory.createCaseClause(factory.createStringLiteral('Contains'), [
-                                      factory.createReturnStatement(
-                                        factory.createObjectLiteralExpression(
-                                          [
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('hasError'),
-                                              factory.createPrefixUnaryExpression(
-                                                ts.SyntaxKind.ExclamationToken,
-                                                factory.createCallExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('strValues'),
-                                                    ),
-                                                    factory.createIdentifier('some'),
-                                                  ),
-                                                  undefined,
-                                                  [
-                                                    factory.createArrowFunction(
-                                                      undefined,
-                                                      undefined,
-                                                      [
-                                                        factory.createParameterDeclaration(
-                                                          undefined,
-                                                          undefined,
-                                                          undefined,
-                                                          factory.createIdentifier('el'),
-                                                          undefined,
-                                                          factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-                                                          undefined,
-                                                        ),
-                                                      ],
-                                                      undefined,
-                                                      factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                                      factory.createCallExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createIdentifier('value'),
-                                                          factory.createIdentifier('includes'),
-                                                        ),
-                                                        undefined,
-                                                        [factory.createIdentifier('el')],
-                                                      ),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('errorMessage'),
-                                              factory.createBinaryExpression(
-                                                factory.createPropertyAccessExpression(
-                                                  factory.createIdentifier('validation'),
-                                                  factory.createIdentifier('validationMessage'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.BarBarToken),
-                                                factory.createTemplateExpression(
-                                                  factory.createTemplateHead(
-                                                    'The value must contain ',
-                                                    'The value must contain ',
-                                                  ),
-                                                  [
-                                                    factory.createTemplateSpan(
-                                                      factory.createCallExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createPropertyAccessExpression(
-                                                            factory.createIdentifier('validation'),
-                                                            factory.createIdentifier('strValues'),
-                                                          ),
-                                                          factory.createIdentifier('join'),
-                                                        ),
-                                                        undefined,
-                                                        [factory.createStringLiteral(', ')],
-                                                      ),
-                                                      factory.createTemplateTail('', ''),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ],
-                                          true,
-                                        ),
-                                      ),
-                                    ]),
-                                    factory.createCaseClause(factory.createStringLiteral('NotContains'), [
-                                      factory.createReturnStatement(
-                                        factory.createObjectLiteralExpression(
-                                          [
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('hasError'),
-                                              factory.createPrefixUnaryExpression(
-                                                ts.SyntaxKind.ExclamationToken,
-                                                factory.createCallExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('strValues'),
-                                                    ),
-                                                    factory.createIdentifier('every'),
-                                                  ),
-                                                  undefined,
-                                                  [
-                                                    factory.createArrowFunction(
-                                                      undefined,
-                                                      undefined,
-                                                      [
-                                                        factory.createParameterDeclaration(
-                                                          undefined,
-                                                          undefined,
-                                                          undefined,
-                                                          factory.createIdentifier('el'),
-                                                          undefined,
-                                                          factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-                                                          undefined,
-                                                        ),
-                                                      ],
-                                                      undefined,
-                                                      factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                                      factory.createPrefixUnaryExpression(
-                                                        ts.SyntaxKind.ExclamationToken,
-                                                        factory.createCallExpression(
-                                                          factory.createPropertyAccessExpression(
-                                                            factory.createIdentifier('value'),
-                                                            factory.createIdentifier('includes'),
-                                                          ),
-                                                          undefined,
-                                                          [factory.createIdentifier('el')],
-                                                        ),
-                                                      ),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('errorMessage'),
-                                              factory.createBinaryExpression(
-                                                factory.createPropertyAccessExpression(
-                                                  factory.createIdentifier('validation'),
-                                                  factory.createIdentifier('validationMessage'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.BarBarToken),
-                                                factory.createTemplateExpression(
-                                                  factory.createTemplateHead(
-                                                    'The value must not contain ',
-                                                    'The value must not contain ',
-                                                  ),
-                                                  [
-                                                    factory.createTemplateSpan(
-                                                      factory.createCallExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createPropertyAccessExpression(
-                                                            factory.createIdentifier('validation'),
-                                                            factory.createIdentifier('strValues'),
-                                                          ),
-                                                          factory.createIdentifier('join'),
-                                                        ),
-                                                        undefined,
-                                                        [factory.createStringLiteral(', ')],
-                                                      ),
-                                                      factory.createTemplateTail('', ''),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ],
-                                          true,
-                                        ),
-                                      ),
-                                    ]),
-                                    factory.createCaseClause(factory.createStringLiteral('BeAfter'), [
-                                      factory.createVariableStatement(
-                                        undefined,
-                                        factory.createVariableDeclarationList(
-                                          [
-                                            factory.createVariableDeclaration(
-                                              factory.createIdentifier('afterTimeValue'),
-                                              undefined,
-                                              undefined,
-                                              factory.createCallExpression(
-                                                factory.createIdentifier('parseInt'),
-                                                undefined,
-                                                [
-                                                  factory.createElementAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('strValues'),
-                                                    ),
-                                                    factory.createNumericLiteral('0'),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ],
-                                          ts.NodeFlags.Const,
-                                        ),
-                                      ),
-                                      factory.createVariableStatement(
-                                        undefined,
-                                        factory.createVariableDeclarationList(
-                                          [
-                                            factory.createVariableDeclaration(
-                                              factory.createIdentifier('afterTimeValidator'),
-                                              undefined,
-                                              undefined,
-                                              factory.createConditionalExpression(
-                                                factory.createCallExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createIdentifier('Number'),
-                                                    factory.createIdentifier('isNaN'),
-                                                  ),
-                                                  undefined,
-                                                  [factory.createIdentifier('afterTimeValue')],
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.QuestionToken),
-                                                factory.createElementAccessExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createIdentifier('validation'),
-                                                    factory.createIdentifier('strValues'),
-                                                  ),
-                                                  factory.createNumericLiteral('0'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.ColonToken),
-                                                factory.createIdentifier('afterTimeValue'),
-                                              ),
-                                            ),
-                                          ],
-                                          ts.NodeFlags.Const,
-                                        ),
-                                      ),
-                                      factory.createReturnStatement(
-                                        factory.createObjectLiteralExpression(
-                                          [
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('hasError'),
-                                              factory.createPrefixUnaryExpression(
-                                                ts.SyntaxKind.ExclamationToken,
-                                                factory.createParenthesizedExpression(
-                                                  factory.createBinaryExpression(
-                                                    factory.createNewExpression(
-                                                      factory.createIdentifier('Date'),
-                                                      undefined,
-                                                      [factory.createIdentifier('value')],
-                                                    ),
-                                                    factory.createToken(ts.SyntaxKind.GreaterThanToken),
-                                                    factory.createNewExpression(
-                                                      factory.createIdentifier('Date'),
-                                                      undefined,
-                                                      [factory.createIdentifier('afterTimeValidator')],
-                                                    ),
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('errorMessage'),
-                                              factory.createBinaryExpression(
-                                                factory.createPropertyAccessExpression(
-                                                  factory.createIdentifier('validation'),
-                                                  factory.createIdentifier('validationMessage'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.BarBarToken),
-                                                factory.createTemplateExpression(
-                                                  factory.createTemplateHead(
-                                                    'The value must be after ',
-                                                    'The value must be after ',
-                                                  ),
-                                                  [
-                                                    factory.createTemplateSpan(
-                                                      factory.createElementAccessExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createIdentifier('validation'),
-                                                          factory.createIdentifier('strValues'),
-                                                        ),
-                                                        factory.createNumericLiteral('0'),
-                                                      ),
-                                                      factory.createTemplateTail('', ''),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ],
-                                          true,
-                                        ),
-                                      ),
-                                    ]),
-                                    factory.createCaseClause(factory.createStringLiteral('BeBefore'), [
-                                      factory.createVariableStatement(
-                                        undefined,
-                                        factory.createVariableDeclarationList(
-                                          [
-                                            factory.createVariableDeclaration(
-                                              factory.createIdentifier('beforeTimeValue'),
-                                              undefined,
-                                              undefined,
-                                              factory.createCallExpression(
-                                                factory.createIdentifier('parseInt'),
-                                                undefined,
-                                                [
-                                                  factory.createElementAccessExpression(
-                                                    factory.createPropertyAccessExpression(
-                                                      factory.createIdentifier('validation'),
-                                                      factory.createIdentifier('strValues'),
-                                                    ),
-                                                    factory.createNumericLiteral('0'),
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ],
-                                          ts.NodeFlags.Const,
-                                        ),
-                                      ),
-                                      factory.createVariableStatement(
-                                        undefined,
-                                        factory.createVariableDeclarationList(
-                                          [
-                                            factory.createVariableDeclaration(
-                                              factory.createIdentifier('beforeTimevalue'),
-                                              undefined,
-                                              undefined,
-                                              factory.createConditionalExpression(
-                                                factory.createCallExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createIdentifier('Number'),
-                                                    factory.createIdentifier('isNaN'),
-                                                  ),
-                                                  undefined,
-                                                  [factory.createIdentifier('beforeTimeValue')],
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.QuestionToken),
-                                                factory.createElementAccessExpression(
-                                                  factory.createPropertyAccessExpression(
-                                                    factory.createIdentifier('validation'),
-                                                    factory.createIdentifier('strValues'),
-                                                  ),
-                                                  factory.createNumericLiteral('0'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.ColonToken),
-                                                factory.createIdentifier('beforeTimeValue'),
-                                              ),
-                                            ),
-                                          ],
-                                          ts.NodeFlags.Const,
-                                        ),
-                                      ),
-                                      factory.createReturnStatement(
-                                        factory.createObjectLiteralExpression(
-                                          [
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('hasError'),
-                                              factory.createPrefixUnaryExpression(
-                                                ts.SyntaxKind.ExclamationToken,
-                                                factory.createParenthesizedExpression(
-                                                  factory.createBinaryExpression(
-                                                    factory.createNewExpression(
-                                                      factory.createIdentifier('Date'),
-                                                      undefined,
-                                                      [factory.createIdentifier('value')],
-                                                    ),
-                                                    factory.createToken(ts.SyntaxKind.LessThanToken),
-                                                    factory.createNewExpression(
-                                                      factory.createIdentifier('Date'),
-                                                      undefined,
-                                                      [factory.createIdentifier('beforeTimevalue')],
-                                                    ),
-                                                  ),
-                                                ),
-                                              ),
-                                            ),
-                                            factory.createPropertyAssignment(
-                                              factory.createIdentifier('errorMessage'),
-                                              factory.createBinaryExpression(
-                                                factory.createPropertyAccessExpression(
-                                                  factory.createIdentifier('validation'),
-                                                  factory.createIdentifier('validationMessage'),
-                                                ),
-                                                factory.createToken(ts.SyntaxKind.BarBarToken),
-                                                factory.createTemplateExpression(
-                                                  factory.createTemplateHead(
-                                                    'The value must be before ',
-                                                    'The value must be before ',
-                                                  ),
-                                                  [
-                                                    factory.createTemplateSpan(
-                                                      factory.createElementAccessExpression(
-                                                        factory.createPropertyAccessExpression(
-                                                          factory.createIdentifier('validation'),
-                                                          factory.createIdentifier('strValues'),
-                                                        ),
-                                                        factory.createNumericLiteral('0'),
-                                                      ),
-                                                      factory.createTemplateTail('', ''),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ],
-                                          true,
-                                        ),
-                                      ),
-                                    ]),
-                                  ]),
-                                ),
-                              ],
-                              true,
-                            ),
-                            undefined,
+                            ts.NodeFlags.Const,
                           ),
                         ),
+                        factory.createIfStatement(
+                          factory.createPropertyAccessChain(
+                            factory.createIdentifier('validationResult'),
+                            factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                            factory.createIdentifier('hasError'),
+                          ),
+                          factory.createBlock(
+                            [factory.createReturnStatement(factory.createIdentifier('validationResult'))],
+                            true,
+                          ),
+                          undefined,
+                        ),
+                      ],
+                      true,
+                    ),
+                  ),
+                  factory.createReturnStatement(
+                    factory.createObjectLiteralExpression(
+                      [factory.createPropertyAssignment(factory.createIdentifier('hasError'), factory.createFalse())],
+                      false,
+                    ),
+                  ),
+                ],
+                true,
+              ),
+            ),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    ),
+    factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('checkValidation'),
+            undefined,
+            undefined,
+            factory.createArrowFunction(
+              undefined,
+              undefined,
+              [
+                factory.createParameterDeclaration(
+                  undefined,
+                  undefined,
+                  undefined,
+                  factory.createIdentifier('value'),
+                  undefined,
+                  factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+                  undefined,
+                ),
+                factory.createParameterDeclaration(
+                  undefined,
+                  undefined,
+                  undefined,
+                  factory.createIdentifier('validation'),
+                  undefined,
+                  factory.createTypeReferenceNode(factory.createIdentifier('FieldValidationConfiguration'), undefined),
+                  undefined,
+                ),
+              ],
+              undefined,
+              factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+              factory.createBlock(
+                [
+                  factory.createIfStatement(
+                    factory.createPropertyAccessChain(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier('validation'),
+                        factory.createIdentifier('numValues'),
+                      ),
+                      factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                      factory.createIdentifier('length'),
+                    ),
+                    factory.createBlock(
+                      [
                         factory.createSwitchStatement(
                           factory.createPropertyAccessExpression(
                             factory.createIdentifier('validation'),
                             factory.createIdentifier('type'),
                           ),
                           factory.createCaseBlock([
-                            factory.createCaseClause(factory.createStringLiteral('Email'), [
-                              factory.createVariableStatement(
-                                undefined,
-                                factory.createVariableDeclarationList(
-                                  [
-                                    factory.createVariableDeclaration(
-                                      factory.createIdentifier('EMAIL_ADDRESS_REGEX'),
-                                      undefined,
-                                      undefined,
-                                      factory.createRegularExpressionLiteral(EscapedRegexLiterals.emailAddress),
-                                    ),
-                                  ],
-                                  ts.NodeFlags.Const,
-                                ),
-                              ),
-                              factory.createReturnStatement(
-                                factory.createObjectLiteralExpression(
-                                  [
-                                    factory.createPropertyAssignment(
-                                      factory.createIdentifier('hasError'),
-                                      factory.createPrefixUnaryExpression(
-                                        ts.SyntaxKind.ExclamationToken,
-                                        factory.createCallExpression(
-                                          factory.createPropertyAccessExpression(
-                                            factory.createIdentifier('EMAIL_ADDRESS_REGEX'),
-                                            factory.createIdentifier('test'),
-                                          ),
-                                          undefined,
-                                          [factory.createIdentifier('value')],
-                                        ),
-                                      ),
-                                    ),
-                                    factory.createPropertyAssignment(
-                                      factory.createIdentifier('errorMessage'),
-                                      factory.createBinaryExpression(
-                                        factory.createPropertyAccessExpression(
-                                          factory.createIdentifier('validation'),
-                                          factory.createIdentifier('validationMessage'),
-                                        ),
-                                        factory.createToken(ts.SyntaxKind.BarBarToken),
-                                        factory.createStringLiteral('The value must be a valid email address'),
-                                      ),
-                                    ),
-                                  ],
-                                  true,
-                                ),
-                              ),
-                            ]),
-                            factory.createCaseClause(factory.createStringLiteral('JSON'), [
-                              factory.createVariableStatement(
-                                undefined,
-                                factory.createVariableDeclarationList(
-                                  [
-                                    factory.createVariableDeclaration(
-                                      factory.createIdentifier('isInvalidJSON'),
-                                      undefined,
-                                      undefined,
-                                      factory.createFalse(),
-                                    ),
-                                  ],
-                                  ts.NodeFlags.Let,
-                                ),
-                              ),
-                              factory.createTryStatement(
-                                factory.createBlock(
-                                  [
-                                    factory.createExpressionStatement(
-                                      factory.createCallExpression(
-                                        factory.createPropertyAccessExpression(
-                                          factory.createIdentifier('JSON'),
-                                          factory.createIdentifier('parse'),
-                                        ),
-                                        undefined,
-                                        [factory.createIdentifier('value')],
-                                      ),
-                                    ),
-                                  ],
-                                  true,
-                                ),
-                                factory.createCatchClause(
-                                  factory.createVariableDeclaration(
-                                    factory.createIdentifier('e'),
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                  ),
-                                  factory.createBlock(
-                                    [
-                                      factory.createExpressionStatement(
-                                        factory.createBinaryExpression(
-                                          factory.createIdentifier('isInvalidJSON'),
-                                          factory.createToken(ts.SyntaxKind.EqualsToken),
-                                          factory.createTrue(),
-                                        ),
-                                      ),
-                                    ],
-                                    true,
-                                  ),
-                                ),
-                                undefined,
-                              ),
-                              factory.createReturnStatement(
-                                factory.createObjectLiteralExpression(
-                                  [
-                                    factory.createPropertyAssignment(
-                                      factory.createIdentifier('hasError'),
-                                      factory.createIdentifier('isInvalidJSON'),
-                                    ),
-                                    factory.createPropertyAssignment(
-                                      factory.createIdentifier('errorMessage'),
-                                      factory.createBinaryExpression(
-                                        factory.createPropertyAccessExpression(
-                                          factory.createIdentifier('validation'),
-                                          factory.createIdentifier('validationMessage'),
-                                        ),
-                                        factory.createToken(ts.SyntaxKind.BarBarToken),
-                                        factory.createStringLiteral('The value must be in a correct JSON format'),
-                                      ),
-                                    ),
-                                  ],
-                                  true,
-                                ),
-                              ),
-                            ]),
-                            factory.createCaseClause(factory.createStringLiteral('IpAddress'), [
-                              factory.createVariableStatement(
-                                undefined,
-                                factory.createVariableDeclarationList(
-                                  [
-                                    factory.createVariableDeclaration(
-                                      factory.createIdentifier('IPV_4'),
-                                      undefined,
-                                      undefined,
-                                      factory.createRegularExpressionLiteral(EscapedRegexLiterals.ipv4),
-                                    ),
-                                  ],
-                                  ts.NodeFlags.Const,
-                                ),
-                              ),
-                              factory.createVariableStatement(
-                                undefined,
-                                factory.createVariableDeclarationList(
-                                  [
-                                    factory.createVariableDeclaration(
-                                      factory.createIdentifier('IPV_6'),
-                                      undefined,
-                                      undefined,
-                                      factory.createRegularExpressionLiteral(EscapedRegexLiterals.ipv6),
-                                    ),
-                                  ],
-                                  ts.NodeFlags.Const,
-                                ),
-                              ),
+                            factory.createCaseClause(factory.createStringLiteral('LessThanChar'), [
                               factory.createReturnStatement(
                                 factory.createObjectLiteralExpression(
                                   [
@@ -1426,22 +455,17 @@ export const generateValidationFunction = () => {
                                         ts.SyntaxKind.ExclamationToken,
                                         factory.createParenthesizedExpression(
                                           factory.createBinaryExpression(
-                                            factory.createCallExpression(
-                                              factory.createPropertyAccessExpression(
-                                                factory.createIdentifier('IPV_4'),
-                                                factory.createIdentifier('test'),
-                                              ),
-                                              undefined,
-                                              [factory.createIdentifier('value')],
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('value'),
+                                              factory.createIdentifier('length'),
                                             ),
-                                            factory.createToken(ts.SyntaxKind.BarBarToken),
-                                            factory.createCallExpression(
+                                            factory.createToken(ts.SyntaxKind.LessThanToken),
+                                            factory.createElementAccessExpression(
                                               factory.createPropertyAccessExpression(
-                                                factory.createIdentifier('IPV_6'),
-                                                factory.createIdentifier('test'),
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('numValues'),
                                               ),
-                                              undefined,
-                                              [factory.createIdentifier('value')],
+                                              factory.createNumericLiteral('0'),
                                             ),
                                           ),
                                         ),
@@ -1455,79 +479,23 @@ export const generateValidationFunction = () => {
                                           factory.createIdentifier('validationMessage'),
                                         ),
                                         factory.createToken(ts.SyntaxKind.BarBarToken),
-                                        factory.createStringLiteral('The value must be an IPv4 or IPv6 address'),
-                                      ),
-                                    ),
-                                  ],
-                                  true,
-                                ),
-                              ),
-                            ]),
-                            factory.createCaseClause(factory.createStringLiteral('URL'), [
-                              factory.createVariableStatement(
-                                undefined,
-                                factory.createVariableDeclarationList(
-                                  [
-                                    factory.createVariableDeclaration(
-                                      factory.createIdentifier('isInvalidUrl'),
-                                      undefined,
-                                      undefined,
-                                      factory.createFalse(),
-                                    ),
-                                  ],
-                                  ts.NodeFlags.Let,
-                                ),
-                              ),
-                              factory.createTryStatement(
-                                factory.createBlock(
-                                  [
-                                    factory.createExpressionStatement(
-                                      factory.createNewExpression(factory.createIdentifier('URL'), undefined, [
-                                        factory.createIdentifier('value'),
-                                      ]),
-                                    ),
-                                  ],
-                                  true,
-                                ),
-                                factory.createCatchClause(
-                                  factory.createVariableDeclaration(
-                                    factory.createIdentifier('e'),
-                                    undefined,
-                                    undefined,
-                                    undefined,
-                                  ),
-                                  factory.createBlock(
-                                    [
-                                      factory.createExpressionStatement(
-                                        factory.createBinaryExpression(
-                                          factory.createIdentifier('isInvalidUrl'),
-                                          factory.createToken(ts.SyntaxKind.EqualsToken),
-                                          factory.createTrue(),
-                                        ),
-                                      ),
-                                    ],
-                                    true,
-                                  ),
-                                ),
-                                undefined,
-                              ),
-                              factory.createReturnStatement(
-                                factory.createObjectLiteralExpression(
-                                  [
-                                    factory.createPropertyAssignment(
-                                      factory.createIdentifier('hasError'),
-                                      factory.createIdentifier('isInvalidUrl'),
-                                    ),
-                                    factory.createPropertyAssignment(
-                                      factory.createIdentifier('errorMessage'),
-                                      factory.createBinaryExpression(
-                                        factory.createPropertyAccessExpression(
-                                          factory.createIdentifier('validation'),
-                                          factory.createIdentifier('validationMessage'),
-                                        ),
-                                        factory.createToken(ts.SyntaxKind.BarBarToken),
-                                        factory.createStringLiteral(
-                                          'The value must be a valid URL that begins with a schema (i.e. http:// or mailto:)',
+                                        factory.createTemplateExpression(
+                                          factory.createTemplateHead(
+                                            'The value must be shorter than ',
+                                            'The value must be shorter than ',
+                                          ),
+                                          [
+                                            factory.createTemplateSpan(
+                                              factory.createElementAccessExpression(
+                                                factory.createPropertyAccessExpression(
+                                                  factory.createIdentifier('validation'),
+                                                  factory.createIdentifier('numValues'),
+                                                ),
+                                                factory.createNumericLiteral('0'),
+                                              ),
+                                              factory.createTemplateTail('', ''),
+                                            ),
+                                          ],
                                         ),
                                       ),
                                     ),
@@ -1536,21 +504,7 @@ export const generateValidationFunction = () => {
                                 ),
                               ),
                             ]),
-                            factory.createCaseClause(factory.createStringLiteral('Phone'), [
-                              factory.createVariableStatement(
-                                undefined,
-                                factory.createVariableDeclarationList(
-                                  [
-                                    factory.createVariableDeclaration(
-                                      factory.createIdentifier('PHONE'),
-                                      undefined,
-                                      undefined,
-                                      factory.createRegularExpressionLiteral(EscapedRegexLiterals.phone),
-                                    ),
-                                  ],
-                                  ts.NodeFlags.Const,
-                                ),
-                              ),
+                            factory.createCaseClause(factory.createStringLiteral('GreaterThanChar'), [
                               factory.createReturnStatement(
                                 factory.createObjectLiteralExpression(
                                   [
@@ -1559,13 +513,19 @@ export const generateValidationFunction = () => {
                                       factory.createPrefixUnaryExpression(
                                         ts.SyntaxKind.ExclamationToken,
                                         factory.createParenthesizedExpression(
-                                          factory.createCallExpression(
+                                          factory.createBinaryExpression(
                                             factory.createPropertyAccessExpression(
-                                              factory.createIdentifier('PHONE'),
-                                              factory.createIdentifier('test'),
+                                              factory.createIdentifier('value'),
+                                              factory.createIdentifier('length'),
                                             ),
-                                            undefined,
-                                            [factory.createIdentifier('value')],
+                                            factory.createToken(ts.SyntaxKind.GreaterThanToken),
+                                            factory.createElementAccessExpression(
+                                              factory.createPropertyAccessExpression(
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('numValues'),
+                                              ),
+                                              factory.createNumericLiteral('0'),
+                                            ),
                                           ),
                                         ),
                                       ),
@@ -1578,7 +538,217 @@ export const generateValidationFunction = () => {
                                           factory.createIdentifier('validationMessage'),
                                         ),
                                         factory.createToken(ts.SyntaxKind.BarBarToken),
-                                        factory.createStringLiteral('The value must be a valid phone number'),
+                                        factory.createTemplateExpression(
+                                          factory.createTemplateHead(
+                                            'The value must be longer than ',
+                                            'The value must be longer than ',
+                                          ),
+                                          [
+                                            factory.createTemplateSpan(
+                                              factory.createElementAccessExpression(
+                                                factory.createPropertyAccessExpression(
+                                                  factory.createIdentifier('validation'),
+                                                  factory.createIdentifier('numValues'),
+                                                ),
+                                                factory.createNumericLiteral('0'),
+                                              ),
+                                              factory.createTemplateTail('', ''),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                  true,
+                                ),
+                              ),
+                            ]),
+                            factory.createCaseClause(factory.createStringLiteral('LessThanNum'), [
+                              factory.createReturnStatement(
+                                factory.createObjectLiteralExpression(
+                                  [
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('hasError'),
+                                      factory.createPrefixUnaryExpression(
+                                        ts.SyntaxKind.ExclamationToken,
+                                        factory.createParenthesizedExpression(
+                                          factory.createBinaryExpression(
+                                            factory.createIdentifier('value'),
+                                            factory.createToken(ts.SyntaxKind.LessThanToken),
+                                            factory.createElementAccessExpression(
+                                              factory.createPropertyAccessExpression(
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('numValues'),
+                                              ),
+                                              factory.createNumericLiteral('0'),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('errorMessage'),
+                                      factory.createBinaryExpression(
+                                        factory.createPropertyAccessExpression(
+                                          factory.createIdentifier('validation'),
+                                          factory.createIdentifier('validationMessage'),
+                                        ),
+                                        factory.createToken(ts.SyntaxKind.BarBarToken),
+                                        factory.createTemplateExpression(
+                                          factory.createTemplateHead(
+                                            'The value must be less than ',
+                                            'The value must be less than ',
+                                          ),
+                                          [
+                                            factory.createTemplateSpan(
+                                              factory.createElementAccessExpression(
+                                                factory.createPropertyAccessExpression(
+                                                  factory.createIdentifier('validation'),
+                                                  factory.createIdentifier('numValues'),
+                                                ),
+                                                factory.createNumericLiteral('0'),
+                                              ),
+                                              factory.createTemplateTail('', ''),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                  true,
+                                ),
+                              ),
+                            ]),
+                            factory.createCaseClause(factory.createStringLiteral('GreaterThanNum'), [
+                              factory.createReturnStatement(
+                                factory.createObjectLiteralExpression(
+                                  [
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('hasError'),
+                                      factory.createPrefixUnaryExpression(
+                                        ts.SyntaxKind.ExclamationToken,
+                                        factory.createParenthesizedExpression(
+                                          factory.createBinaryExpression(
+                                            factory.createIdentifier('value'),
+                                            factory.createToken(ts.SyntaxKind.GreaterThanToken),
+                                            factory.createElementAccessExpression(
+                                              factory.createPropertyAccessExpression(
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('numValues'),
+                                              ),
+                                              factory.createNumericLiteral('0'),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('errorMessage'),
+                                      factory.createBinaryExpression(
+                                        factory.createPropertyAccessExpression(
+                                          factory.createIdentifier('validation'),
+                                          factory.createIdentifier('validationMessage'),
+                                        ),
+                                        factory.createToken(ts.SyntaxKind.BarBarToken),
+                                        factory.createTemplateExpression(
+                                          factory.createTemplateHead(
+                                            'The value must be greater than ',
+                                            'The value must be greater than ',
+                                          ),
+                                          [
+                                            factory.createTemplateSpan(
+                                              factory.createElementAccessExpression(
+                                                factory.createPropertyAccessExpression(
+                                                  factory.createIdentifier('validation'),
+                                                  factory.createIdentifier('numValues'),
+                                                ),
+                                                factory.createNumericLiteral('0'),
+                                              ),
+                                              factory.createTemplateTail('', ''),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                  true,
+                                ),
+                              ),
+                            ]),
+                            factory.createCaseClause(factory.createStringLiteral('EqualTo'), [
+                              factory.createReturnStatement(
+                                factory.createObjectLiteralExpression(
+                                  [
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('hasError'),
+                                      factory.createPrefixUnaryExpression(
+                                        ts.SyntaxKind.ExclamationToken,
+                                        factory.createCallExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('validation'),
+                                              factory.createIdentifier('numValues'),
+                                            ),
+                                            factory.createIdentifier('some'),
+                                          ),
+                                          undefined,
+                                          [
+                                            factory.createArrowFunction(
+                                              undefined,
+                                              undefined,
+                                              [
+                                                factory.createParameterDeclaration(
+                                                  undefined,
+                                                  undefined,
+                                                  undefined,
+                                                  factory.createIdentifier('el'),
+                                                  undefined,
+                                                  undefined,
+                                                  undefined,
+                                                ),
+                                              ],
+                                              undefined,
+                                              factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                                              factory.createBinaryExpression(
+                                                factory.createIdentifier('el'),
+                                                factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+                                                factory.createIdentifier('value'),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier('errorMessage'),
+                                      factory.createBinaryExpression(
+                                        factory.createPropertyAccessExpression(
+                                          factory.createIdentifier('validation'),
+                                          factory.createIdentifier('validationMessage'),
+                                        ),
+                                        factory.createToken(ts.SyntaxKind.BarBarToken),
+                                        factory.createTemplateExpression(
+                                          factory.createTemplateHead(
+                                            'The value must be equal to ',
+                                            'The value must be equal to ',
+                                          ),
+                                          [
+                                            factory.createTemplateSpan(
+                                              factory.createCallExpression(
+                                                factory.createPropertyAccessExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createIdentifier('validation'),
+                                                    factory.createIdentifier('numValues'),
+                                                  ),
+                                                  factory.createIdentifier('join'),
+                                                ),
+                                                undefined,
+                                                [factory.createStringLiteral(' or ')],
+                                              ),
+                                              factory.createTemplateTail('', ''),
+                                            ),
+                                          ],
+                                        ),
                                       ),
                                     ),
                                   ],
@@ -1592,12 +762,916 @@ export const generateValidationFunction = () => {
                       ],
                       true,
                     ),
-                  ),
-                  factory.createReturnStatement(
-                    factory.createObjectLiteralExpression(
-                      [factory.createPropertyAssignment(factory.createIdentifier('hasError'), factory.createFalse())],
-                      false,
+                    factory.createIfStatement(
+                      factory.createPropertyAccessChain(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('validation'),
+                          factory.createIdentifier('strValues'),
+                        ),
+                        factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                        factory.createIdentifier('length'),
+                      ),
+                      factory.createBlock(
+                        [
+                          factory.createSwitchStatement(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('validation'),
+                              factory.createIdentifier('type'),
+                            ),
+                            factory.createCaseBlock([
+                              factory.createCaseClause(factory.createStringLiteral('StartWith'), [
+                                factory.createReturnStatement(
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('hasError'),
+                                        factory.createPrefixUnaryExpression(
+                                          ts.SyntaxKind.ExclamationToken,
+                                          factory.createCallExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createPropertyAccessExpression(
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('strValues'),
+                                              ),
+                                              factory.createIdentifier('some'),
+                                            ),
+                                            undefined,
+                                            [
+                                              factory.createArrowFunction(
+                                                undefined,
+                                                undefined,
+                                                [
+                                                  factory.createParameterDeclaration(
+                                                    undefined,
+                                                    undefined,
+                                                    undefined,
+                                                    factory.createIdentifier('el'),
+                                                    undefined,
+                                                    factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+                                                    undefined,
+                                                  ),
+                                                ],
+                                                undefined,
+                                                factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                                                factory.createCallExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createIdentifier('value'),
+                                                    factory.createIdentifier('startsWith'),
+                                                  ),
+                                                  undefined,
+                                                  [factory.createIdentifier('el')],
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('errorMessage'),
+                                        factory.createBinaryExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createIdentifier('validation'),
+                                            factory.createIdentifier('validationMessage'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.BarBarToken),
+                                          factory.createTemplateExpression(
+                                            factory.createTemplateHead(
+                                              'The value must start with ',
+                                              'The value must start with ',
+                                            ),
+                                            [
+                                              factory.createTemplateSpan(
+                                                factory.createCallExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createPropertyAccessExpression(
+                                                      factory.createIdentifier('validation'),
+                                                      factory.createIdentifier('strValues'),
+                                                    ),
+                                                    factory.createIdentifier('join'),
+                                                  ),
+                                                  undefined,
+                                                  [factory.createStringLiteral(', ')],
+                                                ),
+                                                factory.createTemplateTail('', ''),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ]),
+                              factory.createCaseClause(factory.createStringLiteral('EndWith'), [
+                                factory.createReturnStatement(
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('hasError'),
+                                        factory.createPrefixUnaryExpression(
+                                          ts.SyntaxKind.ExclamationToken,
+                                          factory.createCallExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createPropertyAccessExpression(
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('strValues'),
+                                              ),
+                                              factory.createIdentifier('some'),
+                                            ),
+                                            undefined,
+                                            [
+                                              factory.createArrowFunction(
+                                                undefined,
+                                                undefined,
+                                                [
+                                                  factory.createParameterDeclaration(
+                                                    undefined,
+                                                    undefined,
+                                                    undefined,
+                                                    factory.createIdentifier('el'),
+                                                    undefined,
+                                                    factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+                                                    undefined,
+                                                  ),
+                                                ],
+                                                undefined,
+                                                factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                                                factory.createCallExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createIdentifier('value'),
+                                                    factory.createIdentifier('endsWith'),
+                                                  ),
+                                                  undefined,
+                                                  [factory.createIdentifier('el')],
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('errorMessage'),
+                                        factory.createBinaryExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createIdentifier('validation'),
+                                            factory.createIdentifier('validationMessage'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.BarBarToken),
+                                          factory.createTemplateExpression(
+                                            factory.createTemplateHead(
+                                              'The value must end with ',
+                                              'The value must end with ',
+                                            ),
+                                            [
+                                              factory.createTemplateSpan(
+                                                factory.createCallExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createPropertyAccessExpression(
+                                                      factory.createIdentifier('validation'),
+                                                      factory.createIdentifier('strValues'),
+                                                    ),
+                                                    factory.createIdentifier('join'),
+                                                  ),
+                                                  undefined,
+                                                  [factory.createStringLiteral(', ')],
+                                                ),
+                                                factory.createTemplateTail('', ''),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ]),
+                              factory.createCaseClause(factory.createStringLiteral('Contains'), [
+                                factory.createReturnStatement(
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('hasError'),
+                                        factory.createPrefixUnaryExpression(
+                                          ts.SyntaxKind.ExclamationToken,
+                                          factory.createCallExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createPropertyAccessExpression(
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('strValues'),
+                                              ),
+                                              factory.createIdentifier('some'),
+                                            ),
+                                            undefined,
+                                            [
+                                              factory.createArrowFunction(
+                                                undefined,
+                                                undefined,
+                                                [
+                                                  factory.createParameterDeclaration(
+                                                    undefined,
+                                                    undefined,
+                                                    undefined,
+                                                    factory.createIdentifier('el'),
+                                                    undefined,
+                                                    factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+                                                    undefined,
+                                                  ),
+                                                ],
+                                                undefined,
+                                                factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                                                factory.createCallExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createIdentifier('value'),
+                                                    factory.createIdentifier('includes'),
+                                                  ),
+                                                  undefined,
+                                                  [factory.createIdentifier('el')],
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('errorMessage'),
+                                        factory.createBinaryExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createIdentifier('validation'),
+                                            factory.createIdentifier('validationMessage'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.BarBarToken),
+                                          factory.createTemplateExpression(
+                                            factory.createTemplateHead(
+                                              'The value must contain ',
+                                              'The value must contain ',
+                                            ),
+                                            [
+                                              factory.createTemplateSpan(
+                                                factory.createCallExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createPropertyAccessExpression(
+                                                      factory.createIdentifier('validation'),
+                                                      factory.createIdentifier('strValues'),
+                                                    ),
+                                                    factory.createIdentifier('join'),
+                                                  ),
+                                                  undefined,
+                                                  [factory.createStringLiteral(', ')],
+                                                ),
+                                                factory.createTemplateTail('', ''),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ]),
+                              factory.createCaseClause(factory.createStringLiteral('NotContains'), [
+                                factory.createReturnStatement(
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('hasError'),
+                                        factory.createPrefixUnaryExpression(
+                                          ts.SyntaxKind.ExclamationToken,
+                                          factory.createCallExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createPropertyAccessExpression(
+                                                factory.createIdentifier('validation'),
+                                                factory.createIdentifier('strValues'),
+                                              ),
+                                              factory.createIdentifier('every'),
+                                            ),
+                                            undefined,
+                                            [
+                                              factory.createArrowFunction(
+                                                undefined,
+                                                undefined,
+                                                [
+                                                  factory.createParameterDeclaration(
+                                                    undefined,
+                                                    undefined,
+                                                    undefined,
+                                                    factory.createIdentifier('el'),
+                                                    undefined,
+                                                    factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+                                                    undefined,
+                                                  ),
+                                                ],
+                                                undefined,
+                                                factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                                                factory.createPrefixUnaryExpression(
+                                                  ts.SyntaxKind.ExclamationToken,
+                                                  factory.createCallExpression(
+                                                    factory.createPropertyAccessExpression(
+                                                      factory.createIdentifier('value'),
+                                                      factory.createIdentifier('includes'),
+                                                    ),
+                                                    undefined,
+                                                    [factory.createIdentifier('el')],
+                                                  ),
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('errorMessage'),
+                                        factory.createBinaryExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createIdentifier('validation'),
+                                            factory.createIdentifier('validationMessage'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.BarBarToken),
+                                          factory.createTemplateExpression(
+                                            factory.createTemplateHead(
+                                              'The value must not contain ',
+                                              'The value must not contain ',
+                                            ),
+                                            [
+                                              factory.createTemplateSpan(
+                                                factory.createCallExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createPropertyAccessExpression(
+                                                      factory.createIdentifier('validation'),
+                                                      factory.createIdentifier('strValues'),
+                                                    ),
+                                                    factory.createIdentifier('join'),
+                                                  ),
+                                                  undefined,
+                                                  [factory.createStringLiteral(', ')],
+                                                ),
+                                                factory.createTemplateTail('', ''),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ]),
+                              factory.createCaseClause(factory.createStringLiteral('BeAfter'), [
+                                factory.createVariableStatement(
+                                  undefined,
+                                  factory.createVariableDeclarationList(
+                                    [
+                                      factory.createVariableDeclaration(
+                                        factory.createIdentifier('afterTimeValue'),
+                                        undefined,
+                                        undefined,
+                                        factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [
+                                          factory.createElementAccessExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('validation'),
+                                              factory.createIdentifier('strValues'),
+                                            ),
+                                            factory.createNumericLiteral('0'),
+                                          ),
+                                        ]),
+                                      ),
+                                    ],
+                                    ts.NodeFlags.Const,
+                                  ),
+                                ),
+                                factory.createVariableStatement(
+                                  undefined,
+                                  factory.createVariableDeclarationList(
+                                    [
+                                      factory.createVariableDeclaration(
+                                        factory.createIdentifier('afterTimeValidator'),
+                                        undefined,
+                                        undefined,
+                                        factory.createConditionalExpression(
+                                          factory.createCallExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('Number'),
+                                              factory.createIdentifier('isNaN'),
+                                            ),
+                                            undefined,
+                                            [factory.createIdentifier('afterTimeValue')],
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.QuestionToken),
+                                          factory.createElementAccessExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('validation'),
+                                              factory.createIdentifier('strValues'),
+                                            ),
+                                            factory.createNumericLiteral('0'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.ColonToken),
+                                          factory.createIdentifier('afterTimeValue'),
+                                        ),
+                                      ),
+                                    ],
+                                    ts.NodeFlags.Const,
+                                  ),
+                                ),
+                                factory.createReturnStatement(
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('hasError'),
+                                        factory.createPrefixUnaryExpression(
+                                          ts.SyntaxKind.ExclamationToken,
+                                          factory.createParenthesizedExpression(
+                                            factory.createBinaryExpression(
+                                              factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
+                                                factory.createIdentifier('value'),
+                                              ]),
+                                              factory.createToken(ts.SyntaxKind.GreaterThanToken),
+                                              factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
+                                                factory.createIdentifier('afterTimeValidator'),
+                                              ]),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('errorMessage'),
+                                        factory.createBinaryExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createIdentifier('validation'),
+                                            factory.createIdentifier('validationMessage'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.BarBarToken),
+                                          factory.createTemplateExpression(
+                                            factory.createTemplateHead(
+                                              'The value must be after ',
+                                              'The value must be after ',
+                                            ),
+                                            [
+                                              factory.createTemplateSpan(
+                                                factory.createElementAccessExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createIdentifier('validation'),
+                                                    factory.createIdentifier('strValues'),
+                                                  ),
+                                                  factory.createNumericLiteral('0'),
+                                                ),
+                                                factory.createTemplateTail('', ''),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ]),
+                              factory.createCaseClause(factory.createStringLiteral('BeBefore'), [
+                                factory.createVariableStatement(
+                                  undefined,
+                                  factory.createVariableDeclarationList(
+                                    [
+                                      factory.createVariableDeclaration(
+                                        factory.createIdentifier('beforeTimeValue'),
+                                        undefined,
+                                        undefined,
+                                        factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [
+                                          factory.createElementAccessExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('validation'),
+                                              factory.createIdentifier('strValues'),
+                                            ),
+                                            factory.createNumericLiteral('0'),
+                                          ),
+                                        ]),
+                                      ),
+                                    ],
+                                    ts.NodeFlags.Const,
+                                  ),
+                                ),
+                                factory.createVariableStatement(
+                                  undefined,
+                                  factory.createVariableDeclarationList(
+                                    [
+                                      factory.createVariableDeclaration(
+                                        factory.createIdentifier('beforeTimevalue'),
+                                        undefined,
+                                        undefined,
+                                        factory.createConditionalExpression(
+                                          factory.createCallExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('Number'),
+                                              factory.createIdentifier('isNaN'),
+                                            ),
+                                            undefined,
+                                            [factory.createIdentifier('beforeTimeValue')],
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.QuestionToken),
+                                          factory.createElementAccessExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('validation'),
+                                              factory.createIdentifier('strValues'),
+                                            ),
+                                            factory.createNumericLiteral('0'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.ColonToken),
+                                          factory.createIdentifier('beforeTimeValue'),
+                                        ),
+                                      ),
+                                    ],
+                                    ts.NodeFlags.Const,
+                                  ),
+                                ),
+                                factory.createReturnStatement(
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('hasError'),
+                                        factory.createPrefixUnaryExpression(
+                                          ts.SyntaxKind.ExclamationToken,
+                                          factory.createParenthesizedExpression(
+                                            factory.createBinaryExpression(
+                                              factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
+                                                factory.createIdentifier('value'),
+                                              ]),
+                                              factory.createToken(ts.SyntaxKind.LessThanToken),
+                                              factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
+                                                factory.createIdentifier('beforeTimevalue'),
+                                              ]),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('errorMessage'),
+                                        factory.createBinaryExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createIdentifier('validation'),
+                                            factory.createIdentifier('validationMessage'),
+                                          ),
+                                          factory.createToken(ts.SyntaxKind.BarBarToken),
+                                          factory.createTemplateExpression(
+                                            factory.createTemplateHead(
+                                              'The value must be before ',
+                                              'The value must be before ',
+                                            ),
+                                            [
+                                              factory.createTemplateSpan(
+                                                factory.createElementAccessExpression(
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createIdentifier('validation'),
+                                                    factory.createIdentifier('strValues'),
+                                                  ),
+                                                  factory.createNumericLiteral('0'),
+                                                ),
+                                                factory.createTemplateTail('', ''),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ]),
+                            ]),
+                          ),
+                        ],
+                        true,
+                      ),
+                      undefined,
                     ),
+                  ),
+                  factory.createSwitchStatement(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('validation'),
+                      factory.createIdentifier('type'),
+                    ),
+                    factory.createCaseBlock([
+                      factory.createCaseClause(factory.createStringLiteral('Email'), [
+                        factory.createVariableStatement(
+                          undefined,
+                          factory.createVariableDeclarationList(
+                            [
+                              factory.createVariableDeclaration(
+                                factory.createIdentifier('EMAIL_ADDRESS_REGEX'),
+                                undefined,
+                                undefined,
+                                factory.createRegularExpressionLiteral(EscapedRegexLiterals.emailAddress),
+                              ),
+                            ],
+                            ts.NodeFlags.Const,
+                          ),
+                        ),
+                        factory.createReturnStatement(
+                          factory.createObjectLiteralExpression(
+                            [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('hasError'),
+                                factory.createPrefixUnaryExpression(
+                                  ts.SyntaxKind.ExclamationToken,
+                                  factory.createCallExpression(
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier('EMAIL_ADDRESS_REGEX'),
+                                      factory.createIdentifier('test'),
+                                    ),
+                                    undefined,
+                                    [factory.createIdentifier('value')],
+                                  ),
+                                ),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('errorMessage'),
+                                factory.createBinaryExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('validation'),
+                                    factory.createIdentifier('validationMessage'),
+                                  ),
+                                  factory.createToken(ts.SyntaxKind.BarBarToken),
+                                  factory.createStringLiteral('The value must be a valid email address'),
+                                ),
+                              ),
+                            ],
+                            true,
+                          ),
+                        ),
+                      ]),
+                      factory.createCaseClause(factory.createStringLiteral('JSON'), [
+                        factory.createVariableStatement(
+                          undefined,
+                          factory.createVariableDeclarationList(
+                            [
+                              factory.createVariableDeclaration(
+                                factory.createIdentifier('isInvalidJSON'),
+                                undefined,
+                                undefined,
+                                factory.createFalse(),
+                              ),
+                            ],
+                            ts.NodeFlags.Let,
+                          ),
+                        ),
+                        factory.createTryStatement(
+                          factory.createBlock(
+                            [
+                              factory.createExpressionStatement(
+                                factory.createCallExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('JSON'),
+                                    factory.createIdentifier('parse'),
+                                  ),
+                                  undefined,
+                                  [factory.createIdentifier('value')],
+                                ),
+                              ),
+                            ],
+                            true,
+                          ),
+                          factory.createCatchClause(
+                            factory.createVariableDeclaration(
+                              factory.createIdentifier('e'),
+                              undefined,
+                              undefined,
+                              undefined,
+                            ),
+                            factory.createBlock(
+                              [
+                                factory.createExpressionStatement(
+                                  factory.createBinaryExpression(
+                                    factory.createIdentifier('isInvalidJSON'),
+                                    factory.createToken(ts.SyntaxKind.EqualsToken),
+                                    factory.createTrue(),
+                                  ),
+                                ),
+                              ],
+                              true,
+                            ),
+                          ),
+                          undefined,
+                        ),
+                        factory.createReturnStatement(
+                          factory.createObjectLiteralExpression(
+                            [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('hasError'),
+                                factory.createIdentifier('isInvalidJSON'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('errorMessage'),
+                                factory.createBinaryExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('validation'),
+                                    factory.createIdentifier('validationMessage'),
+                                  ),
+                                  factory.createToken(ts.SyntaxKind.BarBarToken),
+                                  factory.createStringLiteral('The value must be in a correct JSON format'),
+                                ),
+                              ),
+                            ],
+                            true,
+                          ),
+                        ),
+                      ]),
+                      factory.createCaseClause(factory.createStringLiteral('IpAddress'), [
+                        factory.createVariableStatement(
+                          undefined,
+                          factory.createVariableDeclarationList(
+                            [
+                              factory.createVariableDeclaration(
+                                factory.createIdentifier('IPV_4'),
+                                undefined,
+                                undefined,
+                                factory.createRegularExpressionLiteral(EscapedRegexLiterals.ipv4),
+                              ),
+                            ],
+                            ts.NodeFlags.Const,
+                          ),
+                        ),
+                        factory.createVariableStatement(
+                          undefined,
+                          factory.createVariableDeclarationList(
+                            [
+                              factory.createVariableDeclaration(
+                                factory.createIdentifier('IPV_6'),
+                                undefined,
+                                undefined,
+                                factory.createRegularExpressionLiteral(EscapedRegexLiterals.ipv6),
+                              ),
+                            ],
+                            ts.NodeFlags.Const,
+                          ),
+                        ),
+                        factory.createReturnStatement(
+                          factory.createObjectLiteralExpression(
+                            [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('hasError'),
+                                factory.createPrefixUnaryExpression(
+                                  ts.SyntaxKind.ExclamationToken,
+                                  factory.createParenthesizedExpression(
+                                    factory.createBinaryExpression(
+                                      factory.createCallExpression(
+                                        factory.createPropertyAccessExpression(
+                                          factory.createIdentifier('IPV_4'),
+                                          factory.createIdentifier('test'),
+                                        ),
+                                        undefined,
+                                        [factory.createIdentifier('value')],
+                                      ),
+                                      factory.createToken(ts.SyntaxKind.BarBarToken),
+                                      factory.createCallExpression(
+                                        factory.createPropertyAccessExpression(
+                                          factory.createIdentifier('IPV_6'),
+                                          factory.createIdentifier('test'),
+                                        ),
+                                        undefined,
+                                        [factory.createIdentifier('value')],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('errorMessage'),
+                                factory.createBinaryExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('validation'),
+                                    factory.createIdentifier('validationMessage'),
+                                  ),
+                                  factory.createToken(ts.SyntaxKind.BarBarToken),
+                                  factory.createStringLiteral('The value must be an IPv4 or IPv6 address'),
+                                ),
+                              ),
+                            ],
+                            true,
+                          ),
+                        ),
+                      ]),
+                      factory.createCaseClause(factory.createStringLiteral('URL'), [
+                        factory.createVariableStatement(
+                          undefined,
+                          factory.createVariableDeclarationList(
+                            [
+                              factory.createVariableDeclaration(
+                                factory.createIdentifier('isInvalidUrl'),
+                                undefined,
+                                undefined,
+                                factory.createFalse(),
+                              ),
+                            ],
+                            ts.NodeFlags.Let,
+                          ),
+                        ),
+                        factory.createTryStatement(
+                          factory.createBlock(
+                            [
+                              factory.createExpressionStatement(
+                                factory.createNewExpression(factory.createIdentifier('URL'), undefined, [
+                                  factory.createIdentifier('value'),
+                                ]),
+                              ),
+                            ],
+                            true,
+                          ),
+                          factory.createCatchClause(
+                            factory.createVariableDeclaration(
+                              factory.createIdentifier('e'),
+                              undefined,
+                              undefined,
+                              undefined,
+                            ),
+                            factory.createBlock(
+                              [
+                                factory.createExpressionStatement(
+                                  factory.createBinaryExpression(
+                                    factory.createIdentifier('isInvalidUrl'),
+                                    factory.createToken(ts.SyntaxKind.EqualsToken),
+                                    factory.createTrue(),
+                                  ),
+                                ),
+                              ],
+                              true,
+                            ),
+                          ),
+                          undefined,
+                        ),
+                        factory.createReturnStatement(
+                          factory.createObjectLiteralExpression(
+                            [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('hasError'),
+                                factory.createIdentifier('isInvalidUrl'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('errorMessage'),
+                                factory.createBinaryExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('validation'),
+                                    factory.createIdentifier('validationMessage'),
+                                  ),
+                                  factory.createToken(ts.SyntaxKind.BarBarToken),
+                                  factory.createStringLiteral(
+                                    'The value must be a valid URL that begins with a schema (i.e. http:// or mailto:)',
+                                  ),
+                                ),
+                              ),
+                            ],
+                            true,
+                          ),
+                        ),
+                      ]),
+                      factory.createCaseClause(factory.createStringLiteral('Phone'), [
+                        factory.createVariableStatement(
+                          undefined,
+                          factory.createVariableDeclarationList(
+                            [
+                              factory.createVariableDeclaration(
+                                factory.createIdentifier('PHONE'),
+                                undefined,
+                                undefined,
+                                factory.createRegularExpressionLiteral(EscapedRegexLiterals.phone),
+                              ),
+                            ],
+                            ts.NodeFlags.Const,
+                          ),
+                        ),
+                        factory.createReturnStatement(
+                          factory.createObjectLiteralExpression(
+                            [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('hasError'),
+                                factory.createPrefixUnaryExpression(
+                                  ts.SyntaxKind.ExclamationToken,
+                                  factory.createCallExpression(
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier('PHONE'),
+                                      factory.createIdentifier('test'),
+                                    ),
+                                    undefined,
+                                    [factory.createIdentifier('value')],
+                                  ),
+                                ),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('errorMessage'),
+                                factory.createBinaryExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('validation'),
+                                    factory.createIdentifier('validationMessage'),
+                                  ),
+                                  factory.createToken(ts.SyntaxKind.BarBarToken),
+                                  factory.createStringLiteral('The value must be a valid phone number'),
+                                ),
+                              ),
+                            ],
+                            true,
+                          ),
+                        ),
+                      ]),
+                      factory.createDefaultClause([]),
+                    ]),
                   ),
                 ],
                 true,


### PR DESCRIPTION
## Problem
`validateField` reports no error for fields with multiple validations configured if it passes the first check, even if it would fail any of the remaining conditions.

## Solution
Refactor `validateField` to only return the result of a rule check if a validation error was found, allowing other configured rules to be checked.

## Additional Changes
n/a

## Verification
### Automated tests
- [x] Automated tests added
- [x] Automated tests updated
- [ ] N/A - (provide a reason)
