### PR TITLE
fix: remove ArrayField items state and change onBlur to validate inpu…

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1957,7 +1957,7 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
-  defaultValues = [],
+  items = [],
   onChange,
   inputFieldRef,
   children,
@@ -1966,23 +1966,19 @@ function ArrayField({
   currentFieldValue,
 }) {
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
-  const [items, setItems] = React.useState(defaultValues);
   const removeItem = async (removeIndex) => {
     const newItems = items.filter((value, index) => index !== removeIndex);
     await onChange(newItems);
     setSelectedBadgeIndex(undefined);
-    setItems(newItems);
   };
   const addItem = async () => {
     if (currentFieldValue.length && !hasError) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;
-        setItems(newItems);
         setSelectedBadgeIndex(undefined);
       } else {
         newItems.push(currentFieldValue);
-        setItems(newItems);
       }
       await onChange(newItems);
     }
@@ -2332,6 +2328,7 @@ export default function InputGalleryCreateForm(props) {
           setCurrentArrayTypeFieldValue(\\"\\");
         }}
         currentFieldValue={currentArrayTypeFieldValue}
+        items={arrayTypeField}
         hasError={errors.arrayTypeField?.hasError}
         setFieldValue={setCurrentArrayTypeFieldValue}
         inputFieldRef={arrayTypeFieldRef}
@@ -2363,7 +2360,10 @@ export default function InputGalleryCreateForm(props) {
             setCurrentArrayTypeFieldValue(value);
           }}
           onBlur={async () =>
-            await runValidationTasks(\\"arrayTypeField\\", arrayTypeField)
+            await runValidationTasks(
+              \\"arrayTypeField\\",
+              currentArrayTypeFieldValue
+            )
           }
           errorMessage={errors.arrayTypeField?.errorMessage}
           hasError={errors.arrayTypeField?.hasError}
@@ -2570,7 +2570,7 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
-  defaultValues = [],
+  items = [],
   onChange,
   inputFieldRef,
   children,
@@ -2579,23 +2579,19 @@ function ArrayField({
   currentFieldValue,
 }) {
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
-  const [items, setItems] = React.useState(defaultValues);
   const removeItem = async (removeIndex) => {
     const newItems = items.filter((value, index) => index !== removeIndex);
     await onChange(newItems);
     setSelectedBadgeIndex(undefined);
-    setItems(newItems);
   };
   const addItem = async () => {
     if (currentFieldValue.length && !hasError) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;
-        setItems(newItems);
         setSelectedBadgeIndex(undefined);
       } else {
         newItems.push(currentFieldValue);
-        setItems(newItems);
       }
       await onChange(newItems);
     }
@@ -2978,6 +2974,7 @@ export default function InputGalleryCreateForm(props) {
           setCurrentArrayTypeFieldValue(\\"\\");
         }}
         currentFieldValue={currentArrayTypeFieldValue}
+        items={arrayTypeField}
         hasError={errors.arrayTypeField?.hasError}
         setFieldValue={setCurrentArrayTypeFieldValue}
         inputFieldRef={arrayTypeFieldRef}
@@ -3009,7 +3006,10 @@ export default function InputGalleryCreateForm(props) {
             setCurrentArrayTypeFieldValue(value);
           }}
           onBlur={async () =>
-            await runValidationTasks(\\"arrayTypeField\\", arrayTypeField)
+            await runValidationTasks(
+              \\"arrayTypeField\\",
+              currentArrayTypeFieldValue
+            )
           }
           errorMessage={errors.arrayTypeField?.errorMessage}
           hasError={errors.arrayTypeField?.hasError}

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -156,7 +156,7 @@ export const addFormAttributes = (component: StudioComponent | StudioComponentCh
       );
     }
     attributes.push(buildOnChangeStatement(component, formMetadata.fieldConfigs));
-    attributes.push(buildOnBlurStatement(componentName));
+    attributes.push(buildOnBlurStatement(componentName, fieldConfig.isArray));
     attributes.push(
       factory.createJsxAttribute(
         factory.createIdentifier('errorMessage'),
@@ -307,7 +307,7 @@ function getOnChangeValidationBlock(fieldName: string) {
   );
 }
 
-export function buildOnBlurStatement(fieldName: string) {
+export function buildOnBlurStatement(fieldName: string, isArray: boolean | undefined) {
   return factory.createJsxAttribute(
     factory.createIdentifier('onBlur'),
     factory.createJsxExpression(
@@ -321,7 +321,7 @@ export function buildOnBlurStatement(fieldName: string) {
         factory.createAwaitExpression(
           factory.createCallExpression(factory.createIdentifier('runValidationTasks'), undefined, [
             factory.createStringLiteral(fieldName),
-            factory.createIdentifier(fieldName),
+            factory.createIdentifier(isArray ? `current${capitalizeFirstLetter(fieldName)}Value` : fieldName),
           ]),
         ),
       ),

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -34,7 +34,7 @@ export const generateArrayFieldComponent = () => {
           factory.createBindingElement(
             undefined,
             undefined,
-            factory.createIdentifier('defaultValues'),
+            factory.createIdentifier('items'),
             factory.createArrayLiteralExpression([], false),
           ),
           factory.createBindingElement(undefined, undefined, factory.createIdentifier('onChange'), undefined),
@@ -80,30 +80,6 @@ export const generateArrayFieldComponent = () => {
                   ),
                   undefined,
                   [],
-                ),
-              ),
-            ],
-            NodeFlags.Const,
-          ),
-        ),
-        factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                factory.createArrayBindingPattern([
-                  factory.createBindingElement(undefined, undefined, factory.createIdentifier('items'), undefined),
-                  factory.createBindingElement(undefined, undefined, factory.createIdentifier('setItems'), undefined),
-                ]),
-                undefined,
-                undefined,
-                factory.createCallExpression(
-                  factory.createPropertyAccessExpression(
-                    factory.createIdentifier('React'),
-                    factory.createIdentifier('useState'),
-                  ),
-                  undefined,
-                  [factory.createIdentifier('defaultValues')],
                 ),
               ),
             ],
@@ -198,11 +174,6 @@ export const generateArrayFieldComponent = () => {
                           factory.createIdentifier('undefined'),
                         ]),
                       ),
-                      factory.createExpressionStatement(
-                        factory.createCallExpression(factory.createIdentifier('setItems'), undefined, [
-                          factory.createIdentifier('newItems'),
-                        ]),
-                      ),
                     ],
                     true,
                   ),
@@ -278,11 +249,6 @@ export const generateArrayFieldComponent = () => {
                                     ),
                                   ),
                                   factory.createExpressionStatement(
-                                    factory.createCallExpression(factory.createIdentifier('setItems'), undefined, [
-                                      factory.createIdentifier('newItems'),
-                                    ]),
-                                  ),
-                                  factory.createExpressionStatement(
                                     factory.createCallExpression(
                                       factory.createIdentifier('setSelectedBadgeIndex'),
                                       undefined,
@@ -303,11 +269,6 @@ export const generateArrayFieldComponent = () => {
                                       undefined,
                                       [factory.createIdentifier('currentFieldValue')],
                                     ),
-                                  ),
-                                  factory.createExpressionStatement(
-                                    factory.createCallExpression(factory.createIdentifier('setItems'), undefined, [
-                                      factory.createIdentifier('newItems'),
-                                    ]),
                                   ),
                                 ],
                                 true,
@@ -848,6 +809,10 @@ export const renderArrayFieldComponent = (fieldName: string, inputField: JsxChil
             undefined,
             factory.createIdentifier(`current${capitalizeFirstLetter(fieldName)}Value`),
           ),
+        ),
+        factory.createJsxAttribute(
+          factory.createIdentifier('items'),
+          factory.createJsxExpression(undefined, factory.createIdentifier(fieldName)),
         ),
         factory.createJsxAttribute(
           factory.createIdentifier('hasError'),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove items state management from ArrayField
- Change ArrayField child input field onBlur validation to current input field value instead of validating all array items

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
