### PR TITLE
Fix/float

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -4310,6 +4310,7 @@ export default function InputGalleryCreateForm(props) {
         isRequired={false}
         isReadOnly={false}
         type=\\"number\\"
+        step=\\"any\\"
         onChange={(e) => {
           let value = parseInt(e.target.value);
           if (isNaN(value)) {
@@ -4349,6 +4350,7 @@ export default function InputGalleryCreateForm(props) {
         isRequired={false}
         isReadOnly={false}
         type=\\"number\\"
+        step=\\"any\\"
         onChange={(e) => {
           let value = Number(e.target.value);
           if (isNaN(value)) {
@@ -5062,6 +5064,7 @@ export default function InputGalleryUpdateForm(props) {
         isRequired={false}
         isReadOnly={false}
         type=\\"number\\"
+        step=\\"any\\"
         defaultValue={num}
         onChange={(e) => {
           let value = parseInt(e.target.value);
@@ -5102,6 +5105,7 @@ export default function InputGalleryUpdateForm(props) {
         isRequired={false}
         isReadOnly={false}
         type=\\"number\\"
+        step=\\"any\\"
         defaultValue={rootbeer}
         onChange={(e) => {
           let value = Number(e.target.value);

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -175,7 +175,7 @@ export const addFormAttributes = (component: StudioComponent | StudioComponentCh
           );
     attributes.push(
       ...buildComponentSpecificAttributes({
-        componentType,
+        componentType: fieldConfig.studioFormComponentType ?? fieldConfig.componentType,
         componentName: renderedVariableName,
         currentValueIdentifier: fieldConfig.isArray ? getCurrentValueIdentifier(renderedVariableName) : undefined,
       }),
@@ -497,6 +497,7 @@ export const buildComponentSpecificAttributes = ({
         factory.createJsxExpression(undefined, valueIdentifier),
       ),
     ],
+    NumberField: [factory.createJsxAttribute(factory.createIdentifier('step'), factory.createStringLiteral('any'))],
   };
 
   return componentToAttributesMap[componentType] ?? [];

--- a/packages/codegen-ui/lib/types/form/form-metadata.ts
+++ b/packages/codegen-ui/lib/types/form/form-metadata.ts
@@ -31,6 +31,7 @@ export type FieldConfigMetadata = {
   sanitizedFieldName?: string;
   isArray?: boolean;
   componentType: string;
+  studioFormComponentType?: string;
 };
 
 export type FormMetadata = {

--- a/packages/codegen-ui/lib/utils/form-component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/form-component-metadata.ts
@@ -72,6 +72,7 @@ export const mapFormMetadata = (form: StudioForm, formDefinition: FormDefinition
       const metadata: FieldConfigMetadata = {
         validationRules: [],
         componentType: config.componentType,
+        studioFormComponentType: 'studioFormComponentType' in config ? config.studioFormComponentType : undefined,
         isArray: 'isArray' in config && config.isArray,
       };
       if ('validations' in config && config.validations) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In Chrome (and perhaps other browsers), form will be blocked from submitting if `input` has `type=number` and no `step` but user enters floats (e.g. `20.349`). This sets `step=any` for those fields). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
