### PR TITLE
fix: add datastore as dev dep

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
+++ b/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
@@ -18,10 +18,10 @@ import {
   GenericDataSchema,
   StudioComponent,
   getGenericFromDataStore,
-  Schema,
   StudioForm,
   StudioView,
 } from '@aws-amplify/codegen-ui';
+import { Schema } from '@aws-amplify/datastore';
 import { createPrinter, createSourceFile, EmitHint, NewLineKind, Node } from 'typescript';
 import { AmplifyFormRenderer } from '../../amplify-ui-renderers/amplify-form-renderer';
 import { AmplifyRenderer } from '../../amplify-ui-renderers/amplify-renderer';

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -6,13 +6,14 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-react",
-			"version": "2.5.0",
+			"version": "2.5.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript/vfs": "~1.3.5",
 				"typescript": "<=4.5.0"
 			},
 			"devDependencies": {
+				"@aws-amplify/datastore": "^3.12.12",
 				"@aws-amplify/ui-react": "^2.1.0",
 				"@types/node": "^16.3.3",
 				"@types/react": "^17.0.4",
@@ -172,16 +173,15 @@
 			}
 		},
 		"node_modules/@aws-amplify/datastore": {
-			"version": "3.12.2",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.2.tgz",
-			"integrity": "sha512-q9Rt//Hjde/9LWy2f7sMfauL64qwyU6GVKdaGvgVehpOp4L91XAp25xofxByCqPyyOhuiQ0mjrdp6pEpuMlHrQ==",
+			"version": "3.12.12",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.12.tgz",
+			"integrity": "sha512-uINHA1CD+MgM1LgbvoDKfvrhKjLIUvnU3KU8tLjvnQ0TjjQTR42NvgckyAgrVn/SKGCr9ien+ACRG/XGo5l8BA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@aws-amplify/api": "4.0.45",
-				"@aws-amplify/auth": "4.5.9",
-				"@aws-amplify/core": "4.5.9",
-				"@aws-amplify/pubsub": "4.4.6",
+				"@aws-amplify/api": "4.0.55",
+				"@aws-amplify/auth": "4.6.8",
+				"@aws-amplify/core": "4.7.6",
+				"@aws-amplify/pubsub": "4.5.5",
 				"amazon-cognito-identity-js": "5.2.10",
 				"idb": "5.0.6",
 				"immer": "9.0.6",
@@ -191,13 +191,100 @@
 				"zen-push": "0.2.1"
 			}
 		},
+		"node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api": {
+			"version": "4.0.55",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.55.tgz",
+			"integrity": "sha512-uW3+1JJaWfaCC35iqIwcI1sYCwbTDoNI3sNRQOfylf0AijIybcyxHlvbu6bk3ciTU0epto6SKXasSC53Q+ejfQ==",
+			"dev": true,
+			"dependencies": {
+				"@aws-amplify/api-graphql": "2.3.19",
+				"@aws-amplify/api-rest": "2.0.55"
+			}
+		},
+		"node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api-graphql": {
+			"version": "2.3.19",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.3.19.tgz",
+			"integrity": "sha512-b9mkisvarX4WrfhZQdk2JR3tmtfemL8ZUgspOvI45cePe7siNIc+4IyokZwMMw8My0p4HjIBsiu+baaA722Q2Q==",
+			"dev": true,
+			"dependencies": {
+				"@aws-amplify/api-rest": "2.0.55",
+				"@aws-amplify/auth": "4.6.8",
+				"@aws-amplify/cache": "4.0.57",
+				"@aws-amplify/core": "4.7.6",
+				"@aws-amplify/pubsub": "4.5.5",
+				"graphql": "15.8.0",
+				"uuid": "^3.2.1",
+				"zen-observable-ts": "0.8.19"
+			}
+		},
+		"node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api-rest": {
+			"version": "2.0.55",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.55.tgz",
+			"integrity": "sha512-QbTjNxxIeu/clCWBBU+53KUwZiCRbr3m4Yicz/yasqykO1cQlfjzT1vfRHKEJOLV0chfF1QfkhdQ9Xvmbq6RaQ==",
+			"dev": true,
+			"dependencies": {
+				"@aws-amplify/core": "4.7.6",
+				"axios": "0.26.0"
+			}
+		},
+		"node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/auth": {
+			"version": "4.6.8",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.6.8.tgz",
+			"integrity": "sha512-RGao7wlRPNVRpmohdPQiYEHUeCRBsQXlDFYRSLj6dXcPE6Sxk4OMnk/MTUSOQkKxD7qVygV5Y9aICq846j8TtQ==",
+			"dev": true,
+			"dependencies": {
+				"@aws-amplify/cache": "4.0.57",
+				"@aws-amplify/core": "4.7.6",
+				"amazon-cognito-identity-js": "5.2.10",
+				"crypto-js": "^4.1.1"
+			}
+		},
+		"node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/cache": {
+			"version": "4.0.57",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.57.tgz",
+			"integrity": "sha512-06IvJfEVZ7vgJSB13rEipdhBnQSnA91cXGi3Sl0KeiBj7p8ir4+2xhXevkqqjdPTSP8dsuZj+orLsxBltoZcsg==",
+			"dev": true,
+			"dependencies": {
+				"@aws-amplify/core": "4.7.6"
+			}
+		},
+		"node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/core": {
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.7.6.tgz",
+			"integrity": "sha512-Jtrt3yBXKJCejwQzDmT1lzYdMXwmWi5xDu9BCjFreo5CjELF+drmXv7LhKwSIyC8B6OG3juQ/gTnpEtpGTm9rA==",
+			"dev": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "1.0.0-alpha.0",
+				"@aws-sdk/client-cloudwatch-logs": "3.6.1",
+				"@aws-sdk/client-cognito-identity": "3.6.1",
+				"@aws-sdk/credential-provider-cognito-identity": "3.6.1",
+				"@aws-sdk/types": "3.6.1",
+				"@aws-sdk/util-hex-encoding": "3.6.1",
+				"universal-cookie": "^4.0.4",
+				"zen-observable-ts": "0.8.19"
+			}
+		},
+		"node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/pubsub": {
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.5.5.tgz",
+			"integrity": "sha512-9V/2Wdy1MrSZrPJXaOgitIsRo+lvn9Qxve88lM2NsO208ubKf3G4ttrpeOwZ87lUSgZG1vx8A8vpvEbWj/6PEQ==",
+			"dev": true,
+			"dependencies": {
+				"@aws-amplify/auth": "4.6.8",
+				"@aws-amplify/cache": "4.0.57",
+				"@aws-amplify/core": "4.7.6",
+				"graphql": "15.8.0",
+				"paho-mqtt": "^1.1.0",
+				"uuid": "^3.2.1",
+				"zen-observable-ts": "0.8.19"
+			}
+		},
 		"node_modules/@aws-amplify/datastore/node_modules/uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"uuid": "bin/uuid"
 			}
@@ -421,7 +508,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
 			"integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -431,7 +517,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
 			"integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/ie11-detection": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.2.2",
@@ -447,7 +532,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
 			"integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/util": "^1.2.2",
 				"@aws-sdk/types": "^3.1.0",
@@ -459,7 +543,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0-alpha.0.tgz",
 			"integrity": "sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "^1.0.0-alpha.0",
 				"@aws-sdk/util-utf8-browser": "^1.0.0-alpha.0",
@@ -471,7 +554,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz",
 			"integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -481,7 +563,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
 			"integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -491,7 +572,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
 			"integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "^3.1.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -503,7 +583,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
 			"integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			}
@@ -512,15 +591,13 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/abort-controller": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
 			"integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -555,7 +632,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.6.1.tgz",
 			"integrity": "sha512-QOxIDnlVTpnwJ26Gap6RGz61cDLH6TKrIp30VqwdMeT1pCGy8mn9rWln6XA+ymkofHy/08RfpGp+VN4axwd4Lw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
@@ -598,7 +674,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
 			"integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/util": "^1.2.2",
 				"@aws-sdk/types": "^3.1.0",
@@ -609,15 +684,13 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-utf8-browser": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
 			"integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			}
@@ -626,22 +699,19 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/tslib": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.6.1.tgz",
 			"integrity": "sha512-FMj2GR9R5oCKb3/NI16GIvWeHcE4uX42fBAaQKPbjg2gALFDx9CcJYsdOtDP37V89GtPyZilLv6GJxrwJKzYGg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
@@ -684,7 +754,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
 			"integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/util": "^1.2.2",
 				"@aws-sdk/types": "^3.1.0",
@@ -695,15 +764,13 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-utf8-browser": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
 			"integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			}
@@ -712,15 +779,13 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/client-comprehend": {
 			"version": "3.6.1",
@@ -3853,7 +3918,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
 			"integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/signature-v4": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -3868,7 +3932,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz",
 			"integrity": "sha512-uJ9q+yq+Dhdo32gcv0p/AT7sKSAUH0y4ts9XRK/vx0dW9Q3XJy99mOJlq/6fkh4LfWeavJJlaCo9lSHNMWXx4w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/client-cognito-identity": "3.6.1",
 				"@aws-sdk/property-provider": "3.6.1",
@@ -3884,7 +3947,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
 			"integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -3899,7 +3961,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
 			"integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -3914,7 +3975,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
 			"integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -3930,7 +3990,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
 			"integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.6.1",
 				"@aws-sdk/credential-provider-imds": "3.6.1",
@@ -3950,7 +4009,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
 			"integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/credential-provider-ini": "3.6.1",
 				"@aws-sdk/property-provider": "3.6.1",
@@ -4150,7 +4208,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
 			"integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/querystring-builder": "3.6.1",
@@ -4177,7 +4234,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
 			"integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"@aws-sdk/util-buffer-from": "3.6.1",
@@ -4206,7 +4262,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
 			"integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -4217,7 +4272,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
 			"integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			},
@@ -4284,7 +4338,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
 			"integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -4330,7 +4383,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
 			"integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -4359,7 +4411,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
 			"integrity": "sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -4373,7 +4424,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
 			"integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/service-error-classification": "3.6.1",
@@ -4525,7 +4575,6 @@
 			"resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
 			"integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"fast-base64-decode": "^1.0.0"
 			},
@@ -4569,7 +4618,6 @@
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"uuid": "bin/uuid"
 			}
@@ -4731,7 +4779,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
 			"integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -4745,7 +4792,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
 			"integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/signature-v4": "3.6.1",
@@ -4775,7 +4821,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
 			"integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			},
@@ -4788,7 +4833,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
 			"integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -4803,7 +4847,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
 			"integrity": "sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -4819,7 +4862,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
 			"integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/abort-controller": "3.6.1",
 				"@aws-sdk/protocol-http": "3.6.1",
@@ -4836,7 +4878,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
 			"integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -4850,7 +4891,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
 			"integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -4864,7 +4904,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
 			"integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"@aws-sdk/util-uri-escape": "3.6.1",
@@ -4879,7 +4918,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
 			"integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -4912,7 +4950,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
 			"integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -4922,7 +4959,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
 			"integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			},
@@ -4935,7 +4971,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
 			"integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/is-array-buffer": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -4952,7 +4987,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
 			"integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/middleware-stack": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -4967,7 +5001,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
 			"integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -4977,7 +5010,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.6.1.tgz",
 			"integrity": "sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/querystring-parser": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -4989,7 +5021,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz",
 			"integrity": "sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/querystring-parser": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -5018,7 +5049,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
 			"integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			}
@@ -5028,7 +5058,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
 			"integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/util-buffer-from": "3.6.1",
 				"tslib": "^1.8.0"
@@ -5042,7 +5071,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
 			"integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			}
@@ -5052,7 +5080,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
 			"integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			},
@@ -5065,7 +5092,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
 			"integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/is-array-buffer": "3.6.1",
 				"tslib": "^1.8.0"
@@ -5404,7 +5430,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
 			"integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			},
@@ -5417,7 +5442,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
 			"integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -5429,15 +5453,13 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@aws-sdk/util-uri-escape": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
 			"integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			},
@@ -5450,7 +5472,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
 			"integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "3.6.1",
 				"bowser": "^2.11.0",
@@ -5462,7 +5483,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
 			"integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/node-config-provider": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -5477,7 +5497,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
 			"integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.8.0"
 			}
@@ -5487,7 +5506,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
 			"integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/util-buffer-from": "3.6.1",
 				"tslib": "^1.8.0"
@@ -8608,8 +8626,7 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
 			"integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@types/geojson": {
 			"version": "7946.0.9",
@@ -8785,7 +8802,6 @@
 			"resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.10.tgz",
 			"integrity": "sha512-40ZFQeMjNRymyE7X7XwW78VHftPMFt3di0GsL2/lFfWOXJJWrJGuBFWBYvz/aFMpl/omZHuwwqfwR4bZ+xF5Wg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"buffer": "4.9.2",
 				"crypto-js": "^4.1.1",
@@ -9039,6 +9055,26 @@
 				"@aws-amplify/xr": "3.0.45"
 			}
 		},
+		"node_modules/aws-amplify/node_modules/@aws-amplify/datastore": {
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.2.tgz",
+			"integrity": "sha512-q9Rt//Hjde/9LWy2f7sMfauL64qwyU6GVKdaGvgVehpOp4L91XAp25xofxByCqPyyOhuiQ0mjrdp6pEpuMlHrQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@aws-amplify/api": "4.0.45",
+				"@aws-amplify/auth": "4.5.9",
+				"@aws-amplify/core": "4.5.9",
+				"@aws-amplify/pubsub": "4.4.6",
+				"amazon-cognito-identity-js": "5.2.10",
+				"idb": "5.0.6",
+				"immer": "9.0.6",
+				"ulid": "2.3.0",
+				"uuid": "3.3.2",
+				"zen-observable-ts": "0.8.19",
+				"zen-push": "0.2.1"
+			}
+		},
 		"node_modules/aws-amplify/node_modules/@aws-amplify/ui": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.5.tgz",
@@ -9046,12 +9082,22 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/aws-amplify/node_modules/uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
 		"node_modules/axios": {
 			"version": "0.26.0",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
 			"integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"follow-redirects": "^1.14.8"
 			}
@@ -9240,8 +9286,7 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			],
-			"peer": true
+			]
 		},
 		"node_modules/bl": {
 			"version": "4.1.0",
@@ -9284,8 +9329,7 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
 			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -9386,7 +9430,6 @@
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
 			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
@@ -9970,7 +10013,6 @@
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
 			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -10064,8 +10106,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/csscolorparser": {
 			"version": "1.0.3",
@@ -10672,8 +10713,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
 			"integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fast-xml-parser": {
 			"version": "3.19.0",
@@ -10823,7 +10863,6 @@
 					"url": "https://github.com/sponsors/RubenVerborgh"
 				}
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -11035,7 +11074,6 @@
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
 			"integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 10.x"
 			}
@@ -11230,8 +11268,7 @@
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/idb/-/idb-5.0.6.tgz",
 			"integrity": "sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
@@ -11271,7 +11308,6 @@
 			"resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
 			"integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
 			"dev": true,
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/immer"
@@ -11529,8 +11565,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -11554,7 +11589,6 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
 			"integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"node-fetch": "^2.6.1",
 				"unfetch": "^4.2.0"
@@ -11828,8 +11862,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
 			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -12886,7 +12919,6 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
 			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -13268,8 +13300,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/paho-mqtt/-/paho-mqtt-1.1.0.tgz",
 			"integrity": "sha512-KPbL9KAB0ASvhSDbOrZBaccXS+/s7/LIofbPyERww8hM5Ko71GUJQ6Nmg0BWqj8phAIT8zdf/Sd/RftHU9i2HA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -13649,8 +13680,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
 			"integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/qrcode": {
 			"version": "1.5.0",
@@ -13676,7 +13706,6 @@
 			"integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
 			"deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.4.x"
 			}
@@ -15285,8 +15314,7 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
@@ -15356,7 +15384,6 @@
 			"resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
 			"integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"ulid": "bin/cli.js"
 			}
@@ -15365,8 +15392,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
 			"integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",
@@ -15443,7 +15469,6 @@
 			"resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
 			"integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@types/cookie": "^0.3.3",
 				"cookie": "^0.4.0"
@@ -15590,7 +15615,6 @@
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -15762,8 +15786,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/whatwg-fetch": {
 			"version": "3.6.2",
@@ -15777,7 +15800,6 @@
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -15924,15 +15946,13 @@
 			"version": "0.8.15",
 			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
 			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/zen-observable-ts": {
 			"version": "0.8.19",
 			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
 			"integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^1.9.3",
 				"zen-observable": "^0.8.0"
@@ -15943,7 +15963,6 @@
 			"resolved": "https://registry.npmjs.org/zen-push/-/zen-push-0.2.1.tgz",
 			"integrity": "sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"zen-observable": "^0.7.0"
 			}
@@ -15952,8 +15971,7 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
 			"integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		}
 	},
 	"dependencies": {
@@ -16094,16 +16112,15 @@
 			}
 		},
 		"@aws-amplify/datastore": {
-			"version": "3.12.2",
-			"resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.2.tgz",
-			"integrity": "sha512-q9Rt//Hjde/9LWy2f7sMfauL64qwyU6GVKdaGvgVehpOp4L91XAp25xofxByCqPyyOhuiQ0mjrdp6pEpuMlHrQ==",
+			"version": "3.12.12",
+			"resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.12.tgz",
+			"integrity": "sha512-uINHA1CD+MgM1LgbvoDKfvrhKjLIUvnU3KU8tLjvnQ0TjjQTR42NvgckyAgrVn/SKGCr9ien+ACRG/XGo5l8BA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
-				"@aws-amplify/api": "4.0.45",
-				"@aws-amplify/auth": "4.5.9",
-				"@aws-amplify/core": "4.5.9",
-				"@aws-amplify/pubsub": "4.4.6",
+				"@aws-amplify/api": "4.0.55",
+				"@aws-amplify/auth": "4.6.8",
+				"@aws-amplify/core": "4.7.6",
+				"@aws-amplify/pubsub": "4.5.5",
 				"amazon-cognito-identity-js": "5.2.10",
 				"idb": "5.0.6",
 				"immer": "9.0.6",
@@ -16113,12 +16130,99 @@
 				"zen-push": "0.2.1"
 			},
 			"dependencies": {
+				"@aws-amplify/api": {
+					"version": "4.0.55",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.55.tgz",
+					"integrity": "sha512-uW3+1JJaWfaCC35iqIwcI1sYCwbTDoNI3sNRQOfylf0AijIybcyxHlvbu6bk3ciTU0epto6SKXasSC53Q+ejfQ==",
+					"dev": true,
+					"requires": {
+						"@aws-amplify/api-graphql": "2.3.19",
+						"@aws-amplify/api-rest": "2.0.55"
+					}
+				},
+				"@aws-amplify/api-graphql": {
+					"version": "2.3.19",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.3.19.tgz",
+					"integrity": "sha512-b9mkisvarX4WrfhZQdk2JR3tmtfemL8ZUgspOvI45cePe7siNIc+4IyokZwMMw8My0p4HjIBsiu+baaA722Q2Q==",
+					"dev": true,
+					"requires": {
+						"@aws-amplify/api-rest": "2.0.55",
+						"@aws-amplify/auth": "4.6.8",
+						"@aws-amplify/cache": "4.0.57",
+						"@aws-amplify/core": "4.7.6",
+						"@aws-amplify/pubsub": "4.5.5",
+						"graphql": "15.8.0",
+						"uuid": "^3.2.1",
+						"zen-observable-ts": "0.8.19"
+					}
+				},
+				"@aws-amplify/api-rest": {
+					"version": "2.0.55",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.55.tgz",
+					"integrity": "sha512-QbTjNxxIeu/clCWBBU+53KUwZiCRbr3m4Yicz/yasqykO1cQlfjzT1vfRHKEJOLV0chfF1QfkhdQ9Xvmbq6RaQ==",
+					"dev": true,
+					"requires": {
+						"@aws-amplify/core": "4.7.6",
+						"axios": "0.26.0"
+					}
+				},
+				"@aws-amplify/auth": {
+					"version": "4.6.8",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.6.8.tgz",
+					"integrity": "sha512-RGao7wlRPNVRpmohdPQiYEHUeCRBsQXlDFYRSLj6dXcPE6Sxk4OMnk/MTUSOQkKxD7qVygV5Y9aICq846j8TtQ==",
+					"dev": true,
+					"requires": {
+						"@aws-amplify/cache": "4.0.57",
+						"@aws-amplify/core": "4.7.6",
+						"amazon-cognito-identity-js": "5.2.10",
+						"crypto-js": "^4.1.1"
+					}
+				},
+				"@aws-amplify/cache": {
+					"version": "4.0.57",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.57.tgz",
+					"integrity": "sha512-06IvJfEVZ7vgJSB13rEipdhBnQSnA91cXGi3Sl0KeiBj7p8ir4+2xhXevkqqjdPTSP8dsuZj+orLsxBltoZcsg==",
+					"dev": true,
+					"requires": {
+						"@aws-amplify/core": "4.7.6"
+					}
+				},
+				"@aws-amplify/core": {
+					"version": "4.7.6",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.7.6.tgz",
+					"integrity": "sha512-Jtrt3yBXKJCejwQzDmT1lzYdMXwmWi5xDu9BCjFreo5CjELF+drmXv7LhKwSIyC8B6OG3juQ/gTnpEtpGTm9rA==",
+					"dev": true,
+					"requires": {
+						"@aws-crypto/sha256-js": "1.0.0-alpha.0",
+						"@aws-sdk/client-cloudwatch-logs": "3.6.1",
+						"@aws-sdk/client-cognito-identity": "3.6.1",
+						"@aws-sdk/credential-provider-cognito-identity": "3.6.1",
+						"@aws-sdk/types": "3.6.1",
+						"@aws-sdk/util-hex-encoding": "3.6.1",
+						"universal-cookie": "^4.0.4",
+						"zen-observable-ts": "0.8.19"
+					}
+				},
+				"@aws-amplify/pubsub": {
+					"version": "4.5.5",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.5.5.tgz",
+					"integrity": "sha512-9V/2Wdy1MrSZrPJXaOgitIsRo+lvn9Qxve88lM2NsO208ubKf3G4ttrpeOwZ87lUSgZG1vx8A8vpvEbWj/6PEQ==",
+					"dev": true,
+					"requires": {
+						"@aws-amplify/auth": "4.6.8",
+						"@aws-amplify/cache": "4.0.57",
+						"@aws-amplify/core": "4.7.6",
+						"graphql": "15.8.0",
+						"paho-mqtt": "^1.1.0",
+						"uuid": "^3.2.1",
+						"zen-observable-ts": "0.8.19"
+					}
+				},
 				"uuid": {
 					"version": "3.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -16315,7 +16419,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
 			"integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			}
@@ -16325,7 +16428,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
 			"integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-crypto/ie11-detection": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.2.2",
@@ -16341,7 +16443,6 @@
 					"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
 					"integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"@aws-crypto/util": "^1.2.2",
 						"@aws-sdk/types": "^3.1.0",
@@ -16355,7 +16456,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0-alpha.0.tgz",
 			"integrity": "sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "^1.0.0-alpha.0",
 				"@aws-sdk/util-utf8-browser": "^1.0.0-alpha.0",
@@ -16366,8 +16466,7 @@
 					"version": "1.0.0-rc.10",
 					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz",
 					"integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -16376,7 +16475,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
 			"integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			}
@@ -16386,7 +16484,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
 			"integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "^3.1.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -16398,7 +16495,6 @@
 					"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
 					"integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"tslib": "^2.3.1"
 					},
@@ -16407,8 +16503,7 @@
 							"version": "2.4.0",
 							"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 							"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-							"dev": true,
-							"peer": true
+							"dev": true
 						}
 					}
 				}
@@ -16419,7 +16514,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
 			"integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -16451,7 +16545,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.6.1.tgz",
 			"integrity": "sha512-QOxIDnlVTpnwJ26Gap6RGz61cDLH6TKrIp30VqwdMeT1pCGy8mn9rWln6XA+ymkofHy/08RfpGp+VN4axwd4Lw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
@@ -16491,7 +16584,6 @@
 					"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
 					"integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"@aws-crypto/util": "^1.2.2",
 						"@aws-sdk/types": "^3.1.0",
@@ -16502,8 +16594,7 @@
 							"version": "1.14.1",
 							"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 							"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-							"dev": true,
-							"peer": true
+							"dev": true
 						}
 					}
 				},
@@ -16512,7 +16603,6 @@
 					"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
 					"integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"tslib": "^1.8.0"
 					},
@@ -16521,8 +16611,7 @@
 							"version": "1.14.1",
 							"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 							"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-							"dev": true,
-							"peer": true
+							"dev": true
 						}
 					}
 				},
@@ -16530,8 +16619,7 @@
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -16540,7 +16628,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.6.1.tgz",
 			"integrity": "sha512-FMj2GR9R5oCKb3/NI16GIvWeHcE4uX42fBAaQKPbjg2gALFDx9CcJYsdOtDP37V89GtPyZilLv6GJxrwJKzYGg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "^1.0.0",
 				"@aws-crypto/sha256-js": "^1.0.0",
@@ -16580,7 +16667,6 @@
 					"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
 					"integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"@aws-crypto/util": "^1.2.2",
 						"@aws-sdk/types": "^3.1.0",
@@ -16591,8 +16677,7 @@
 							"version": "1.14.1",
 							"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 							"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-							"dev": true,
-							"peer": true
+							"dev": true
 						}
 					}
 				},
@@ -16601,7 +16686,6 @@
 					"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
 					"integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"tslib": "^1.8.0"
 					},
@@ -16610,8 +16694,7 @@
 							"version": "1.14.1",
 							"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 							"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-							"dev": true,
-							"peer": true
+							"dev": true
 						}
 					}
 				},
@@ -16619,8 +16702,7 @@
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -19510,7 +19592,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
 			"integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/signature-v4": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -19522,7 +19603,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz",
 			"integrity": "sha512-uJ9q+yq+Dhdo32gcv0p/AT7sKSAUH0y4ts9XRK/vx0dW9Q3XJy99mOJlq/6fkh4LfWeavJJlaCo9lSHNMWXx4w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/client-cognito-identity": "3.6.1",
 				"@aws-sdk/property-provider": "3.6.1",
@@ -19535,7 +19615,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
 			"integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -19547,7 +19626,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
 			"integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -19559,7 +19637,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
 			"integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -19572,7 +19649,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
 			"integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/credential-provider-env": "3.6.1",
 				"@aws-sdk/credential-provider-imds": "3.6.1",
@@ -19589,7 +19665,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
 			"integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/credential-provider-ini": "3.6.1",
 				"@aws-sdk/property-provider": "3.6.1",
@@ -19756,7 +19831,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
 			"integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/querystring-builder": "3.6.1",
@@ -19783,7 +19857,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
 			"integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"@aws-sdk/util-buffer-from": "3.6.1",
@@ -19806,7 +19879,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
 			"integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -19817,7 +19889,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
 			"integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -19877,7 +19948,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
 			"integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -19914,7 +19984,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
 			"integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -19937,7 +20006,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
 			"integrity": "sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -19948,7 +20016,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
 			"integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/service-error-classification": "3.6.1",
@@ -20044,7 +20111,7 @@
 						"anser": "^1.4.9",
 						"base64-js": "^1.1.2",
 						"event-target-shim": "^5.0.1",
-						"hermes-engine": ">=0.10.0",
+						"hermes-engine": "~0.11.0",
 						"invariant": "^2.2.4",
 						"jsc-android": "^250230.2.1",
 						"memoize-one": "^5.0.0",
@@ -20073,7 +20140,6 @@
 					"resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
 					"integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"fast-base64-decode": "^1.0.0"
 					}
@@ -20106,8 +20172,7 @@
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -20240,7 +20305,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
 			"integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -20251,7 +20315,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
 			"integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/signature-v4": "3.6.1",
@@ -20275,7 +20338,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
 			"integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20285,7 +20347,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
 			"integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/protocol-http": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -20297,7 +20358,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
 			"integrity": "sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/property-provider": "3.6.1",
 				"@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -20310,7 +20370,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
 			"integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/abort-controller": "3.6.1",
 				"@aws-sdk/protocol-http": "3.6.1",
@@ -20324,7 +20383,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
 			"integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -20335,7 +20393,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
 			"integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -20346,7 +20403,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
 			"integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"@aws-sdk/util-uri-escape": "3.6.1",
@@ -20358,7 +20414,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
 			"integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"tslib": "^1.8.0"
@@ -20384,15 +20439,13 @@
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
 			"integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@aws-sdk/shared-ini-file-loader": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
 			"integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20402,7 +20455,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
 			"integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/is-array-buffer": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -20416,7 +20468,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
 			"integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/middleware-stack": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -20427,15 +20478,13 @@
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
 			"integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@aws-sdk/url-parser": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.6.1.tgz",
 			"integrity": "sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/querystring-parser": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -20447,7 +20496,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz",
 			"integrity": "sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/querystring-parser": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -20470,7 +20518,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
 			"integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20480,7 +20527,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
 			"integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/util-buffer-from": "3.6.1",
 				"tslib": "^1.8.0"
@@ -20491,7 +20537,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
 			"integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20501,7 +20546,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
 			"integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20511,7 +20555,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
 			"integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/is-array-buffer": "3.6.1",
 				"tslib": "^1.8.0"
@@ -20795,7 +20838,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
 			"integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20805,7 +20847,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
 			"integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			},
@@ -20814,8 +20855,7 @@
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -20824,7 +20864,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
 			"integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20834,7 +20873,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
 			"integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/types": "3.6.1",
 				"bowser": "^2.11.0",
@@ -20846,7 +20884,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
 			"integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/node-config-provider": "3.6.1",
 				"@aws-sdk/types": "3.6.1",
@@ -20858,7 +20895,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
 			"integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.8.0"
 			}
@@ -20868,7 +20904,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
 			"integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aws-sdk/util-buffer-from": "3.6.1",
 				"tslib": "^1.8.0"
@@ -23141,7 +23176,7 @@
 				"open": "^6.2.0",
 				"ora": "^5.4.1",
 				"semver": "^6.3.0",
-				"shell-quote": ">=1.7.3"
+				"shell-quote": "^1.7.3"
 			},
 			"dependencies": {
 				"semver": {
@@ -23240,8 +23275,7 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
 			"integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@types/geojson": {
 			"version": "7946.0.9",
@@ -23398,7 +23432,6 @@
 			"resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.10.tgz",
 			"integrity": "sha512-40ZFQeMjNRymyE7X7XwW78VHftPMFt3di0GsL2/lFfWOXJJWrJGuBFWBYvz/aFMpl/omZHuwwqfwR4bZ+xF5Wg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"buffer": "4.9.2",
 				"crypto-js": "^4.1.1",
@@ -23608,10 +23641,37 @@
 				"@aws-amplify/xr": "3.0.45"
 			},
 			"dependencies": {
+				"@aws-amplify/datastore": {
+					"version": "3.12.2",
+					"resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.2.tgz",
+					"integrity": "sha512-q9Rt//Hjde/9LWy2f7sMfauL64qwyU6GVKdaGvgVehpOp4L91XAp25xofxByCqPyyOhuiQ0mjrdp6pEpuMlHrQ==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"@aws-amplify/api": "4.0.45",
+						"@aws-amplify/auth": "4.5.9",
+						"@aws-amplify/core": "4.5.9",
+						"@aws-amplify/pubsub": "4.4.6",
+						"amazon-cognito-identity-js": "5.2.10",
+						"idb": "5.0.6",
+						"immer": "9.0.6",
+						"ulid": "2.3.0",
+						"uuid": "3.3.2",
+						"zen-observable-ts": "0.8.19",
+						"zen-push": "0.2.1"
+					}
+				},
 				"@aws-amplify/ui": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.5.tgz",
 					"integrity": "sha512-atoc/zIJRhgpoSDDKgRxbTSD7D9S4wbOzHUHMqRlcEPRKqRrQPGvd6zCUVSBS0jqdrrw6+UTJbWj7ttWCfE4pQ==",
+					"dev": true,
+					"peer": true
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 					"dev": true,
 					"peer": true
 				}
@@ -23622,7 +23682,6 @@
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
 			"integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"follow-redirects": "^1.14.8"
 			}
@@ -23775,8 +23834,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"bl": {
 			"version": "4.1.0",
@@ -23807,8 +23865,7 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
 			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -23886,7 +23943,6 @@
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
 			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
@@ -24387,8 +24443,7 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
 			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -24464,8 +24519,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"csscolorparser": {
 			"version": "1.0.3",
@@ -24960,8 +25014,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
 			"integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fast-xml-parser": {
 			"version": "3.19.0",
@@ -25080,8 +25133,7 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
 			"integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -25232,8 +25284,7 @@
 			"version": "15.8.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
 			"integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"grid-index": {
 			"version": "1.1.0",
@@ -25397,8 +25448,7 @@
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/idb/-/idb-5.0.6.tgz",
 			"integrity": "sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -25417,8 +25467,7 @@
 			"version": "9.0.6",
 			"resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
 			"integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"import-fresh": {
 			"version": "2.0.0",
@@ -25620,8 +25669,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -25642,7 +25690,6 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
 			"integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"node-fetch": "^2.6.1",
 				"unfetch": "^4.2.0"
@@ -25866,8 +25913,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
 			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -26768,7 +26814,6 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
 			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
 			}
@@ -27052,8 +27097,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/paho-mqtt/-/paho-mqtt-1.1.0.tgz",
 			"integrity": "sha512-KPbL9KAB0ASvhSDbOrZBaccXS+/s7/LIofbPyERww8hM5Ko71GUJQ6Nmg0BWqj8phAIT8zdf/Sd/RftHU9i2HA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"param-case": {
 			"version": "3.0.4",
@@ -27371,8 +27415,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
 			"integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"qrcode": {
 			"version": "1.5.0",
@@ -27390,8 +27433,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
 			"integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"quick-lru": {
 			"version": "4.0.1",
@@ -27430,7 +27472,7 @@
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"shell-quote": ">=1.7.3",
+				"shell-quote": "^1.6.1",
 				"ws": "^7"
 			},
 			"dependencies": {
@@ -28714,8 +28756,7 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.14.1",
@@ -28766,15 +28807,13 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
 			"integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"unfetch": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
 			"integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",
@@ -28835,7 +28874,6 @@
 			"resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
 			"integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@types/cookie": "^0.3.3",
 				"cookie": "^0.4.0"
@@ -28955,7 +28993,6 @@
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -29086,8 +29123,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"whatwg-fetch": {
 			"version": "3.6.2",
@@ -29101,7 +29137,6 @@
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -29226,15 +29261,13 @@
 			"version": "0.8.15",
 			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
 			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"zen-observable-ts": {
 			"version": "0.8.19",
 			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
 			"integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"tslib": "^1.9.3",
 				"zen-observable": "^0.8.0"
@@ -29245,7 +29278,6 @@
 			"resolved": "https://registry.npmjs.org/zen-push/-/zen-push-0.2.1.tgz",
 			"integrity": "sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"zen-observable": "^0.7.0"
 			},
@@ -29254,8 +29286,7 @@
 					"version": "0.7.1",
 					"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
 					"integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		}

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -20,6 +20,7 @@
     "build:watch": "npm run build -- --watch"
   },
   "devDependencies": {
+    "@aws-amplify/datastore": "^3.12.12",
     "@aws-amplify/ui-react": "^2.1.0",
     "@types/node": "^16.3.3",
     "@types/react": "^17.0.4",


### PR DESCRIPTION
*Description of changes:*
`Schema` is no longer being exported from `codegen-ui`, so test throws a type error when running. This adds datastore as a dev dep of `codegen-ui-react` directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
