### PR TITLE
fix: add state to controlled components

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -22,7 +22,7 @@ export default function CustomDataForm(props) {
   const [email, setEmail] = React.useState(undefined);
   const [city, setCity] = React.useState(undefined);
   const [category, setCategory] = React.useState(undefined);
-  const [pages, setPages] = React.useState(undefined);
+  const [pages, setPages] = React.useState(0);
   const [errors, setErrors] = React.useState({});
   const validations = {
     name: [{ type: \\"Required\\" }],
@@ -135,6 +135,8 @@ export default function CustomDataForm(props) {
       ></TextField>
       <SelectField
         label=\\"Label\\"
+        placeholder=\\"Please select an option\\"
+        value={city}
         onChange={async (e) => {
           let { value } = e.target;
           if (onChange) {
@@ -220,6 +222,7 @@ export default function CustomDataForm(props) {
       </RadioGroupField>
       <StepperField
         label=\\"Label\\"
+        value={pages}
         onStepChange={async (e) => {
           let value = e;
           if (onChange) {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -559,11 +559,30 @@ export const buildComponentSpecificAttributes = ({
   componentType: string;
   componentName: string;
 }) => {
+  const stateName = componentName.split('.')[0];
   const componentToAttributesMap: { [key: string]: JsxAttribute[] } = {
     ToggleButton: [
       factory.createJsxAttribute(
         factory.createIdentifier('isPressed'),
-        factory.createJsxExpression(undefined, factory.createIdentifier(componentName)),
+        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+      ),
+    ],
+    SliderField: [
+      factory.createJsxAttribute(
+        factory.createIdentifier('value'),
+        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+      ),
+    ],
+    SelectField: [
+      factory.createJsxAttribute(
+        factory.createIdentifier('value'),
+        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+      ),
+    ],
+    StepperField: [
+      factory.createJsxAttribute(
+        factory.createIdentifier('value'),
+        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
       ),
     ],
   };

--- a/packages/codegen-ui-react/lib/forms/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-state.ts
@@ -41,6 +41,8 @@ export const getDefaultValueExpression = (
 ): Expression => {
   const componentTypeToDefaultValueMap: { [key: string]: Expression } = {
     ToggleButton: factory.createFalse(),
+    StepperField: factory.createNumericLiteral(0),
+    SliderField: factory.createNumericLiteral(0),
   };
 
   // it's a nonModel or relationship object

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
@@ -302,7 +302,7 @@ describe('getFormDefinitionInputElement', () => {
 
     expect(getFormDefinitionInputElement(config)).toStrictEqual({
       componentType: 'SelectField',
-      props: { label: 'Label', isDisabled: true },
+      props: { label: 'Label', isDisabled: true, placeholder: 'Please select an option' },
       valueMappings: {
         values: [{ value: { value: 'value1' }, displayvalue: { value: 'displayValue1' } }],
         bindingProperties: {},

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -214,7 +214,7 @@ export function getFormDefinitionInputElement(
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           descriptiveText: config.inputType?.descriptiveText ?? baseConfig?.inputType?.descriptiveText,
-          placeholder: config.inputType?.placeholder || baseConfig?.inputType?.placeholder,
+          placeholder: config.inputType?.placeholder || baseConfig?.inputType?.placeholder || 'Please select an option',
           isDisabled: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
         },
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- adding state to controlled components so they get updated with the default value
- selectField as a default placeholder before the state is updated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
