### PR TITLE
fix: update fix onSubmit types for ds and custom

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -15,13 +15,7 @@ import {
   TextField,
 } from \\"@aws-amplify/ui-react\\";
 export default function CustomDataForm(props) {
-  const {
-    onSubmit: customDataFormOnSubmit,
-    onCancel,
-    onValidate,
-    overrides,
-    ...rest
-  } = props;
+  const { onSubmit, onCancel, onValidate, overrides, ...rest } = props;
   const [name, setName] = React.useState(undefined);
   const [email, setEmail] = React.useState(undefined);
   const [city, setCity] = React.useState(undefined);
@@ -75,7 +69,7 @@ export default function CustomDataForm(props) {
         if (validationResponses.some((r) => r.hasError)) {
           return;
         }
-        await customDataFormOnSubmit(modelFields);
+        await onSubmit(modelFields);
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"CustomDataForm\\")}
@@ -235,7 +229,7 @@ export declare type CustomDataFormOverridesProps = {
 export declare type CustomDataFormProps = React.PropsWithChildren<{
     overrides?: CustomDataFormOverridesProps | undefined | null;
 } & {
-    onSubmit: (fields: Record<string, string>) => void;
+    onSubmit: (fields: Record<string, unknown>) => void;
     onCancel?: () => void;
     onValidate?: CustomDataFormInputValues;
 }>;
@@ -250,13 +244,7 @@ import { fetchByPath, validateField } from \\"./utils\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Button, Flex, Grid, Heading, TextField } from \\"@aws-amplify/ui-react\\";
 export default function NestedJson(props) {
-  const {
-    onSubmit: nestedJsonOnSubmit,
-    onCancel,
-    onValidate,
-    overrides,
-    ...rest
-  } = props;
+  const { onSubmit, onCancel, onValidate, overrides, ...rest } = props;
   const [firstName, setFirstName] = React.useState(undefined);
   const [lastName, setLastName] = React.useState(undefined);
   const [bio, setBio] = React.useState({});
@@ -308,7 +296,7 @@ export default function NestedJson(props) {
         if (validationResponses.some((r) => r.hasError)) {
           return;
         }
-        await nestedJsonOnSubmit(modelFields);
+        await onSubmit(modelFields);
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"NestedJson\\")}
@@ -441,7 +429,7 @@ export declare type NestedJsonOverridesProps = {
 export declare type NestedJsonProps = React.PropsWithChildren<{
     overrides?: NestedJsonOverridesProps | undefined | null;
 } & {
-    onSubmit: (fields: Record<string, string>) => void;
+    onSubmit: (fields: Record<string, unknown>) => void;
     onCancel?: () => void;
     onValidate?: NestedJsonInputValues;
 }>;
@@ -464,13 +452,7 @@ import {
   TextField,
 } from \\"@aws-amplify/ui-react\\";
 export default function CustomWithSectionalElements(props) {
-  const {
-    onSubmit: customWithSectionalElementsOnSubmit,
-    onCancel,
-    onValidate,
-    overrides,
-    ...rest
-  } = props;
+  const { onSubmit, onCancel, onValidate, overrides, ...rest } = props;
   const [name, setName] = React.useState(undefined);
   const [errors, setErrors] = React.useState({});
   const validations = {
@@ -515,7 +497,7 @@ export default function CustomWithSectionalElements(props) {
         if (validationResponses.some((r) => r.hasError)) {
           return;
         }
-        await customWithSectionalElementsOnSubmit(modelFields);
+        await onSubmit(modelFields);
       }}
       {...rest}
       {...getOverrideProps(overrides, \\"CustomWithSectionalElements\\")}
@@ -604,7 +586,7 @@ export declare type CustomWithSectionalElementsOverridesProps = {
 export declare type CustomWithSectionalElementsProps = React.PropsWithChildren<{
     overrides?: CustomWithSectionalElementsOverridesProps | undefined | null;
 } & {
-    onSubmit: (fields: Record<string, string>) => void;
+    onSubmit: (fields: Record<string, unknown>) => void;
     onCancel?: () => void;
     onValidate?: CustomWithSectionalElementsInputValues;
 }>;
@@ -622,9 +604,9 @@ import { Button, Flex, Grid, TextField } from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function MyPostForm(props) {
   const {
-    onSubmit,
     onSuccess,
     onError,
+    onSubmit,
     onCancel,
     onValidate,
     overrides,
@@ -683,8 +665,8 @@ export default function MyPostForm(props) {
         if (validationResponses.some((r) => r.hasError)) {
           return;
         }
-        if (onSubmitBefore) {
-          modelFields = onSubmitBefore(modelFields);
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
         }
         try {
           await DataStore.save(new Post(modelFields));
@@ -854,9 +836,9 @@ export default function MyPostForm(props) {
   const {
     id,
     post,
-    onSubmit,
     onSuccess,
     onError,
+    onSubmit,
     onCancel,
     onValidate,
     overrides,
@@ -932,8 +914,8 @@ export default function MyPostForm(props) {
         if (validationResponses.some((r) => r.hasError)) {
           return;
         }
-        if (onSubmitBefore) {
-          modelFields = onSubmitBefore(modelFields);
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
         }
         try {
           await DataStore.save(
@@ -1268,9 +1250,9 @@ function ArrayField({
 }
 export default function InputGalleryCreateForm(props) {
   const {
-    onSubmit,
     onSuccess,
     onError,
+    onSubmit,
     onCancel,
     onValidate,
     overrides,
@@ -1347,8 +1329,8 @@ export default function InputGalleryCreateForm(props) {
         if (validationResponses.some((r) => r.hasError)) {
           return;
         }
-        if (onSubmitBefore) {
-          modelFields = onSubmitBefore(modelFields);
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
         }
         try {
           await DataStore.save(new InputGallery(modelFields));

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -12,7 +12,7 @@ exports[`form-render utils should generate before & complete types if datastore 
 
 exports[`form-render utils should generate regular onsubmit if dataSourceType is custom 1`] = `
 "{
-    onSubmit: (fields: Record<string, string>) => void;
+    onSubmit: (fields: Record<string, unknown>) => void;
     onCancel?: () => void;
     onValidate?: myCustomFormInputValues;
 }"

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -51,7 +51,7 @@ describe('amplify form renderer tests', () => {
   describe('custom form tests', () => {
     it('should render a custom backed form', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer('forms/post-custom-create', undefined);
-      expect(componentText.replace(/\s/g, '')).toContain('onSubmit:customDataFormOnSubmit');
+      expect(componentText.replace(/\s/g, '')).toContain('onSubmit');
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -25,7 +25,6 @@ import { factory, JsxAttribute, JsxChild, JsxElement, JsxOpeningElement, Stateme
 import { ReactComponentRenderer } from '../react-component-renderer';
 import { buildOpeningElementProperties } from '../react-component-render-helper';
 import { ImportCollection } from '../imports';
-import { getActionIdentifier } from '../workflow';
 import { buildDataStoreExpression } from '../forms';
 import { onSubmitValidationRun, buildModelFieldObject } from '../forms/form-renderer-helper';
 
@@ -85,15 +84,13 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
       formActionType,
     } = this.form;
 
+    const onSubmitIdentifier = factory.createIdentifier('onSubmit');
+
     if (dataSourceType === 'Custom') {
       return [
         factory.createExpressionStatement(
           factory.createAwaitExpression(
-            factory.createCallExpression(
-              factory.createIdentifier(getActionIdentifier(this.form.name, 'onSubmit')),
-              undefined,
-              [factory.createIdentifier('modelFields')],
-            ),
+            factory.createCallExpression(onSubmitIdentifier, undefined, [factory.createIdentifier('modelFields')]),
           ),
         ),
       ];
@@ -101,14 +98,14 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
     if (dataSourceType === 'DataStore') {
       return [
         factory.createIfStatement(
-          factory.createIdentifier('onSubmitBefore'),
+          onSubmitIdentifier,
           factory.createBlock(
             [
               factory.createExpressionStatement(
                 factory.createBinaryExpression(
                   factory.createIdentifier('modelFields'),
                   factory.createToken(SyntaxKind.EqualsToken),
-                  factory.createCallExpression(factory.createIdentifier('onSubmitBefore'), undefined, [
+                  factory.createCallExpression(onSubmitIdentifier, undefined, [
                     factory.createIdentifier('modelFields'),
                   ]),
                 ),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -38,7 +38,6 @@ import {
 } from 'typescript';
 import { lowerCaseFirst } from '../helpers';
 import { ImportCollection, ImportSource } from '../imports';
-import { getActionIdentifier } from '../workflow';
 import { buildTargetVariable } from './event-targets';
 import { buildOnValidateType } from './type-helper';
 import { capitalizeFirstLetter, setFieldState } from './form-state';
@@ -52,6 +51,7 @@ export const buildMutationBindings = (form: StudioForm) => {
   if (dataSourceType === 'DataStore') {
     if (formActionType === 'update') {
       elements.push(
+        // TODO: change once cpk is supported in datastore
         factory.createBindingElement(undefined, undefined, factory.createIdentifier('id'), undefined),
         factory.createBindingElement(
           undefined,
@@ -62,20 +62,11 @@ export const buildMutationBindings = (form: StudioForm) => {
       );
     }
     elements.push(
-      factory.createBindingElement(undefined, undefined, factory.createIdentifier('onSubmit'), undefined),
       factory.createBindingElement(undefined, undefined, factory.createIdentifier('onSuccess'), undefined),
       factory.createBindingElement(undefined, undefined, factory.createIdentifier('onError'), undefined),
     );
-  } else {
-    elements.push(
-      factory.createBindingElement(
-        undefined,
-        factory.createIdentifier('onSubmit'),
-        getActionIdentifier(form.name, 'onSubmit'), // custom onsubmit function with the name of the form
-        undefined,
-      ),
-    );
   }
+  elements.push(factory.createBindingElement(undefined, undefined, factory.createIdentifier('onSubmit'), undefined));
   elements.push(factory.createBindingElement(undefined, undefined, factory.createIdentifier('onCancel'), undefined));
   return elements;
 };
@@ -211,7 +202,7 @@ export const buildFormPropNode = (form: StudioForm) => {
               undefined,
               factory.createTypeReferenceNode(factory.createIdentifier('Record'), [
                 factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
-                factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+                factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
               ]),
               undefined,
             ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- keep onSubmit naming function consistent between datastore and custom forms
- change types for onSubmit for custom forms to also use `Record<string, unknown>`
- remove instance of `onSubmitBefore` to avoid crashes when rendering form component

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
