### PR TITLE
fix: handle nullable child arrays

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -2078,7 +2078,7 @@ function ArrayField({
           </Button>
         </Flex>
       )}
-      {!!items.length && (
+      {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
             return (
@@ -2724,7 +2724,7 @@ function ArrayField({
           </Button>
         </Flex>
       )}
-      {!!items.length && (
+      {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
             return (

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -537,8 +537,9 @@ export const generateArrayFieldComponent = () => {
                   SyntaxKind.ExclamationToken,
                   factory.createPrefixUnaryExpression(
                     SyntaxKind.ExclamationToken,
-                    factory.createPropertyAccessExpression(
+                    factory.createPropertyAccessChain(
                       factory.createIdentifier('items'),
+                      factory.createToken(SyntaxKind.QuestionDotToken),
                       factory.createIdentifier('length'),
                     ),
                   ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If an child arrays is null, we were throwing an array. This fix adds a nullable operator to handle this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
