### PR TITLE
fix: fix value props on ArrayField child

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1013,7 +1013,6 @@ export default function CustomDataForm(props) {
           onBlur={() => runValidationTasks(\\"email\\", currentEmailValue)}
           errorMessage={errors.email?.errorMessage}
           hasError={errors.email?.hasError}
-          value={currentEmailValue}
           ref={emailRef}
           {...getOverrideProps(overrides, \\"email\\")}
         ></TextField>
@@ -1055,7 +1054,6 @@ export default function CustomDataForm(props) {
           onBlur={() => runValidationTasks(\\"phone\\", currentPhoneValue)}
           errorMessage={errors.phone?.errorMessage}
           hasError={errors.phone?.hasError}
-          value={currentPhoneValue}
           ref={phoneRef}
           {...getOverrideProps(overrides, \\"phone\\")}
         ></TextField>
@@ -1523,7 +1521,6 @@ export default function MyPostForm(props) {
           }
           errorMessage={errors.Customtags?.errorMessage}
           hasError={errors.Customtags?.hasError}
-          value={currentCustomtagsValue}
           ref={CustomtagsRef}
           {...getOverrideProps(overrides, \\"Customtags\\")}
         ></TextField>
@@ -2029,7 +2026,6 @@ export default function NestedJson(props) {
           }
           errorMessage={errors.Nicknames1?.errorMessage}
           hasError={errors.Nicknames1?.hasError}
-          value={currentNicknames1Value}
           ref={Nicknames1Ref}
           {...getOverrideProps(overrides, \\"Nicknames1\\")}
         ></TextField>
@@ -2073,7 +2069,6 @@ export default function NestedJson(props) {
           }
           errorMessage={errors[\\"nick-names2\\"]?.errorMessage}
           hasError={errors[\\"nick-names2\\"]?.hasError}
-          value={currentNicknamesValue}
           ref={nicknamesRef}
           {...getOverrideProps(overrides, \\"nick-names2\\")}
         ></TextField>
@@ -2515,7 +2510,6 @@ export default function NestedJson(props) {
           onBlur={() => runValidationTasks(\\"lastName\\", currentLastName1Value)}
           errorMessage={errors.lastName?.errorMessage}
           hasError={errors.lastName?.hasError}
-          value={currentLastName1Value}
           ref={lastName1Ref}
           {...getOverrideProps(overrides, \\"lastName\\")}
         ></TextField>
@@ -3660,7 +3654,7 @@ export default function BlogCreateForm(props) {
         label=\\"Switch\\"
         defaultChecked={false}
         isDisabled={false}
-        value={switch1}
+        isChecked={switch1}
         onChange={(e) => {
           let value = e.target.checked;
           if (onChange) {
@@ -4296,7 +4290,6 @@ export default function InputGalleryCreateForm(props) {
           }
           errorMessage={errors.arrayTypeField?.errorMessage}
           hasError={errors.arrayTypeField?.hasError}
-          value={currentArrayTypeFieldValue}
           ref={arrayTypeFieldRef}
           {...getOverrideProps(overrides, \\"arrayTypeField\\")}
         ></TextField>
@@ -5047,7 +5040,6 @@ export default function InputGalleryUpdateForm(props) {
           }
           errorMessage={errors.arrayTypeField?.errorMessage}
           hasError={errors.arrayTypeField?.hasError}
-          value={currentArrayTypeFieldValue}
           ref={arrayTypeFieldRef}
           {...getOverrideProps(overrides, \\"arrayTypeField\\")}
         ></TextField>

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -174,7 +174,13 @@ export const addFormAttributes = (component: StudioComponent | StudioComponentCh
             factory.createIdentifier('errors'),
             factory.createIdentifier(componentName),
           );
-    attributes.push(...buildComponentSpecificAttributes({ componentType, componentName: renderedVariableName }));
+    attributes.push(
+      ...buildComponentSpecificAttributes({
+        componentType,
+        componentName: renderedVariableName,
+        currentValueIdentifier: fieldConfig.isArray ? getCurrentValueIdentifier(renderedVariableName) : undefined,
+      }),
+    );
     if (formMetadata.formActionType === 'update' && !fieldConfig.isArray && !isControlledComponent(componentType)) {
       attributes.push(renderDefaultValueAttribute(renderedVariableName, fieldConfig));
     }
@@ -206,10 +212,6 @@ export const addFormAttributes = (component: StudioComponent | StudioComponentCh
     );
     if (fieldConfig.isArray) {
       attributes.push(
-        factory.createJsxAttribute(
-          factory.createIdentifier('value'),
-          factory.createJsxExpression(undefined, getCurrentValueIdentifier(renderedVariableName)),
-        ),
         factory.createJsxAttribute(
           factory.createIdentifier('ref'),
           factory.createJsxExpression(undefined, factory.createIdentifier(`${renderedVariableName}Ref`)),
@@ -452,40 +454,43 @@ function getOnValueChangeProp(fieldType: string): string {
 export const buildComponentSpecificAttributes = ({
   componentType,
   componentName,
+  currentValueIdentifier,
 }: {
   componentType: string;
   componentName: string;
+  currentValueIdentifier?: Identifier;
 }) => {
-  const stateName = componentName.split('.')[0];
+  const valueIdentifier = currentValueIdentifier || factory.createIdentifier(componentName.split('.')[0]);
+
   const componentToAttributesMap: { [key: string]: JsxAttribute[] } = {
     ToggleButton: [
       factory.createJsxAttribute(
         factory.createIdentifier('isPressed'),
-        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+        factory.createJsxExpression(undefined, valueIdentifier),
       ),
     ],
     SliderField: [
       factory.createJsxAttribute(
         factory.createIdentifier('value'),
-        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+        factory.createJsxExpression(undefined, valueIdentifier),
       ),
     ],
     SelectField: [
       factory.createJsxAttribute(
         factory.createIdentifier('value'),
-        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+        factory.createJsxExpression(undefined, valueIdentifier),
       ),
     ],
     StepperField: [
       factory.createJsxAttribute(
         factory.createIdentifier('value'),
-        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+        factory.createJsxExpression(undefined, valueIdentifier),
       ),
     ],
     SwitchField: [
       factory.createJsxAttribute(
-        factory.createIdentifier('value'),
-        factory.createJsxExpression(undefined, factory.createIdentifier(stateName)),
+        factory.createIdentifier('isChecked'),
+        factory.createJsxExpression(undefined, valueIdentifier),
       ),
     ],
   };


### PR DESCRIPTION
*Description of changes:*
_Problems:_
- `SwitchField` child of `ArrayField` had 2 `value` props.
- child of `ArrayField` always had `value` prop, even if the component did not need to be controlled. It would cause issues like TextField tied to AWSTimestamp DataStore field resetting to undefined `onChange`.
- child of `ArrayField` always had `value` prop even when it needed to be something else to be effective, like `isPressed`, `isChecked`, etc.

_Changes:_
- Change `value` on `SwitchField` to `isChecked`. `value` has no effect on this component.
- Remove `value` on child of `ArrayField` on components that don't need it.
- For components that do need to be controlled, render the correct prop (e.g. `isPressed`), not always just `value`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
