### PR TITLE
fix: accept 0 for number fields

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -730,7 +730,12 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((!!currentFieldValue || currentFieldValue === false) && !hasError) {
+    if (
+      (currentFieldValue !== undefined ||
+        currentFieldValue !== null ||
+        currentFieldValue !== \\"\\") &&
+      !hasError
+    ) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;
@@ -1072,7 +1077,12 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((!!currentFieldValue || currentFieldValue === false) && !hasError) {
+    if (
+      (currentFieldValue !== undefined ||
+        currentFieldValue !== null ||
+        currentFieldValue !== \\"\\") &&
+      !hasError
+    ) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;
@@ -1563,7 +1573,12 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((!!currentFieldValue || currentFieldValue === false) && !hasError) {
+    if (
+      (currentFieldValue !== undefined ||
+        currentFieldValue !== null ||
+        currentFieldValue !== \\"\\") &&
+      !hasError
+    ) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;
@@ -2112,7 +2127,12 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((!!currentFieldValue || currentFieldValue === false) && !hasError) {
+    if (
+      (currentFieldValue !== undefined ||
+        currentFieldValue !== null ||
+        currentFieldValue !== \\"\\") &&
+      !hasError
+    ) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;
@@ -3699,7 +3719,12 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((!!currentFieldValue || currentFieldValue === false) && !hasError) {
+    if (
+      (currentFieldValue !== undefined ||
+        currentFieldValue !== null ||
+        currentFieldValue !== \\"\\") &&
+      !hasError
+    ) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;
@@ -4393,7 +4418,12 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((!!currentFieldValue || currentFieldValue === false) && !hasError) {
+    if (
+      (currentFieldValue !== undefined ||
+        currentFieldValue !== null ||
+        currentFieldValue !== \\"\\") &&
+      !hasError
+    ) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -252,18 +252,24 @@ export const generateArrayFieldComponent = () => {
                     factory.createBinaryExpression(
                       factory.createParenthesizedExpression(
                         factory.createBinaryExpression(
-                          factory.createPrefixUnaryExpression(
-                            SyntaxKind.ExclamationToken,
-                            factory.createPrefixUnaryExpression(
-                              SyntaxKind.ExclamationToken,
+                          factory.createBinaryExpression(
+                            factory.createBinaryExpression(
                               factory.createIdentifier('currentFieldValue'),
+                              factory.createToken(SyntaxKind.ExclamationEqualsEqualsToken),
+                              factory.createIdentifier('undefined'),
+                            ),
+                            factory.createToken(SyntaxKind.BarBarToken),
+                            factory.createBinaryExpression(
+                              factory.createIdentifier('currentFieldValue'),
+                              factory.createToken(SyntaxKind.ExclamationEqualsEqualsToken),
+                              factory.createNull(),
                             ),
                           ),
                           factory.createToken(SyntaxKind.BarBarToken),
                           factory.createBinaryExpression(
                             factory.createIdentifier('currentFieldValue'),
-                            factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
-                            factory.createFalse(),
+                            factory.createToken(SyntaxKind.ExclamationEqualsEqualsToken),
+                            factory.createStringLiteral(''),
                           ),
                         ),
                       ),


### PR DESCRIPTION
…y string

*Issue #, if available:*

https://app.asana.com/0/1202966106210868/1203050023493661/f

*Description of changes:*

I updated the addItem code to allow for the number 0

I updated the default values for string fields to be an empty string. This prevents react components from going from uncontrolled to controlled components.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
