### PR TITLE
fix: do not parse AWSJSON for submit

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1421,7 +1421,7 @@ export default function MyPostForm(props) {
           caption,
           Customtags,
           post_url,
-          metadata: JSON.parse(metadata),
+          metadata,
           profile_url,
         };
         const validationResponses = await Promise.all(
@@ -1510,7 +1510,7 @@ export default function MyPostForm(props) {
                 caption,
                 Customtags,
                 post_url,
-                metadata: JSON.parse(metadata),
+                metadata,
                 profile_url,
               };
               const result = onChange(modelFields);
@@ -1539,7 +1539,7 @@ export default function MyPostForm(props) {
                 caption: value,
                 Customtags,
                 post_url,
-                metadata: JSON.parse(metadata),
+                metadata,
                 profile_url,
               };
               const result = onChange(modelFields);
@@ -1565,7 +1565,7 @@ export default function MyPostForm(props) {
               caption,
               Customtags: values,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
               profile_url,
             };
             const result = onChange(modelFields);
@@ -1613,7 +1613,7 @@ export default function MyPostForm(props) {
               caption,
               Customtags,
               post_url: value,
-              metadata: JSON.parse(metadata),
+              metadata,
               profile_url,
             };
             const result = onChange(modelFields);
@@ -1641,7 +1641,7 @@ export default function MyPostForm(props) {
               caption,
               Customtags,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata: value,
               profile_url,
             };
             const result = onChange(modelFields);
@@ -1669,7 +1669,7 @@ export default function MyPostForm(props) {
               caption,
               Customtags,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
               profile_url: value,
             };
             const result = onChange(modelFields);
@@ -3040,7 +3040,7 @@ export default function MyPostForm(props) {
           caption,
           username,
           post_url,
-          metadata: JSON.parse(metadata),
+          metadata,
           profile_url,
         };
         const validationResponses = await Promise.all(
@@ -3121,7 +3121,7 @@ export default function MyPostForm(props) {
               caption: value,
               username,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
               profile_url,
             };
             const result = onChange(modelFields);
@@ -3148,7 +3148,7 @@ export default function MyPostForm(props) {
               caption,
               username: value,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
               profile_url,
             };
             const result = onChange(modelFields);
@@ -3175,7 +3175,7 @@ export default function MyPostForm(props) {
               caption,
               username,
               post_url: value,
-              metadata: JSON.parse(metadata),
+              metadata,
               profile_url,
             };
             const result = onChange(modelFields);
@@ -3202,7 +3202,7 @@ export default function MyPostForm(props) {
               caption,
               username,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata: value,
               profile_url,
             };
             const result = onChange(modelFields);
@@ -3229,7 +3229,7 @@ export default function MyPostForm(props) {
               caption,
               username,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
               profile_url: value,
             };
             const result = onChange(modelFields);
@@ -3396,7 +3396,7 @@ export default function MyPostForm(props) {
           username,
           profile_url,
           post_url,
-          metadata: JSON.parse(metadata),
+          metadata,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -3478,7 +3478,7 @@ export default function MyPostForm(props) {
               username,
               profile_url,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.TextAreaFieldbbd63464 ?? value;
@@ -3509,7 +3509,7 @@ export default function MyPostForm(props) {
               username,
               profile_url,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.caption ?? value;
@@ -3538,7 +3538,7 @@ export default function MyPostForm(props) {
               username: value,
               profile_url,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.username ?? value;
@@ -3567,7 +3567,7 @@ export default function MyPostForm(props) {
               username,
               profile_url: value,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.profile_url ?? value;
@@ -3596,7 +3596,7 @@ export default function MyPostForm(props) {
               username,
               profile_url,
               post_url: value,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.post_url ?? value;
@@ -3625,7 +3625,7 @@ export default function MyPostForm(props) {
               username,
               profile_url,
               post_url,
-              metadata: JSON.parse(metadata),
+              metadata: value,
             };
             const result = onChange(modelFields);
             value = result?.metadata ?? value;
@@ -5591,7 +5591,7 @@ export default function PostCreateFormRow(props) {
           post_url,
           profile_url,
           status,
-          metadata: JSON.parse(metadata),
+          metadata,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -5652,7 +5652,7 @@ export default function PostCreateFormRow(props) {
                 post_url,
                 profile_url,
                 status,
-                metadata: JSON.parse(metadata),
+                metadata,
               };
               const result = onChange(modelFields);
               value = result?.username ?? value;
@@ -5681,7 +5681,7 @@ export default function PostCreateFormRow(props) {
                 post_url,
                 profile_url,
                 status,
-                metadata: JSON.parse(metadata),
+                metadata,
               };
               const result = onChange(modelFields);
               value = result?.caption ?? value;
@@ -5711,7 +5711,7 @@ export default function PostCreateFormRow(props) {
               post_url: value,
               profile_url,
               status,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.post_url ?? value;
@@ -5740,7 +5740,7 @@ export default function PostCreateFormRow(props) {
               post_url,
               profile_url: value,
               status,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.profile_url ?? value;
@@ -5768,7 +5768,7 @@ export default function PostCreateFormRow(props) {
               post_url,
               profile_url,
               status: value,
-              metadata: JSON.parse(metadata),
+              metadata,
             };
             const result = onChange(modelFields);
             value = result?.status ?? value;
@@ -5796,7 +5796,7 @@ export default function PostCreateFormRow(props) {
               post_url,
               profile_url,
               status,
-              metadata: JSON.parse(metadata),
+              metadata: value,
             };
             const result = onChange(modelFields);
             value = result?.metadata ?? value;

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -923,23 +923,13 @@ export const buildModelFieldObject = (
   const fieldSet = new Set<string>();
   const fields = Object.keys(fieldConfigs).reduce<ObjectLiteralElementLike[]>((acc, value) => {
     const fieldName = value.split('.')[0];
-    const { sanitizedFieldName, dataType } = fieldConfigs[value];
+    const { sanitizedFieldName } = fieldConfigs[value];
     const renderedFieldName = sanitizedFieldName || fieldName;
     if (!fieldSet.has(renderedFieldName)) {
       let assignment = nameOverrides[fieldName]
         ? nameOverrides[fieldName]
         : factory.createShorthandPropertyAssignment(factory.createIdentifier(fieldName), undefined);
-
-      if (dataType === 'AWSJSON') {
-        assignment = factory.createPropertyAssignment(
-          factory.createStringLiteral(fieldName),
-          factory.createCallExpression(
-            factory.createPropertyAccessExpression(factory.createIdentifier('JSON'), factory.createIdentifier('parse')),
-            undefined,
-            [factory.createIdentifier(sanitizedFieldName ?? fieldName)],
-          ),
-        );
-      } else if (sanitizedFieldName) {
+      if (sanitizedFieldName) {
         assignment = factory.createPropertyAssignment(
           factory.createStringLiteral(fieldName),
           factory.createIdentifier(sanitizedFieldName),


### PR DESCRIPTION
*Description of changes:*
Problem:
1) failing form validation because JSON validator wants to parse the string 
2) when value is optional and undefined, JSON.parse is failing

Confirmed that it saves to DS even when not parsed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
