### PR TITLE
fix: reset custom update form to initial data

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -372,13 +372,15 @@ export default function CustomDataForm(props) {
   const [pages, setPages] = React.useState(initialValues.pages);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
-    setName(initialValues.name);
-    setEmail(initialValues.email);
-    setCity(initialValues.city);
-    setCategory(initialValues.category);
-    setPages(initialValues.pages);
+    const cleanValues = { ...initialValues, ...initialData };
+    setName(cleanValues.name);
+    setEmail(cleanValues.email);
+    setCity(cleanValues.city);
+    setCategory(cleanValues.category);
+    setPages(cleanValues.pages);
     setErrors({});
   };
+  React.useEffect(resetStateValues, [initialData]);
   React.useEffect(() => {
     if (initialData) {
       setName(initialData.name);
@@ -2233,13 +2235,15 @@ export default function NestedJson(props) {
   const [bio, setBio] = React.useState(initialValues.bio);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
-    setFirstName(initialValues.firstName);
-    setLastName(initialValues[\\"last-Name\\"]);
-    setLastName1(initialValues.lastName);
+    const cleanValues = { ...initialValues, ...initialData };
+    setFirstName(cleanValues.firstName);
+    setLastName(cleanValues[\\"last-Name\\"]);
+    setLastName1(cleanValues.lastName);
     setCurrentLastName1Value(undefined);
-    setBio(initialValues.bio);
+    setBio(cleanValues.bio);
     setErrors({});
   };
+  React.useEffect(resetStateValues, [initialData]);
   React.useEffect(() => {
     if (initialData) {
       setFirstName(initialData.firstName);
@@ -3038,6 +3042,7 @@ export default function MyPostForm(props) {
     setPost_url(cleanValues.post_url);
     setErrors({});
   };
+  React.useEffect(resetStateValues, [postRecord]);
   const [postRecord, setPostRecord] = React.useState(post);
   React.useEffect(() => {
     const queryData = async () => {
@@ -3046,7 +3051,6 @@ export default function MyPostForm(props) {
     };
     queryData();
   }, [id, post]);
-  React.useEffect(resetStateValues, [postRecord]);
   const validations = {
     TextAreaFieldbbd63464: [],
     caption: [],
@@ -4540,6 +4544,7 @@ export default function InputGalleryCreateForm(props) {
     setTimeisnow(cleanValues.timeisnow);
     setErrors({});
   };
+  React.useEffect(resetStateValues, [inputGalleryRecord]);
   const [inputGalleryRecord, setInputGalleryRecord] =
     React.useState(inputGallery);
   React.useEffect(() => {
@@ -4551,7 +4556,6 @@ export default function InputGalleryCreateForm(props) {
     };
     queryData();
   }, [id, inputGallery]);
-  React.useEffect(resetStateValues, [inputGalleryRecord]);
   const [currentArrayTypeFieldValue, setCurrentArrayTypeFieldValue] =
     React.useState(undefined);
   const arrayTypeFieldRef = React.createRef();

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -407,9 +407,20 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     statements.push(...getUseStateHooks(formMetadata.fieldConfigs));
     statements.push(buildUseStateExpression('errors', factory.createObjectLiteralExpression()));
 
-    statements.push(
-      resetStateFunction(formMetadata.fieldConfigs, isDataStoreUpdateForm ? lowerCaseDataTypeNameRecord : undefined),
-    );
+    let defaultValueVariableName: undefined | string;
+    if (formActionType === 'update') {
+      if (isDataStoreUpdateForm) {
+        defaultValueVariableName = lowerCaseDataTypeNameRecord;
+      } else {
+        defaultValueVariableName = 'initialData';
+      }
+    }
+
+    statements.push(resetStateFunction(formMetadata.fieldConfigs, defaultValueVariableName));
+
+    if (defaultValueVariableName) {
+      statements.push(buildResetValuesOnRecordUpdate(defaultValueVariableName));
+    }
 
     if (isDataStoreUpdateForm) {
       statements.push(
@@ -422,8 +433,6 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
           ['id', lowerCaseDataTypeName],
         ),
       );
-
-      statements.push(buildResetValuesOnRecordUpdate(lowerCaseDataTypeNameRecord));
     }
 
     this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD);


### PR DESCRIPTION
*Description of changes:*
1. Use `initialData` when resetting form
2. Change initial values whenever `initialData` changes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
