### PR TITLE
chore: do not autogen non-model fields

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -175,7 +175,7 @@ describe('mapModelFieldsConfigs', () => {
           fields: {
             ownerId: {
               dataType: 'ID',
-              readOnly: true,
+              readOnly: false,
               required: false,
               isArray: false,
               relationship: { type: 'HAS_ONE', relatedModelName: 'Owner' },
@@ -193,7 +193,7 @@ describe('mapModelFieldsConfigs', () => {
         dataType: 'ID',
         inputType: {
           name: 'ownerId',
-          readOnly: true,
+          readOnly: false,
           required: false,
           type: 'SelectField',
           value: 'ownerId',
@@ -202,6 +202,32 @@ describe('mapModelFieldsConfigs', () => {
         label: 'Owner id',
       },
     });
+  });
+
+  it('should not add nonModel field to matrix', () => {
+    const formDefinition: FormDefinition = getBasicFormDefinition();
+
+    const dataSchema: GenericDataSchema = {
+      dataSourceType: 'DataStore',
+      enums: {},
+      nonModels: { Interaction: { fields: {} } },
+      models: {
+        Dog: {
+          fields: {
+            ownerId: {
+              dataType: { nonModel: 'Interaction' },
+              readOnly: false,
+              required: false,
+              isArray: false,
+            },
+          },
+        },
+      },
+    };
+
+    mapModelFieldsConfigs({ dataTypeName: 'Dog', formDefinition, dataSchema });
+
+    expect(formDefinition.elementMatrix).toStrictEqual([]);
   });
 
   it('should add value mappings from enums', () => {

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -15,6 +15,7 @@
  */
 
 import { sentenceCase } from 'change-case';
+import { checkIsSupportedAsFormField } from '../../check-support';
 
 import { InvalidInputError } from '../../errors';
 import {
@@ -108,7 +109,9 @@ export function mapModelFieldsConfigs({
 
   Object.entries(model.fields).forEach(([fieldName, field]) => {
     const isAutoExcludedField =
-      field.readOnly || (fieldName === 'id' && field.dataType === 'ID' && field.required) || field.relationship;
+      field.readOnly ||
+      (fieldName === 'id' && field.dataType === 'ID' && field.required) ||
+      !checkIsSupportedAsFormField(field);
 
     if (!isAutoExcludedField) {
       formDefinition.elementMatrix.push([fieldName]);


### PR DESCRIPTION
*Description of changes:*
do not map non-model fields into input elements by using the helper `checkIsSupportedAsFormField`

Additional change: set readOnly to false for relationship test example so that is not the trait that causes it to be excluded. It should be excluded because it's a relationship, not because readOnly is true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
