### PR TITLE
feat: init form support for has-one relationship

### DIFF
--- a/packages/codegen-ui/lib/__tests__/check-support.test.ts
+++ b/packages/codegen-ui/lib/__tests__/check-support.test.ts
@@ -29,13 +29,6 @@ describe('checkIsSupportedAsForm', () => {
     const model: GenericDataModel = {
       fields: {
         nonModel: { dataType: { nonModel: 'myNonModel' }, required: false, readOnly: false, isArray: false },
-        relationship: {
-          dataType: 'ID',
-          required: false,
-          readOnly: false,
-          isArray: false,
-          relationship: { type: 'HAS_ONE', relatedModelName: 'RelatedModel' },
-        },
       },
     };
 
@@ -46,13 +39,6 @@ describe('checkIsSupportedAsForm', () => {
     const model: GenericDataModel = {
       fields: {
         nonModel: { dataType: { nonModel: 'myNonModel' }, required: false, readOnly: false, isArray: false },
-        relationship: {
-          dataType: 'ID',
-          required: false,
-          readOnly: false,
-          isArray: false,
-          relationship: { type: 'HAS_ONE', relatedModelName: 'RelatedModel' },
-        },
         supportedField: { dataType: 'Boolean', required: false, readOnly: false, isArray: false },
       },
     };
@@ -69,5 +55,21 @@ describe('checkIsSupportedAsForm', () => {
     };
 
     expect(checkIsSupportedAsForm(model)).toBe(false);
+  });
+
+  it('should support relationships', () => {
+    const model: GenericDataModel = {
+      fields: {
+        relationship: {
+          dataType: 'ID',
+          required: true,
+          readOnly: false,
+          isArray: false,
+          relationship: { type: 'HAS_ONE', relatedModelName: 'RelatedModel' },
+        },
+      },
+    };
+
+    expect(checkIsSupportedAsForm(model)).toBe(true);
   });
 });

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -71,7 +71,6 @@ describe('generateFormDefinition', () => {
         dataType: { dataSourceType: 'DataStore', dataTypeName: 'Dog' },
         fields: {
           tricks: {
-            dataType: 'String',
             inputType: {
               isArray: true,
               type: 'TextField',

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
@@ -18,13 +18,16 @@ import { mapFormFieldConfig, getFormDefinitionInputElement } from '../../../gene
 import { mergeValueMappings } from '../../../generate-form-definition/helpers/form-field';
 import {
   FormDefinition,
+  GenericDataRelationshipType,
   GenericValidationType,
   ModelFieldsConfigs,
   StringLengthValidationType,
   StudioFormFieldConfig,
+  StudioFormValueMappings,
   StudioGenericFieldConfig,
   ValidationTypes,
 } from '../../../types';
+import { ExtendedStudioGenericFieldConfig } from '../../../types/form/form-definition';
 import { getBasicFormDefinition } from '../../__utils__/basic-form-definition';
 
 describe('mapFormFieldConfig', () => {
@@ -498,6 +501,46 @@ describe('getFormDefinitionInputElement', () => {
     });
   });
 
+  it('should get Autocomplete', () => {
+    const valueMappings: StudioFormValueMappings = {
+      values: [{ value: { bindingProperties: { property: 'Owner', field: 'id' } } }],
+      bindingProperties: { Owner: { type: 'Data', bindingProperties: { model: 'Owner' } } },
+    };
+
+    const dataType = { model: 'Owner' };
+
+    const relationship: GenericDataRelationshipType = { relatedModelName: 'Owner', type: 'HAS_ONE' };
+
+    const config: ExtendedStudioGenericFieldConfig = {
+      dataType,
+      inputType: {
+        name: 'Owner',
+        readOnly: false,
+        required: true,
+        type: 'Autocomplete',
+        value: 'Owner',
+        isArray: false,
+        valueMappings,
+      },
+      label: 'Owner',
+      relationship,
+    };
+
+    expect(getFormDefinitionInputElement(config)).toStrictEqual({
+      componentType: 'Autocomplete',
+      props: {
+        label: 'Owner',
+        isReadOnly: false,
+        isRequired: true,
+      },
+      valueMappings,
+      dataType,
+      relationship,
+      isArray: false,
+      validations: [{ type: ValidationTypes.REQUIRED, immutable: true, validationMessage: 'Owner is required.' }],
+    });
+  });
+
   it('should return default valueMappings for RadioGroupField if no values available', () => {
     const config = {
       inputType: {
@@ -517,7 +560,7 @@ describe('getFormDefinitionInputElement', () => {
   });
 
   it('should handle valueMappings for RadioGroupField of Boolean type', () => {
-    const config: StudioFormFieldConfig = {
+    const config: ExtendedStudioGenericFieldConfig = {
       dataType: 'Boolean',
       inputType: {
         type: 'RadioGroupField',

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -163,7 +163,53 @@ describe('mapModelFieldsConfigs', () => {
     });
   });
 
-  it('should add relationship fields to configs but not to matrix', () => {
+  it('should add model-type relationship fields to configs and matrix', () => {
+    const formDefinition: FormDefinition = getBasicFormDefinition();
+
+    const dataSchema: GenericDataSchema = {
+      dataSourceType: 'DataStore',
+      enums: {},
+      nonModels: {},
+      models: {
+        Dog: {
+          fields: {
+            Owner: {
+              dataType: { model: 'Owner' },
+              readOnly: false,
+              required: false,
+              isArray: false,
+              relationship: { type: 'HAS_ONE', relatedModelName: 'Owner' },
+            },
+          },
+        },
+      },
+    };
+
+    const modelFieldsConfigs = mapModelFieldsConfigs({ dataTypeName: 'Dog', formDefinition, dataSchema });
+
+    expect(formDefinition.elementMatrix).toStrictEqual([['Owner']]);
+    expect(modelFieldsConfigs).toStrictEqual({
+      Owner: {
+        dataType: { model: 'Owner' },
+        inputType: {
+          name: 'Owner',
+          readOnly: false,
+          required: false,
+          type: 'Autocomplete',
+          value: 'Owner',
+          isArray: false,
+          valueMappings: {
+            values: [{ value: { bindingProperties: { property: 'Owner', field: 'id' } } }],
+            bindingProperties: { Owner: { type: 'Data', bindingProperties: { model: 'Owner' } } },
+          },
+        },
+        label: 'Owner',
+        relationship: { relatedModelName: 'Owner', type: 'HAS_ONE' },
+      },
+    });
+  });
+
+  it('should add not-model type relationship fields to configs but not to matrix', () => {
     const formDefinition: FormDefinition = getBasicFormDefinition();
 
     const dataSchema: GenericDataSchema = {
@@ -195,11 +241,12 @@ describe('mapModelFieldsConfigs', () => {
           name: 'ownerId',
           readOnly: false,
           required: false,
-          type: 'SelectField',
+          type: 'Autocomplete',
           value: 'ownerId',
           isArray: false,
         },
         label: 'Owner id',
+        relationship: { relatedModelName: 'Owner', type: 'HAS_ONE' },
       },
     });
   });

--- a/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
@@ -101,6 +101,32 @@ describe('mapFormMetaData', () => {
     expect(fieldConfigs.badges.isArray).toBe(true);
   });
 
+  it('should map relationship if it exists', () => {
+    const dataSchema = getGenericFromDataStore(schemaWithAssumptions);
+
+    const form: StudioForm = {
+      name: 'DataStoreForm',
+      formActionType: 'create',
+      dataType: {
+        dataSourceType: 'DataStore',
+        dataTypeName: 'User',
+      },
+      fields: {},
+      sectionalElements: {},
+      style: {},
+      cta: {},
+    };
+
+    const { fieldConfigs } = mapFormMetadata(form, generateFormDefinition({ form, dataSchema }));
+
+    expect('friends' in fieldConfigs).toBe(true);
+    expect(fieldConfigs.friends.relationship).toStrictEqual({
+      type: 'HAS_MANY',
+      relatedModelName: 'Friend',
+      relatedModelField: 'friendId',
+    });
+  });
+
   describe('generateUniqueFieldName tests', () => {
     let usedFieldNames: Set<string>;
     beforeEach(() => {

--- a/packages/codegen-ui/lib/check-support.ts
+++ b/packages/codegen-ui/lib/check-support.ts
@@ -22,7 +22,6 @@ import { GenericDataField, GenericDataModel } from './types';
 export const checkIsSupportedAsFormField = (field: GenericDataField): boolean => {
   const unsupportedFieldMap: { [key: string]: (f: GenericDataField) => boolean } = {
     nonModel: (f) => typeof f.dataType === 'object' && 'nonModel' in f.dataType,
-    relationship: (f) => !!f.relationship,
   };
 
   const unsupportedArray = Object.values(unsupportedFieldMap);

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
@@ -86,8 +86,8 @@ export const FIELD_TYPE_MAP: {
     supportedComponents: new Set(['RadioGroupField', 'SelectField']),
   },
   Relationship: {
-    defaultComponent: 'SelectField',
-    supportedComponents: new Set(['SelectField']),
+    defaultComponent: 'Autocomplete',
+    supportedComponents: new Set(['Autocomplete']),
   },
   NonModel: {
     defaultComponent: 'TextAreaField',

--- a/packages/codegen-ui/lib/types/form/fields.ts
+++ b/packages/codegen-ui/lib/types/form/fields.ts
@@ -16,7 +16,6 @@
 import { StudioFieldPosition } from './position';
 import { StudioFieldInputConfig } from './input-config';
 import { FieldValidationConfiguration } from './form-validation';
-import { DataFieldDataType } from '../data';
 
 /**
  * Field configurations for StudioForm
@@ -40,7 +39,6 @@ export type StudioGenericFieldConfig = {
    * The configuration for what type of input is used.
    */
   inputType?: StudioFieldInputConfig;
-  dataType?: DataFieldDataType;
 } & StudioFieldConfig;
 
 export type StudioFormFieldConfig = StudioGenericFieldConfig | ExcludedStudioFieldConfig;

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 
-import { DataFieldDataType } from '../data';
+import { DataFieldDataType, GenericDataRelationshipType } from '../data';
 import { FieldValidationConfiguration } from './form-validation';
 import { StudioFormValueMappings } from './input-config';
 
@@ -22,6 +22,7 @@ type FormDefinitionInputElementCommon = {
   dataType?: DataFieldDataType;
   validations?: (FieldValidationConfiguration & { immutable?: true })[];
   isArray?: boolean;
+  relationship?: GenericDataRelationshipType;
 };
 
 export type FormDefinitionTextFieldElement = {
@@ -45,6 +46,19 @@ export type FormDefinitionTextFieldElement = {
     | 'URLField'
     | 'EmailField'
     | 'PhoneNumberField';
+};
+
+export type FormDefinitionAutocompleteElement = {
+  componentType: 'Autocomplete';
+  props: {
+    label: string;
+    descriptiveText?: string;
+    isRequired?: boolean;
+    isReadOnly?: boolean;
+    placeholder?: string;
+    defaultValue?: string;
+  };
+  valueMappings: StudioFormValueMappings;
 };
 
 export type FormDefinitionSwitchFieldElement = {
@@ -178,6 +192,7 @@ export type FormDefinitionInputElement = (
   | FormDefinitionCheckboxFieldElement
   | FormDefinitionRadioGroupFieldElement
   | FormDefinitionPasswordFieldElement
+  | FormDefinitionAutocompleteElement
 ) &
   FormDefinitionInputElementCommon;
 

--- a/packages/codegen-ui/lib/types/form/form-definition.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition.ts
@@ -16,8 +16,14 @@
 import { FormStyleConfig } from './style';
 import { FormDefinitionElement, FormDefinitionButtonElement } from './form-definition-element';
 import { StudioGenericFieldConfig } from './fields';
+import { DataFieldDataType, GenericDataRelationshipType } from '../data';
 
-export type ModelFieldsConfigs = { [key: string]: StudioGenericFieldConfig };
+export type ExtendedStudioGenericFieldConfig = StudioGenericFieldConfig & {
+  dataType?: DataFieldDataType;
+  relationship?: GenericDataRelationshipType;
+};
+
+export type ModelFieldsConfigs = { [key: string]: ExtendedStudioGenericFieldConfig };
 
 export type ButtonConfig = {
   buttonConfigs: {

--- a/packages/codegen-ui/lib/types/form/form-metadata.ts
+++ b/packages/codegen-ui/lib/types/form/form-metadata.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { DataFieldDataType } from '../data';
+import { DataFieldDataType, GenericDataRelationshipType } from '../data';
 import { FieldValidationConfiguration } from './form-validation';
 import { FormStyleConfig, StudioFormStyle } from './style';
 
@@ -27,6 +27,7 @@ export type FieldConfigMetadata = {
   validationRules: FieldValidationConfiguration[];
   // component field is of type AWSTimestamp will need to map this to date then get time from date
   dataType?: DataFieldDataType;
+  relationship?: GenericDataRelationshipType;
   // for JSON type with invalid variable field name ie. { "1first-Name": "John" } => "firstName"
   sanitizedFieldName?: string;
   isArray?: boolean;

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -75,7 +75,7 @@ export type FormInputType =
   | 'URLField'
   | 'EmailField'
   | 'JSONField'
-  | 'ArrayField';
+  | 'Autocomplete';
 
 export * from './form-definition-element';
 export * from './style';


### PR DESCRIPTION
*Description of changes:*
- Allow forms with required relationships to be mapped
- Map relationship fields to form definition element and form metaData as `Autocomplete`
- Generate default valueMappings from related model info for `HAS_ONE` model-type relationships


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
