### PR TITLE
fix: update form useEffect to conditionally change state if record is defined

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -851,12 +851,14 @@ export default function MyPostForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = id ? await DataStore.query(Post, id) : post;
-      setPostRecord(record);
-      setTextAreaFieldbbd63464(record.TextAreaFieldbbd63464);
-      setCaption(record.caption);
-      setUsername(record.username);
-      setProfile_url(record.profile_url);
-      setPost_url(record.post_url);
+      if (record) {
+        setPostRecord(record);
+        setTextAreaFieldbbd63464(record.TextAreaFieldbbd63464);
+        setCaption(record.caption);
+        setUsername(record.username);
+        setProfile_url(record.profile_url);
+        setPost_url(record.post_url);
+      }
     };
     queryData();
   }, [id, post]);

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -1136,10 +1136,36 @@ export const onSubmitValidationRun = [
   ),
 ];
 
-export const buildUpdateDatastoreQuery = (
-  dataTypeName: string,
-  fieldConfigs: Record<string, FieldConfigMetadata> | undefined,
-) => {
+export const ifRecordDefinedExpression = (dataTypeName: string, fieldConfigs: Record<string, FieldConfigMetadata>) => {
+  return factory.createIfStatement(
+    factory.createIdentifier('record'),
+    factory.createBlock(
+      [
+        factory.createExpressionStatement(
+          factory.createCallExpression(factory.createIdentifier(`set${dataTypeName}Record`), undefined, [
+            factory.createIdentifier('record'),
+          ]),
+        ),
+        ...Object.keys(fieldConfigs).map((field) =>
+          factory.createExpressionStatement(
+            factory.createCallExpression(factory.createIdentifier(`set${capitalizeFirstLetter(field)}`), undefined, [
+              factory.createPropertyAccessExpression(
+                factory.createIdentifier('record'),
+                factory.createIdentifier(field),
+              ),
+            ]),
+          ),
+        ),
+      ],
+      true,
+    ),
+    undefined,
+  );
+};
+
+export const buildUpdateDatastoreQuery = (dataTypeName: string, fieldConfigs: Record<string, FieldConfigMetadata>) => {
+  // TODO: update this once cpk is supported in datastore
+  const pkQueryIdentifier = factory.createIdentifier('id');
   return [
     factory.createVariableStatement(
       undefined,
@@ -1166,7 +1192,7 @@ export const buildUpdateDatastoreQuery = (
                           undefined,
                           undefined,
                           factory.createConditionalExpression(
-                            factory.createIdentifier('id'),
+                            pkQueryIdentifier,
                             factory.createToken(SyntaxKind.QuestionToken),
                             factory.createAwaitExpression(
                               factory.createCallExpression(
@@ -1175,7 +1201,7 @@ export const buildUpdateDatastoreQuery = (
                                   factory.createIdentifier('query'),
                                 ),
                                 undefined,
-                                [factory.createIdentifier(dataTypeName), factory.createIdentifier('id')],
+                                [factory.createIdentifier(dataTypeName), pkQueryIdentifier],
                               ),
                             ),
                             factory.createToken(SyntaxKind.ColonToken),
@@ -1186,27 +1212,7 @@ export const buildUpdateDatastoreQuery = (
                       NodeFlags.Const,
                     ),
                   ),
-                  factory.createExpressionStatement(
-                    factory.createCallExpression(factory.createIdentifier(`set${dataTypeName}Record`), undefined, [
-                      factory.createIdentifier('record'),
-                    ]),
-                  ),
-                  ...(fieldConfigs
-                    ? Object.keys(fieldConfigs).map((field) =>
-                        factory.createExpressionStatement(
-                          factory.createCallExpression(
-                            factory.createIdentifier(`set${capitalizeFirstLetter(field)}`),
-                            undefined,
-                            [
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier('record'),
-                                factory.createIdentifier(field),
-                              ),
-                            ],
-                          ),
-                        ),
-                      )
-                    : []),
+                  ifRecordDefinedExpression(dataTypeName, fieldConfigs),
                 ],
                 true,
               ),

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -385,7 +385,8 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
         );
         statements.push(
           addUseEffectWrapper(
-            buildUpdateDatastoreQuery(dataTypeName, this.componentMetadata.formMetadata?.fieldConfigs),
+            buildUpdateDatastoreQuery(dataTypeName, formMetadata.fieldConfigs),
+            // TODO: change once cpk is supported in datastore
             ['id', lowerCaseDataTypeName],
           ),
         );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
updates the useEffect hook to only update state if record is defined from datastore query
```js
React.useEffect(() => {
    const queryData = async () => {
      const record = id ? await DataStore.query(Post, id) : post;
      if (record) {
        setPostRecord(record);
        setTextAreaFieldbbd63464(record.TextAreaFieldbbd63464);
        setCaption(record.caption);
        setUsername(record.username);
        setProfile_url(record.profile_url);
        setPost_url(record.post_url);
      }
    };
    queryData();
  }, [id, post]);
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
