### PR TITLE
fix: onClear to reset state values and errors

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -24,6 +24,14 @@ export default function CustomDataForm(props) {
   const [category, setCategory] = React.useState(undefined);
   const [pages, setPages] = React.useState(0);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setName(undefined);
+    setEmail(undefined);
+    setCity(undefined);
+    setCategory(undefined);
+    setPages(0);
+    setErrors({});
+  };
   const validations = {
     name: [{ type: \\"Required\\" }],
     email: [{ type: \\"Required\\" }],
@@ -253,6 +261,9 @@ export default function CustomDataForm(props) {
         <Button
           children=\\"empty\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -341,6 +352,14 @@ export default function CustomDataForm(props) {
   const [category, setCategory] = React.useState(undefined);
   const [pages, setPages] = React.useState(0);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setName(undefined);
+    setEmail(undefined);
+    setCity(undefined);
+    setCategory(undefined);
+    setPages(0);
+    setErrors({});
+  };
   React.useEffect(() => {
     if (initialData) {
       setName(initialData.name);
@@ -582,6 +601,9 @@ export default function CustomDataForm(props) {
         <Button
           children=\\"empty\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -660,6 +682,12 @@ export default function NestedJson(props) {
   const [lastName, setLastName] = React.useState(undefined);
   const [bio, setBio] = React.useState({});
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setFirstName(undefined);
+    setLastName(undefined);
+    setBio({});
+    setErrors({});
+  };
   const validations = {
     firstName: [],
     lastName: [],
@@ -820,6 +848,9 @@ export default function NestedJson(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -898,6 +929,12 @@ export default function NestedJson(props) {
   const [lastName, setLastName] = React.useState(undefined);
   const [bio, setBio] = React.useState({});
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setFirstName(undefined);
+    setLastName(undefined);
+    setBio({});
+    setErrors({});
+  };
   React.useEffect(() => {
     if (initialData) {
       setFirstName(initialData.firstName);
@@ -1069,6 +1106,9 @@ export default function NestedJson(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -1154,6 +1194,10 @@ export default function CustomWithSectionalElements(props) {
     props;
   const [name, setName] = React.useState(undefined);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setName(undefined);
+    setErrors({});
+  };
   const validations = {
     name: [],
   };
@@ -1242,6 +1286,9 @@ export default function CustomWithSectionalElements(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -1325,6 +1372,13 @@ export default function MyPostForm(props) {
   const [post_url, setPost_url] = React.useState(undefined);
   const [profile_url, setProfile_url] = React.useState(undefined);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setCaption(undefined);
+    setUsername(undefined);
+    setPost_url(undefined);
+    setProfile_url(undefined);
+    setErrors({});
+  };
   const validations = {
     caption: [],
     username: [],
@@ -1397,6 +1451,9 @@ export default function MyPostForm(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -1601,6 +1658,14 @@ export default function MyPostForm(props) {
   const [profile_url, setProfile_url] = React.useState(undefined);
   const [post_url, setPost_url] = React.useState(undefined);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setTextAreaFieldbbd63464(undefined);
+    setCaption(undefined);
+    setUsername(undefined);
+    setProfile_url(undefined);
+    setPost_url(undefined);
+    setErrors({});
+  };
   const [postRecord, setPostRecord] = React.useState(post);
   React.useEffect(() => {
     const queryData = async () => {
@@ -1694,6 +1759,9 @@ export default function MyPostForm(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -1866,6 +1934,9 @@ export default function MyPostForm(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -2072,6 +2143,19 @@ export default function InputGalleryCreateForm(props) {
   const [ippy, setIppy] = React.useState(undefined);
   const [timeisnow, setTimeisnow] = React.useState(undefined);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setNum(undefined);
+    setRootbeer(undefined);
+    setAttend(undefined);
+    setMaybeSlide(false);
+    setMaybeCheck(undefined);
+    setArrayTypeField(undefined);
+    setCurrentArrayTypeFieldValue(undefined);
+    setTimestamp(undefined);
+    setIppy(undefined);
+    setTimeisnow(undefined);
+    setErrors({});
+  };
   const [currentArrayTypeFieldValue, setCurrentArrayTypeFieldValue] =
     React.useState(\\"\\");
   const arrayTypeFieldRef = React.createRef();
@@ -2474,6 +2558,9 @@ export default function InputGalleryCreateForm(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -2687,6 +2774,19 @@ export default function InputGalleryCreateForm(props) {
   const [ippy, setIppy] = React.useState(undefined);
   const [timeisnow, setTimeisnow] = React.useState(undefined);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setNum(undefined);
+    setRootbeer(undefined);
+    setAttend(undefined);
+    setMaybeSlide(false);
+    setMaybeCheck(undefined);
+    setArrayTypeField(undefined);
+    setCurrentArrayTypeFieldValue(undefined);
+    setTimestamp(undefined);
+    setIppy(undefined);
+    setTimeisnow(undefined);
+    setErrors({});
+  };
   const [inputGalleryRecord, setInputGalleryRecord] =
     React.useState(inputGallery);
   React.useEffect(() => {
@@ -3123,6 +3223,9 @@ export default function InputGalleryCreateForm(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>
@@ -3231,6 +3334,14 @@ export default function PostCreateFormRow(props) {
   const [profile_url, setProfile_url] = React.useState(undefined);
   const [status, setStatus] = React.useState(undefined);
   const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setUsername(undefined);
+    setCaption(undefined);
+    setPost_url(undefined);
+    setProfile_url(undefined);
+    setStatus(undefined);
+    setErrors({});
+  };
   const validations = {
     username: [
       {
@@ -3459,6 +3570,9 @@ export default function PostCreateFormRow(props) {
         <Button
           children=\\"Clear\\"
           type=\\"reset\\"
+          onClick={() => {
+            resetStateValues();
+          }}
           {...getOverrideProps(overrides, \\"ClearButton\\")}
         ></Button>
         <Flex {...getOverrideProps(overrides, \\"SubmitAndResetFlex\\")}>

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -69,7 +69,7 @@ import {
   buildValidations,
   runValidationTasksFunction,
 } from './form-renderer-helper';
-import { buildUseStateExpression, capitalizeFirstLetter, getUseStateHooks } from './form-state';
+import { buildUseStateExpression, getCurrentValueName, getUseStateHooks, resetStateFunction } from './form-state';
 import {
   buildFormPropNode,
   baseValidationConditionalType,
@@ -374,6 +374,8 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     statements.push(buildUseStateExpression('errors', factory.createObjectLiteralExpression()));
 
+    statements.push(resetStateFunction(formMetadata.fieldConfigs));
+
     this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD);
     this.importCollection.addMappedImport(ImportValue.FETCH_BY_PATH);
 
@@ -402,7 +404,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     Object.entries(formMetadata.fieldConfigs).forEach(([field, config]) => {
       if (config.isArray) {
         statements.push(
-          buildUseStateExpression(`current${capitalizeFirstLetter(field)}Value`, factory.createStringLiteral('')),
+          buildUseStateExpression(getCurrentValueName(field), factory.createStringLiteral('')),
           factory.createVariableStatement(
             undefined,
             factory.createVariableDeclarationList(

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -14,7 +14,12 @@
   limitations under the License.
  */
 import { factory, JsxChild, JsxTagNamePropertyAccess, NodeFlags, SyntaxKind } from 'typescript';
-import { capitalizeFirstLetter } from '../../forms/form-state';
+import {
+  capitalizeFirstLetter,
+  getCurrentValueIdentifier,
+  getCurrentValueName,
+  getSetNameIdentifier,
+} from '../../forms/form-state';
 import { lowerCaseFirst } from '../../helpers';
 
 export const generateArrayFieldComponent = () => {
@@ -756,8 +761,10 @@ export const generateArrayFieldComponent = () => {
   </ArrayField>
  */
 
-export const renderArrayFieldComponent = (fieldName: string, inputField: JsxChild) =>
-  factory.createJsxElement(
+export const renderArrayFieldComponent = (fieldName: string, inputField: JsxChild) => {
+  const stateName = getCurrentValueIdentifier(fieldName);
+  const setStateName = getSetNameIdentifier(getCurrentValueName(fieldName));
+  return factory.createJsxElement(
     factory.createJsxOpeningElement(
       factory.createIdentifier('ArrayField'),
       undefined,
@@ -791,11 +798,7 @@ export const renderArrayFieldComponent = (fieldName: string, inputField: JsxChil
                     ),
                   ),
                   factory.createExpressionStatement(
-                    factory.createCallExpression(
-                      factory.createIdentifier(`setCurrent${capitalizeFirstLetter(fieldName)}Value`),
-                      undefined,
-                      [factory.createStringLiteral('')],
-                    ),
+                    factory.createCallExpression(setStateName, undefined, [factory.createStringLiteral('')]),
                   ),
                 ],
                 true,
@@ -805,10 +808,7 @@ export const renderArrayFieldComponent = (fieldName: string, inputField: JsxChil
         ),
         factory.createJsxAttribute(
           factory.createIdentifier(`currentFieldValue`),
-          factory.createJsxExpression(
-            undefined,
-            factory.createIdentifier(`current${capitalizeFirstLetter(fieldName)}Value`),
-          ),
+          factory.createJsxExpression(undefined, stateName),
         ),
         factory.createJsxAttribute(
           factory.createIdentifier('items'),
@@ -830,10 +830,7 @@ export const renderArrayFieldComponent = (fieldName: string, inputField: JsxChil
         ),
         factory.createJsxAttribute(
           factory.createIdentifier('setFieldValue'),
-          factory.createJsxExpression(
-            undefined,
-            factory.createIdentifier(`setCurrent${capitalizeFirstLetter(fieldName)}Value`),
-          ),
+          factory.createJsxExpression(undefined, setStateName),
         ),
         factory.createJsxAttribute(
           factory.createIdentifier('inputFieldRef'),
@@ -844,3 +841,4 @@ export const renderArrayFieldComponent = (fieldName: string, inputField: JsxChil
     [inputField],
     factory.createJsxClosingElement(factory.createIdentifier('ArrayField')),
   );
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- create reset values functions to reset state with the reset button
- add helper methods for setting set
- unify name source for setCurrentValue in arrayfield

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
