### PR TITLE
fix: timestamp formatting in defaultValue

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3392,25 +3392,25 @@ export default function BlogCreateForm(props) {
     title: undefined,
     content: undefined,
     switch: false,
-    authorName: undefined,
+    published: undefined,
   };
   const [title, setTitle] = React.useState(initialValues.title);
   const [content, setContent] = React.useState(initialValues.content);
   const [switch1, setSwitch1] = React.useState(initialValues.switch);
-  const [authorName, setAuthorName] = React.useState(initialValues.authorName);
+  const [published, setPublished] = React.useState(initialValues.published);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     setTitle(initialValues.title);
     setContent(initialValues.content);
     setSwitch1(initialValues.switch);
-    setAuthorName(initialValues.authorName);
+    setPublished(initialValues.published);
     setErrors({});
   };
   const validations = {
     title: [],
     content: [],
     switch: [],
-    authorName: [],
+    published: [],
   };
   const runValidationTasks = async (fieldName, value) => {
     let validationResponse = validateField(value, validations[fieldName]);
@@ -3433,7 +3433,7 @@ export default function BlogCreateForm(props) {
           title,
           content,
           switch: switch1,
-          authorName,
+          published,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -3482,7 +3482,7 @@ export default function BlogCreateForm(props) {
               title: value,
               content,
               switch: switch1,
-              authorName,
+              published,
             };
             const result = onChange(modelFields);
             value = result?.title ?? value;
@@ -3508,7 +3508,7 @@ export default function BlogCreateForm(props) {
               title,
               content: value,
               switch: switch1,
-              authorName,
+              published,
             };
             const result = onChange(modelFields);
             value = result?.content ?? value;
@@ -3527,6 +3527,7 @@ export default function BlogCreateForm(props) {
         label=\\"Switch\\"
         defaultChecked={false}
         isDisabled={false}
+        value={switch1}
         onChange={(e) => {
           let value = e.target.checked;
           if (onChange) {
@@ -3534,7 +3535,7 @@ export default function BlogCreateForm(props) {
               title,
               content,
               switch: switch1,
-              authorName,
+              published,
             };
             const result = onChange(modelFields);
             value = result?.switch ?? value;
@@ -3550,9 +3551,10 @@ export default function BlogCreateForm(props) {
         {...getOverrideProps(overrides, \\"switch\\")}
       ></SwitchField>
       <TextField
-        label=\\"Author name\\"
+        label=\\"Published\\"
         isRequired={false}
         isReadOnly={false}
+        type=\\"datetime-local\\"
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -3560,20 +3562,20 @@ export default function BlogCreateForm(props) {
               title,
               content,
               switch: switch1,
-              authorName: value,
+              published: value,
             };
             const result = onChange(modelFields);
-            value = result?.authorName ?? value;
+            value = result?.published ?? value;
           }
-          if (errors.authorName?.hasError) {
-            runValidationTasks(\\"authorName\\", value);
+          if (errors.published?.hasError) {
+            runValidationTasks(\\"published\\", value);
           }
-          setAuthorName(value);
+          setPublished(new Date(value).toISOString());
         }}
-        onBlur={() => runValidationTasks(\\"authorName\\", authorName)}
-        errorMessage={errors.authorName?.errorMessage}
-        hasError={errors.authorName?.hasError}
-        {...getOverrideProps(overrides, \\"authorName\\")}
+        onBlur={() => runValidationTasks(\\"published\\", published)}
+        errorMessage={errors.published?.errorMessage}
+        hasError={errors.published?.hasError}
+        {...getOverrideProps(overrides, \\"published\\")}
       ></TextField>
       <Flex
         justifyContent=\\"space-between\\"
@@ -3623,7 +3625,7 @@ export declare type BlogCreateFormInputValues<useBase extends boolean = true> = 
     title?: UseBaseOrValidationType<useBase, string>;
     content?: UseBaseOrValidationType<useBase, string>;
     switch?: UseBaseOrValidationType<useBase, boolean>;
-    authorName?: UseBaseOrValidationType<useBase, string>;
+    published?: UseBaseOrValidationType<useBase, string>;
 };
 export declare type FormProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type BlogCreateFormOverridesProps = {
@@ -3631,7 +3633,7 @@ export declare type BlogCreateFormOverridesProps = {
     title?: FormProps<TextFieldProps>;
     content?: FormProps<TextFieldProps>;
     switch?: FormProps<SwitchFieldProps>;
-    authorName?: FormProps<TextFieldProps>;
+    published?: FormProps<TextFieldProps>;
 } & EscapeHatchProps;
 export declare type BlogCreateFormProps = React.PropsWithChildren<{
     overrides?: BlogCreateFormOverridesProps | undefined | null;
@@ -4490,7 +4492,7 @@ function ArrayField({
     </React.Fragment>
   );
 }
-export default function InputGalleryCreateForm(props) {
+export default function InputGalleryUpdateForm(props) {
   const {
     id,
     inputGallery,
@@ -4575,6 +4577,34 @@ export default function InputGalleryCreateForm(props) {
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
+  const convertTimeStampToDate = (ts) => {
+    if (Math.abs(Date.now() - ts) < Math.abs(Date.now() - ts * 1000)) {
+      return new Date(ts);
+    }
+    return new Date(ts * 1000);
+  };
+  const convertToLocal = (date) => {
+    const df = new Intl.DateTimeFormat(\\"default\\", {
+      year: \\"numeric\\",
+      month: \\"2-digit\\",
+      day: \\"2-digit\\",
+      hour: \\"2-digit\\",
+      minute: \\"2-digit\\",
+      second: \\"2-digit\\",
+      fractionalSecondDigits: 3,
+      calendar: \\"iso8601\\",
+      numberingSystem: \\"latn\\",
+      hour12: false,
+    });
+    const parts = df.formatToParts(date).reduce((acc, part) => {
+      acc[part.type] = part.value;
+      return acc;
+    }, {});
+    return (
+      \`\${parts.year}-\${parts.month}-\${parts.day}\` +
+      \`T\${parts.hour}:\${parts.minute}:\${parts.second}.\${parts.fractionalSecond}\`
+    );
+  };
   return (
     <Grid
       as=\\"form\\"
@@ -4632,7 +4662,7 @@ export default function InputGalleryCreateForm(props) {
         }
       }}
       {...rest}
-      {...getOverrideProps(overrides, \\"InputGalleryCreateForm\\")}
+      {...getOverrideProps(overrides, \\"InputGalleryUpdateForm\\")}
     >
       <TextField
         label=\\"Num\\"
@@ -4763,7 +4793,6 @@ export default function InputGalleryCreateForm(props) {
         isDisabled={false}
         defaultPressed={false}
         isPressed={maybeSlide}
-        defaultValue={maybeSlide}
         onChange={(e) => {
           let value = !maybeSlide;
           if (onChange) {
@@ -4879,7 +4908,9 @@ export default function InputGalleryCreateForm(props) {
         isRequired={false}
         isReadOnly={false}
         type=\\"datetime-local\\"
-        defaultValue={timestamp}
+        defaultValue={
+          timestamp && convertToLocal(convertTimeStampToDate(timestamp))
+        }
         onChange={(e) => {
           const date = new Date(e.target.value);
           if (!(date instanceof Date && !isNaN(date))) {
@@ -5025,7 +5056,7 @@ export declare type ValidationResponse = {
 };
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type UseBaseOrValidationType<Flag, T> = Flag extends true ? T : ValidationFunction<T>;
-export declare type InputGalleryCreateFormInputValues<useBase extends boolean = true> = {
+export declare type InputGalleryUpdateFormInputValues<useBase extends boolean = true> = {
     num?: UseBaseOrValidationType<useBase, number>;
     rootbeer?: UseBaseOrValidationType<useBase, number>;
     attend?: UseBaseOrValidationType<useBase, boolean>;
@@ -5037,8 +5068,8 @@ export declare type InputGalleryCreateFormInputValues<useBase extends boolean = 
     timeisnow?: UseBaseOrValidationType<useBase, string>;
 };
 export declare type FormProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
-export declare type InputGalleryCreateFormOverridesProps = {
-    InputGalleryCreateFormGrid?: FormProps<GridProps>;
+export declare type InputGalleryUpdateFormOverridesProps = {
+    InputGalleryUpdateFormGrid?: FormProps<GridProps>;
     num?: FormProps<TextFieldProps>;
     rootbeer?: FormProps<TextFieldProps>;
     attend?: FormProps<RadioGroupFieldProps>;
@@ -5049,19 +5080,19 @@ export declare type InputGalleryCreateFormOverridesProps = {
     ippy?: FormProps<TextFieldProps>;
     timeisnow?: FormProps<TextFieldProps>;
 } & EscapeHatchProps;
-export declare type InputGalleryCreateFormProps = React.PropsWithChildren<{
-    overrides?: InputGalleryCreateFormOverridesProps | undefined | null;
+export declare type InputGalleryUpdateFormProps = React.PropsWithChildren<{
+    overrides?: InputGalleryUpdateFormOverridesProps | undefined | null;
 } & {
     id?: string;
     inputGallery?: InputGallery;
-    onSubmit?: (fields: InputGalleryCreateFormInputValues) => InputGalleryCreateFormInputValues;
-    onSuccess?: (fields: InputGalleryCreateFormInputValues) => void;
-    onError?: (fields: InputGalleryCreateFormInputValues, errorMessage: string) => void;
+    onSubmit?: (fields: InputGalleryUpdateFormInputValues) => InputGalleryUpdateFormInputValues;
+    onSuccess?: (fields: InputGalleryUpdateFormInputValues) => void;
+    onError?: (fields: InputGalleryUpdateFormInputValues, errorMessage: string) => void;
     onCancel?: () => void;
-    onChange?: (fields: InputGalleryCreateFormInputValues) => InputGalleryCreateFormInputValues;
-    onValidate?: InputGalleryCreateFormInputValues<false>;
+    onChange?: (fields: InputGalleryUpdateFormInputValues) => InputGalleryUpdateFormInputValues;
+    onValidate?: InputGalleryUpdateFormInputValues<false>;
 }>;
-export default function InputGalleryCreateForm(props: InputGalleryCreateFormProps): React.ReactElement;
+export default function InputGalleryUpdateForm(props: InputGalleryUpdateFormProps): React.ReactElement;
 "
 `;
 

--- a/packages/codegen-ui-react/lib/__tests__/forms/value-mappers.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/forms/value-mappers.test.ts
@@ -1,0 +1,41 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { convertTimeStampToDate, convertToLocal } from '../../utils/forms/value-mappers';
+
+describe('timestamp to date value mapper', () => {
+  it('should get datetime value for timestamp in seconds', () => {
+    // will return the millisecond value though it will not be populated
+    const date = convertTimeStampToDate(1664221323);
+    expect(date).toBeDefined();
+    expect(date.toISOString()).toStrictEqual('2022-09-26T19:42:03.000Z');
+  });
+
+  it('should get datetime for value for timestamp in milliseconds', () => {
+    const date = convertTimeStampToDate(1664221323190);
+    expect(date).toBeDefined();
+    expect(date.toISOString()).toStrictEqual('2022-09-26T19:42:03.190Z');
+  });
+});
+
+describe('convert date object to datetime local format', () => {
+  it('should convert date object to datetime format', () => {
+    const dateString = convertToLocal(convertTimeStampToDate(1664221323190));
+    expect(dateString).toBeDefined();
+    // the format we expect is yyyy-mm-ddThh:mm:ss.SSS
+    expect(dateString).toMatch(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})/);
+  });
+});

--- a/packages/codegen-ui-react/lib/forms/component-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/component-helper.ts
@@ -1,0 +1,65 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { FieldConfigMetadata } from '@aws-amplify/codegen-ui';
+import { BinaryExpression, factory, SyntaxKind } from 'typescript';
+
+export const ControlledComponents = ['StepperField', 'SliderField', 'SelectField', 'ToggleButton', 'SwitchField'];
+
+/**
+ * given the component returns true if the component is a controlled component
+ *
+ * @param componentType
+ * @returns
+ */
+export const isControlledComponent = (componentType: string): boolean => ControlledComponents.includes(componentType);
+
+export const defaultValueAttributeMap: Record<string, (stateName: string) => BinaryExpression> = {
+  AWSTimestamp: (stateName: string) =>
+    factory.createBinaryExpression(
+      factory.createIdentifier(stateName),
+      factory.createToken(SyntaxKind.AmpersandAmpersandToken),
+      factory.createCallExpression(factory.createIdentifier('convertToLocal'), undefined, [
+        factory.createCallExpression(factory.createIdentifier('convertTimeStampToDate'), undefined, [
+          factory.createIdentifier(stateName),
+        ]),
+      ]),
+    ),
+  AWSDateTime: (stateName: string) =>
+    factory.createBinaryExpression(
+      factory.createIdentifier(stateName),
+      factory.createToken(SyntaxKind.AmpersandAmpersandToken),
+      factory.createCallExpression(factory.createIdentifier('convertToLocal'), undefined, [
+        factory.createNewExpression(factory.createIdentifier('Date'), undefined, [factory.createIdentifier(stateName)]),
+      ]),
+    ),
+};
+
+/**
+ *
+ * @param stateName name of the state name to render for the default value
+ * @param { dataType } the dataType
+ * @returns
+ */
+export const renderDefaultValueAttribute = (stateName: string, { dataType }: FieldConfigMetadata) => {
+  let expression = factory.createJsxExpression(undefined, factory.createIdentifier(stateName));
+
+  if (dataType && typeof dataType !== 'object' && defaultValueAttributeMap[dataType]) {
+    expression = factory.createJsxExpression(undefined, defaultValueAttributeMap[dataType](stateName));
+  }
+
+  return factory.createJsxAttribute(factory.createIdentifier('defaultValue'), expression);
+};

--- a/packages/codegen-ui-react/lib/forms/event-targets.ts
+++ b/packages/codegen-ui-react/lib/forms/event-targets.ts
@@ -226,3 +226,19 @@ export const buildTargetVariable = (fieldType: string, fieldName: string, dataTy
       return [setVariableStatement(defaultIdentifier, expression)];
   }
 };
+
+export const getFormattedValueExpression = (dataType?: DataFieldDataType): Expression => {
+  // setStateExpression(getCurrentValueName(renderedFieldName), factory.createIdentifier('value')),
+  let setExpression: Expression = factory.createIdentifier('value');
+  if (dataType === 'AWSDateTime') {
+    setExpression = factory.createCallExpression(
+      factory.createPropertyAccessExpression(
+        factory.createNewExpression(factory.createIdentifier('Date'), undefined, [factory.createIdentifier('value')]),
+        factory.createIdentifier('toISOString'),
+      ),
+      undefined,
+      [],
+    );
+  }
+  return setExpression;
+};

--- a/packages/codegen-ui-react/lib/utils/forms/value-mappers.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/value-mappers.ts
@@ -1,0 +1,421 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+import { factory, NodeFlags, SyntaxKind } from 'typescript';
+
+/**
+ * accepts timestamp number and returns date object
+ * since datastore allows second and millisecond epochs we need to format accordingly
+ *
+ * @param ts number
+ * @returns date object
+ */
+export const convertTimeStampToDate = (ts: number): Date => {
+  if (Math.abs(Date.now() - ts) < Math.abs(Date.now() - ts * 1000)) {
+    return new Date(ts);
+  }
+  return new Date(ts * 1000);
+};
+
+/**
+ * takes a date object and converts it to the local format used for an html input element with datetime-local
+ *
+ * @param date date object
+ * @returns string formatted in datetime-local
+ */
+export const convertToLocal = (date: Date) => {
+  const df = new Intl.DateTimeFormat('default', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3,
+    calendar: 'iso8601',
+    numberingSystem: 'latn',
+    hour12: false,
+  });
+  const parts = df.formatToParts(date).reduce<Record<string, string>>((acc, part) => {
+    acc[part.type] = part.value;
+    return acc;
+  }, {});
+  return (
+    `${parts.year}-${parts.month}-${parts.day}` +
+    `T${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}`
+  );
+};
+
+/**
+ * ast representation fo the convert timestamp to date
+ */
+export const convertTimeStampToDateAST = factory.createVariableStatement(
+  undefined,
+  factory.createVariableDeclarationList(
+    [
+      factory.createVariableDeclaration(
+        factory.createIdentifier('convertTimeStampToDate'),
+        undefined,
+        undefined,
+        factory.createArrowFunction(
+          undefined,
+          undefined,
+          [
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              undefined,
+              factory.createIdentifier('ts'),
+              undefined,
+              factory.createKeywordTypeNode(SyntaxKind.NumberKeyword),
+              undefined,
+            ),
+          ],
+          factory.createTypeReferenceNode(factory.createIdentifier('Date'), undefined),
+          factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+          factory.createBlock(
+            [
+              factory.createIfStatement(
+                factory.createBinaryExpression(
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('Math'),
+                      factory.createIdentifier('abs'),
+                    ),
+                    undefined,
+                    [
+                      factory.createBinaryExpression(
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('Date'),
+                            factory.createIdentifier('now'),
+                          ),
+                          undefined,
+                          [],
+                        ),
+                        factory.createToken(SyntaxKind.MinusToken),
+                        factory.createIdentifier('ts'),
+                      ),
+                    ],
+                  ),
+                  factory.createToken(SyntaxKind.LessThanToken),
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('Math'),
+                      factory.createIdentifier('abs'),
+                    ),
+                    undefined,
+                    [
+                      factory.createBinaryExpression(
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('Date'),
+                            factory.createIdentifier('now'),
+                          ),
+                          undefined,
+                          [],
+                        ),
+                        factory.createToken(SyntaxKind.MinusToken),
+                        factory.createBinaryExpression(
+                          factory.createIdentifier('ts'),
+                          factory.createToken(SyntaxKind.AsteriskToken),
+                          factory.createNumericLiteral('1000'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                factory.createBlock(
+                  [
+                    factory.createReturnStatement(
+                      factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
+                        factory.createIdentifier('ts'),
+                      ]),
+                    ),
+                  ],
+                  true,
+                ),
+                undefined,
+              ),
+              factory.createReturnStatement(
+                factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
+                  factory.createBinaryExpression(
+                    factory.createIdentifier('ts'),
+                    factory.createToken(SyntaxKind.AsteriskToken),
+                    factory.createNumericLiteral('1000'),
+                  ),
+                ]),
+              ),
+            ],
+            true,
+          ),
+        ),
+      ),
+    ],
+    NodeFlags.Const,
+  ),
+);
+
+/**
+ * convertToLocal function represented in ts ast
+ */
+
+export const convertToLocalAST = factory.createVariableStatement(
+  undefined,
+  factory.createVariableDeclarationList(
+    [
+      factory.createVariableDeclaration(
+        factory.createIdentifier('convertToLocal'),
+        undefined,
+        undefined,
+        factory.createArrowFunction(
+          undefined,
+          undefined,
+          [
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              undefined,
+              factory.createIdentifier('date'),
+              undefined,
+              factory.createTypeReferenceNode(factory.createIdentifier('Date'), undefined),
+              undefined,
+            ),
+          ],
+          undefined,
+          factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+          factory.createBlock(
+            [
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createIdentifier('df'),
+                      undefined,
+                      undefined,
+                      factory.createNewExpression(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('Intl'),
+                          factory.createIdentifier('DateTimeFormat'),
+                        ),
+                        undefined,
+                        [
+                          factory.createStringLiteral('default'),
+                          factory.createObjectLiteralExpression(
+                            [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('year'),
+                                factory.createStringLiteral('numeric'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('month'),
+                                factory.createStringLiteral('2-digit'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('day'),
+                                factory.createStringLiteral('2-digit'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('hour'),
+                                factory.createStringLiteral('2-digit'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('minute'),
+                                factory.createStringLiteral('2-digit'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('second'),
+                                factory.createStringLiteral('2-digit'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('fractionalSecondDigits'),
+                                factory.createNumericLiteral('3'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('calendar'),
+                                factory.createStringLiteral('iso8601'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('numberingSystem'),
+                                factory.createStringLiteral('latn'),
+                              ),
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('hour12'),
+                                factory.createFalse(),
+                              ),
+                            ],
+                            true,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                  NodeFlags.Const,
+                ),
+              ),
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createIdentifier('parts'),
+                      undefined,
+                      undefined,
+                      factory.createCallExpression(
+                        factory.createPropertyAccessExpression(
+                          factory.createCallExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('df'),
+                              factory.createIdentifier('formatToParts'),
+                            ),
+                            undefined,
+                            [factory.createIdentifier('date')],
+                          ),
+                          factory.createIdentifier('reduce'),
+                        ),
+                        [
+                          factory.createTypeReferenceNode(factory.createIdentifier('Record'), [
+                            factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+                            factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
+                          ]),
+                        ],
+                        [
+                          factory.createArrowFunction(
+                            undefined,
+                            undefined,
+                            [
+                              factory.createParameterDeclaration(
+                                undefined,
+                                undefined,
+                                undefined,
+                                factory.createIdentifier('acc'),
+                                undefined,
+                                undefined,
+                                undefined,
+                              ),
+                              factory.createParameterDeclaration(
+                                undefined,
+                                undefined,
+                                undefined,
+                                factory.createIdentifier('part'),
+                                undefined,
+                                undefined,
+                                undefined,
+                              ),
+                            ],
+                            undefined,
+                            factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                            factory.createBlock(
+                              [
+                                factory.createExpressionStatement(
+                                  factory.createBinaryExpression(
+                                    factory.createElementAccessExpression(
+                                      factory.createIdentifier('acc'),
+                                      factory.createPropertyAccessExpression(
+                                        factory.createIdentifier('part'),
+                                        factory.createIdentifier('type'),
+                                      ),
+                                    ),
+                                    factory.createToken(SyntaxKind.EqualsToken),
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier('part'),
+                                      factory.createIdentifier('value'),
+                                    ),
+                                  ),
+                                ),
+                                factory.createReturnStatement(factory.createIdentifier('acc')),
+                              ],
+                              true,
+                            ),
+                          ),
+                          factory.createObjectLiteralExpression([], false),
+                        ],
+                      ),
+                    ),
+                  ],
+                  NodeFlags.Const,
+                ),
+              ),
+              factory.createReturnStatement(
+                factory.createParenthesizedExpression(
+                  factory.createBinaryExpression(
+                    factory.createTemplateExpression(factory.createTemplateHead('', ''), [
+                      factory.createTemplateSpan(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('parts'),
+                          factory.createIdentifier('year'),
+                        ),
+                        factory.createTemplateMiddle('-', '-'),
+                      ),
+                      factory.createTemplateSpan(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('parts'),
+                          factory.createIdentifier('month'),
+                        ),
+                        factory.createTemplateMiddle('-', '-'),
+                      ),
+                      factory.createTemplateSpan(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('parts'),
+                          factory.createIdentifier('day'),
+                        ),
+                        factory.createTemplateTail('', ''),
+                      ),
+                    ]),
+                    factory.createToken(SyntaxKind.PlusToken),
+                    factory.createTemplateExpression(factory.createTemplateHead('T', 'T'), [
+                      factory.createTemplateSpan(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('parts'),
+                          factory.createIdentifier('hour'),
+                        ),
+                        factory.createTemplateMiddle(':', ':'),
+                      ),
+                      factory.createTemplateSpan(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('parts'),
+                          factory.createIdentifier('minute'),
+                        ),
+                        factory.createTemplateMiddle(':', ':'),
+                      ),
+                      factory.createTemplateSpan(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('parts'),
+                          factory.createIdentifier('second'),
+                        ),
+                        factory.createTemplateMiddle('.', '.'),
+                      ),
+                      factory.createTemplateSpan(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('parts'),
+                          factory.createIdentifier('fractionalSecond'),
+                        ),
+                        factory.createTemplateTail('', ''),
+                      ),
+                    ]),
+                  ),
+                ),
+              ),
+            ],
+            true,
+          ),
+        ),
+      ),
+    ],
+    NodeFlags.Const,
+  ),
+);

--- a/packages/codegen-ui/example-schemas/datastore/blog.json
+++ b/packages/codegen-ui/example-schemas/datastore/blog.json
@@ -31,10 +31,10 @@
           "isRequired": false,
           "attributes": []
         },
-        "authorName": {
-          "name": "authorName",
+        "published": {
+          "name": "published",
           "isArray": false,
-          "type": "String",
+          "type": "AWSDateTime",
           "isRequired": false,
           "attributes": []
         },

--- a/packages/codegen-ui/example-schemas/forms/input-gallery-update.json
+++ b/packages/codegen-ui/example-schemas/forms/input-gallery-update.json
@@ -22,7 +22,7 @@
     }
   },
   "formActionType": "update",
-  "name": "InputGalleryCreateForm",
+  "name": "InputGalleryUpdateForm",
   "schemaVersion": "1.0",
   "sectionalElements": {},
   "style": {},

--- a/packages/codegen-ui/lib/utils/index.ts
+++ b/packages/codegen-ui/lib/utils/index.ts
@@ -20,11 +20,3 @@ export * from './string-formatter';
 export * from './form-component-metadata';
 export * from './form-to-component';
 export * from './breakpoint-utils';
-export const ControlledComponents = ['StepperField', 'SliderField', 'SelectField'];
-/**
- * given the component returns true if the component is a controlled component
- *
- * @param componentType
- * @returns
- */
-export const isControlledComponent = (componentType: string): boolean => ControlledComponents.includes(componentType);


### PR DESCRIPTION
*Issue #, if available:*
*Description of changes:*
- handle defaultValues date associated fields
  - for `AWSTimestamp` this will convert the epoch seconds/milliseconds to datetime-local input
  - for `AWSDateTime` will remove the 'Z' character so the date is laid out correctly in the input field

note: seconds/milliseconds are not editable
### format for epoch in seconds
<img width="476" alt="Screen Shot 2022-09-26 at 1 48 03 PM" src="https://user-images.githubusercontent.com/7465495/192377424-9a8ab0ba-a9a6-43d9-8ecb-5ef880208b29.png">

### format for epoch in milliseconds
<img width="497" alt="Screen Shot 2022-09-26 at 1 49 05 PM" src="https://user-images.githubusercontent.com/7465495/192377625-b31cd57c-7053-4f78-8296-960d732bd2c2.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
