### PR TITLE
fix: include minimum breakpoints required

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -241,10 +241,14 @@ describe('amplify render tests', () => {
     });
 
     it('should have breakpoint specific generation', () => {
-      const generatedCode = generateWithAmplifyRenderer('componentWithBreakpoint');
-      expect(generatedCode.componentText.includes('restProp')).toBe(true);
-      expect(generatedCode.componentText.includes('breakpointHook')).toBe(true);
-      expect(generatedCode.componentText.includes('breakpoint: breakpointHook')).toBe(true);
+      const { componentText } = generateWithAmplifyRenderer('componentWithBreakpoint');
+      expect(componentText).toContain('restProp');
+      expect(componentText).toContain('breakpointHook');
+      expect(componentText).toContain('breakpoint: breakpointHook');
+      expect(componentText).toContain('base: "small",');
+      expect(componentText).toContain('small: "small",');
+      expect(componentText).toContain('medium: "medium",');
+      expect(componentText).not.toContain('large: "large"');
     });
   });
 

--- a/packages/codegen-ui/lib/renderer-helper.ts
+++ b/packages/codegen-ui/lib/renderer-helper.ts
@@ -25,6 +25,7 @@ import {
   StudioComponentProperty,
   StudioComponentSlotBinding,
 } from './types';
+import { breakpointSizes, BreakpointSizeType } from './utils/breakpoint-utils';
 
 export function isStudioComponentWithBinding(
   component: StudioComponent | StudioComponentChild,
@@ -56,9 +57,9 @@ export function isStudioComponentWithBreakpoints(
   component: StudioComponent | StudioComponentChild,
 ): component is StudioComponent & Required<Pick<StudioComponent, 'variants'>> {
   if (isStudioComponentWithVariants(component)) {
-    return Object.keys(component.variants)
-      .map((i) => component.variants[Number(i)].variantValues.breakpoint !== undefined)
-      .includes(true);
+    return component.variants.some((variant) =>
+      breakpointSizes.includes(variant?.variantValues?.breakpoint as BreakpointSizeType),
+    );
   }
   return false;
 }

--- a/packages/codegen-ui/lib/utils/breakpoint-utils.ts
+++ b/packages/codegen-ui/lib/utils/breakpoint-utils.ts
@@ -1,0 +1,49 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { StudioComponent } from '../types';
+
+export const breakpointSizes = ['base', 'small', 'medium', 'large', 'xl', 'xxl'] as const;
+export type BreakpointSizeType = typeof breakpointSizes[number];
+export const bpWeights: Record<BreakpointSizeType, number> = {
+  base: 0,
+  small: 1,
+  medium: 2,
+  large: 3,
+  xl: 4,
+  xxl: 5,
+};
+
+/**
+ * sorts the breakpoints to the following order
+ *
+ * ['base', 'small', 'medium', 'large', 'xl', 'xxl']
+ */
+export const sortBreakpoints = (bs: BreakpointSizeType[]): BreakpointSizeType[] => {
+  return bs.sort((lhs, rhs) => {
+    return bpWeights[lhs] - bpWeights[rhs];
+  });
+};
+
+export const getBreakpoints = (component: StudioComponent & Required<Pick<StudioComponent, 'variants'>>) => {
+  const breakpoints = component.variants.reduce<BreakpointSizeType[]>((acc, variant) => {
+    if (variant.variantValues?.breakpoint) {
+      acc.push(variant.variantValues.breakpoint as BreakpointSizeType);
+    }
+    return acc;
+  }, []);
+  return sortBreakpoints(breakpoints);
+};

--- a/packages/codegen-ui/lib/utils/index.ts
+++ b/packages/codegen-ui/lib/utils/index.ts
@@ -19,3 +19,4 @@ export * from './state-reference-metadata';
 export * from './string-formatter';
 export * from './form-component-metadata';
 export * from './form-to-component';
+export * from './breakpoint-utils';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- adds the minimum amount of breakpoint configs required for the hook to work
- sorts the breakpoints according to size as the base will use the smallest size if not specified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
