### PR TITLE
chore: identify join tables in generic data schema

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
@@ -124,7 +124,7 @@ describe('getGenericFromDataStore', () => {
     });
   });
 
-  it('should handle schema with assumed associated fields and modldkjld', () => {
+  it('should handle schema with assumed associated fields and models', () => {
     const genericSchema = getGenericFromDataStore(schemaWithAssumptions);
     const userFields = genericSchema.models.User.fields;
 
@@ -139,5 +139,14 @@ describe('getGenericFromDataStore', () => {
       relatedModelName: 'Post',
       relatedModelField: 'userPostsId',
     });
+  });
+
+  it('should correctly identify join tables', () => {
+    const genericSchema = getGenericFromDataStore(schemaWithRelationships);
+    const joinTables = Object.entries(genericSchema.models)
+      .filter(([, model]) => model.isJoinTable)
+      .map(([name]) => name);
+    expect(joinTables).toHaveLength(1);
+    expect(joinTables).toStrictEqual(['StudentTeacher']);
   });
 });

--- a/packages/codegen-ui/lib/generic-from-datastore.ts
+++ b/packages/codegen-ui/lib/generic-from-datastore.ts
@@ -59,6 +59,8 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
     [modelName: string]: { [fieldName: string]: GenericDataField['relationship'] };
   } = {};
 
+  const joinTableNames: string[] = [];
+
   Object.values(dataStoreSchema.models).forEach((model) => {
     const genericFields: { [fieldName: string]: GenericDataField } = {};
 
@@ -85,6 +87,8 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
               'model' in associatedField.type &&
               associatedField.type.model === model.name
             ) {
+              joinTableNames.push(associatedModel.name);
+
               const relatedJoinField = Object.values(associatedModel.fields).find(
                 (joinField) =>
                   joinField.name !== associatedFieldName &&
@@ -134,6 +138,13 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
         field.relationship = relationship;
       }
     });
+  });
+
+  joinTableNames.forEach((joinTableName) => {
+    const model = genericSchema.models[joinTableName];
+    if (model) {
+      model.isJoinTable = true;
+    }
   });
 
   genericSchema.enums = dataStoreSchema.enums;

--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -87,6 +87,7 @@ export type GenericDataField = {
 
 export type GenericDataModel = {
   fields: { [fieldName: string]: GenericDataField };
+  isJoinTable?: boolean;
 };
 
 export type GenericDataSchema = {


### PR DESCRIPTION
*Description of changes:*
In the UI and the CLI, we need to not autogen forms and views for join tables.
So this identifies them in the genericDataSchema


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
