### PR TITLE
fix: remove seconds and milliseconds from timestamp conversion

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -4988,8 +4988,6 @@ export default function InputGalleryUpdateForm(props) {
       day: \\"2-digit\\",
       hour: \\"2-digit\\",
       minute: \\"2-digit\\",
-      second: \\"2-digit\\",
-      fractionalSecondDigits: 3,
       calendar: \\"iso8601\\",
       numberingSystem: \\"latn\\",
       hour12: false,
@@ -4998,10 +4996,7 @@ export default function InputGalleryUpdateForm(props) {
       acc[part.type] = part.value;
       return acc;
     }, {});
-    return (
-      \`\${parts.year}-\${parts.month}-\${parts.day}\` +
-      \`T\${parts.hour}:\${parts.minute}:\${parts.second}.\${parts.fractionalSecond}\`
-    );
+    return \`\${parts.year}-\${parts.month}-\${parts.day}T\${parts.hour}:\${parts.minute}\`;
   };
   return (
     <Grid

--- a/packages/codegen-ui-react/lib/__tests__/forms/value-mappers.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/forms/value-mappers.test.ts
@@ -35,7 +35,7 @@ describe('convert date object to datetime local format', () => {
   it('should convert date object to datetime format', () => {
     const dateString = convertToLocal(convertTimeStampToDate(1664221323190));
     expect(dateString).toBeDefined();
-    // the format we expect is yyyy-mm-ddThh:mm:ss.SSS
-    expect(dateString).toMatch(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d{3})/);
+    // the format we expect is yyyy-mm-ddThh:mm
+    expect(dateString).toMatch(/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/);
   });
 });

--- a/packages/codegen-ui-react/lib/utils/forms/value-mappers.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/value-mappers.ts
@@ -43,8 +43,6 @@ export const convertToLocal = (date: Date) => {
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
-    second: '2-digit',
-    fractionalSecondDigits: 3,
     calendar: 'iso8601',
     numberingSystem: 'latn',
     hour12: false,
@@ -53,10 +51,7 @@ export const convertToLocal = (date: Date) => {
     acc[part.type] = part.value;
     return acc;
   }, {});
-  return (
-    `${parts.year}-${parts.month}-${parts.day}` +
-    `T${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}`
-  );
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`;
 };
 
 /**
@@ -238,14 +233,6 @@ export const convertToLocalAST = factory.createVariableStatement(
                                 factory.createStringLiteral('2-digit'),
                               ),
                               factory.createPropertyAssignment(
-                                factory.createIdentifier('second'),
-                                factory.createStringLiteral('2-digit'),
-                              ),
-                              factory.createPropertyAssignment(
-                                factory.createIdentifier('fractionalSecondDigits'),
-                                factory.createNumericLiteral('3'),
-                              ),
-                              factory.createPropertyAssignment(
                                 factory.createIdentifier('calendar'),
                                 factory.createStringLiteral('iso8601'),
                               ),
@@ -351,64 +338,43 @@ export const convertToLocalAST = factory.createVariableStatement(
                 ),
               ),
               factory.createReturnStatement(
-                factory.createParenthesizedExpression(
-                  factory.createBinaryExpression(
-                    factory.createTemplateExpression(factory.createTemplateHead('', ''), [
-                      factory.createTemplateSpan(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('parts'),
-                          factory.createIdentifier('year'),
-                        ),
-                        factory.createTemplateMiddle('-', '-'),
-                      ),
-                      factory.createTemplateSpan(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('parts'),
-                          factory.createIdentifier('month'),
-                        ),
-                        factory.createTemplateMiddle('-', '-'),
-                      ),
-                      factory.createTemplateSpan(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('parts'),
-                          factory.createIdentifier('day'),
-                        ),
-                        factory.createTemplateTail('', ''),
-                      ),
-                    ]),
-                    factory.createToken(SyntaxKind.PlusToken),
-                    factory.createTemplateExpression(factory.createTemplateHead('T', 'T'), [
-                      factory.createTemplateSpan(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('parts'),
-                          factory.createIdentifier('hour'),
-                        ),
-                        factory.createTemplateMiddle(':', ':'),
-                      ),
-                      factory.createTemplateSpan(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('parts'),
-                          factory.createIdentifier('minute'),
-                        ),
-                        factory.createTemplateMiddle(':', ':'),
-                      ),
-                      factory.createTemplateSpan(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('parts'),
-                          factory.createIdentifier('second'),
-                        ),
-                        factory.createTemplateMiddle('.', '.'),
-                      ),
-                      factory.createTemplateSpan(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('parts'),
-                          factory.createIdentifier('fractionalSecond'),
-                        ),
-                        factory.createTemplateTail('', ''),
-                      ),
-                    ]),
+                factory.createTemplateExpression(factory.createTemplateHead('', ''), [
+                  factory.createTemplateSpan(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('parts'),
+                      factory.createIdentifier('year'),
+                    ),
+                    factory.createTemplateMiddle('-', '-'),
                   ),
-                ),
+                  factory.createTemplateSpan(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('parts'),
+                      factory.createIdentifier('month'),
+                    ),
+                    factory.createTemplateMiddle('-', '-'),
+                  ),
+                  factory.createTemplateSpan(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('parts'),
+                      factory.createIdentifier('day'),
+                    ),
+                    factory.createTemplateMiddle('T', 'T'),
+                  ),
+                  factory.createTemplateSpan(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('parts'),
+                      factory.createIdentifier('hour'),
+                    ),
+                    factory.createTemplateMiddle(':', ':'),
+                  ),
+                  factory.createTemplateSpan(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('parts'),
+                      factory.createIdentifier('minute'),
+                    ),
+                    factory.createTemplateTail('', ''),
+                  ),
+                ]),
               ),
             ],
             true,


### PR DESCRIPTION
*Issue #, if available:*
asana task: https://app.asana.com/0/1202185248783861/1203016994588008/f
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
