### PR TITLE
chore: map props on relationship-based Autocomplete

### DIFF
--- a/packages/codegen-ui-golden-files/lib/react/forms/datastore-create-form-with-has-one-relationship/BookCreateForm.jsx
+++ b/packages/codegen-ui-golden-files/lib/react/forms/datastore-create-form-with-has-one-relationship/BookCreateForm.jsx
@@ -330,7 +330,7 @@ export default function BookCreateForm(props) {
           isRequired={false}
           isReadOnly={false}
           onChange={(e) => {
-            // called when user is tping
+            // called when user is typing
             let { value } = e.target;
             if (errors.primaryAuthor?.hasError) {
               runValidationTasks('primaryAuthor', value);
@@ -340,7 +340,7 @@ export default function BookCreateForm(props) {
           }}
           suggestions={Array.from(authorRecords).map(([key, record]) => ({
             id: key,
-            label: getDisplayValue['primaryAuthor'](record),
+            label: getDisplayValue['primaryAuthor']?.(record) ?? key,
           }))}
           onSuggestionSelect={({ id, label }) => {
             setCurrentPrimaryAuthorValue(authorRecords.find((r) => r.id === id));

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -417,7 +417,7 @@ export default function CustomDataForm(props) {
   };
   const [name, setName] = React.useState(initialValues.name);
   const [email, setEmail] = React.useState(initialValues.email);
-  const [metadatafield, setMetadatafield] = React.useState(
+  const [metadataField, setMetadataField] = React.useState(
     initialValues[\\"metadata-field\\"]
   );
   const [city, setCity] = React.useState(initialValues.city);
@@ -428,7 +428,7 @@ export default function CustomDataForm(props) {
     const cleanValues = { ...initialValues, ...initialData };
     setName(cleanValues.name);
     setEmail(cleanValues.email);
-    setMetadatafield(cleanValues[\\"metadata-field\\"]);
+    setMetadataField(cleanValues[\\"metadata-field\\"]);
     setCity(cleanValues.city);
     setCategory(cleanValues.category);
     setPages(cleanValues.pages);
@@ -439,7 +439,7 @@ export default function CustomDataForm(props) {
     if (initialData) {
       setName(initialData.name);
       setEmail(initialData.email);
-      setMetadatafield(initialData[\\"metadata-field\\"]);
+      setMetadataField(initialData[\\"metadata-field\\"]);
       setCity(initialData.city);
       setCategory(initialData.category);
       setPages(initialData.pages);
@@ -473,7 +473,7 @@ export default function CustomDataForm(props) {
         const modelFields = {
           name,
           email,
-          \\"metadata-field\\": metadatafield,
+          \\"metadata-field\\": metadataField,
           city,
           category,
           pages,
@@ -513,7 +513,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name: value,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category,
               pages,
@@ -542,7 +542,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email: value,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category,
               pages,
@@ -563,14 +563,14 @@ export default function CustomDataForm(props) {
       <TextAreaField
         label=\\"Metadata\\"
         isRequired={true}
-        defaultValue={metadatafield}
+        defaultValue={metadataField}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": value,
               city,
               category,
               pages,
@@ -581,9 +581,9 @@ export default function CustomDataForm(props) {
           if (errors[\\"metadata-field\\"]?.hasError) {
             runValidationTasks(\\"metadata-field\\", value);
           }
-          setMetadatafield(value);
+          setMetadataField(value);
         }}
-        onBlur={() => runValidationTasks(\\"metadata-field\\", metadatafield)}
+        onBlur={() => runValidationTasks(\\"metadata-field\\", metadataField)}
         errorMessage={errors[\\"metadata-field\\"]?.errorMessage}
         hasError={errors[\\"metadata-field\\"]?.hasError}
         {...getOverrideProps(overrides, \\"metadata-field\\")}
@@ -598,7 +598,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city: value,
               category,
               pages,
@@ -644,7 +644,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category: value,
               pages,
@@ -687,7 +687,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category,
               pages: value,
@@ -1910,7 +1910,7 @@ export default function NestedJson(props) {
   const [lastName, setLastName] = React.useState(initialValues.lastName);
   const [bio, setBio] = React.useState(initialValues.bio);
   const [Nicknames1, setNicknames1] = React.useState(initialValues.Nicknames1);
-  const [nicknames, setNicknames] = React.useState(
+  const [nickNames, setNickNames] = React.useState(
     initialValues[\\"nick-names2\\"]
   );
   const [firstName1, setFirstName1] = React.useState(
@@ -1923,17 +1923,17 @@ export default function NestedJson(props) {
     setBio(initialValues.bio);
     setNicknames1(initialValues.Nicknames1);
     setCurrentNicknames1Value(undefined);
-    setNicknames(initialValues[\\"nick-names2\\"]);
-    setCurrentNicknamesValue(undefined);
+    setNickNames(initialValues[\\"nick-names2\\"]);
+    setCurrentNickNamesValue(undefined);
     setFirstName1(initialValues[\\"first Name\\"]);
     setErrors({});
   };
   const [currentNicknames1Value, setCurrentNicknames1Value] =
     React.useState(undefined);
   const Nicknames1Ref = React.createRef();
-  const [currentNicknamesValue, setCurrentNicknamesValue] =
+  const [currentNickNamesValue, setCurrentNickNamesValue] =
     React.useState(undefined);
-  const nicknamesRef = React.createRef();
+  const nickNamesRef = React.createRef();
   const validations = {
     \\"first-Name\\": [],
     lastName: [],
@@ -1965,7 +1965,7 @@ export default function NestedJson(props) {
           lastName,
           bio,
           Nicknames1,
-          \\"nick-names2\\": nicknames,
+          \\"nick-names2\\": nickNames,
           \\"first Name\\": firstName1,
         };
         const validationResponses = await Promise.all(
@@ -1998,11 +1998,11 @@ export default function NestedJson(props) {
           let { value } = e.target;
           if (onChange) {
             const modelFields = {
-              \\"first-Name\\": firstName,
+              \\"first-Name\\": value,
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2028,7 +2028,7 @@ export default function NestedJson(props) {
               lastName: value,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2059,7 +2059,7 @@ export default function NestedJson(props) {
               lastName,
               bio: { ...bio, [\\"favorite Quote\\"]: value },
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2087,7 +2087,7 @@ export default function NestedJson(props) {
               lastName,
               bio: { ...bio, [\\"favorite-Animal\\"]: value },
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2114,7 +2114,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1: values,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2159,39 +2159,39 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": values,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
             values = result?.[\\"nick-names2\\"] ?? values;
           }
-          setNicknames(values);
-          setCurrentNicknamesValue(undefined);
+          setNickNames(values);
+          setCurrentNickNamesValue(undefined);
         }}
-        currentFieldValue={currentNicknamesValue}
+        currentFieldValue={currentNickNamesValue}
         label={\\"nick-Names2\\"}
-        items={nicknames}
+        items={nickNames}
         hasError={errors?.[\\"nick-names2\\"]?.hasError}
-        setFieldValue={setCurrentNicknamesValue}
-        inputFieldRef={nicknamesRef}
+        setFieldValue={setCurrentNickNamesValue}
+        inputFieldRef={nickNamesRef}
         defaultFieldValue={undefined}
       >
         <TextField
           label=\\"nick-Names2\\"
-          value={currentNicknamesValue}
+          value={currentNickNamesValue}
           onChange={(e) => {
             let { value } = e.target;
             if (errors[\\"nick-names2\\"]?.hasError) {
               runValidationTasks(\\"nick-names2\\", value);
             }
-            setCurrentNicknamesValue(value);
+            setCurrentNickNamesValue(value);
           }}
           onBlur={() =>
-            runValidationTasks(\\"nick-names2\\", currentNicknamesValue)
+            runValidationTasks(\\"nick-names2\\", currentNickNamesValue)
           }
           errorMessage={errors[\\"nick-names2\\"]?.errorMessage}
           hasError={errors[\\"nick-names2\\"]?.hasError}
-          ref={nicknamesRef}
+          ref={nickNamesRef}
           {...getOverrideProps(overrides, \\"nick-names2\\")}
         ></TextField>
       </ArrayField>
@@ -2205,8 +2205,8 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
-              \\"first Name\\": firstName1,
+              \\"nick-names2\\": nickNames,
+              \\"first Name\\": value,
             };
             const result = onChange(modelFields);
             value = result?.[\\"first Name\\"] ?? value;
@@ -2590,7 +2590,7 @@ export default function NestedJson(props) {
           if (onChange) {
             const modelFields = {
               firstName,
-              \\"last-Name\\": lastName,
+              \\"last-Name\\": value,
               lastName: lastName1,
               bio,
             };
@@ -2614,7 +2614,7 @@ export default function NestedJson(props) {
             const modelFields = {
               firstName,
               \\"last-Name\\": lastName,
-              lastName: lastName1,
+              lastName: values,
               bio,
             };
             const result = onChange(modelFields);
@@ -3469,21 +3469,24 @@ export default function BookCreateForm(props) {
   } = props;
   const initialValues = {
     name: undefined,
-    primaryAuthor: {},
+    \\"primary-author\\": {},
   };
   const [name, setName] = React.useState(initialValues.name);
   const [primaryAuthor, setPrimaryAuthor] = React.useState(
-    initialValues.primaryAuthor
+    initialValues[\\"primary-author\\"]
   );
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     setName(initialValues.name);
-    setPrimaryAuthor(initialValues.primaryAuthor);
+    setPrimaryAuthor(initialValues[\\"primary-author\\"]);
     setErrors({});
+  };
+  const getDisplayValue = {
+    \\"primary-author\\": (record) => record?.name,
   };
   const validations = {
     name: [],
-    primaryAuthor: [],
+    \\"primary-author\\": [],
   };
   const runValidationTasks = async (fieldName, value) => {
     let validationResponse = validateField(value, validations[fieldName]);
@@ -3504,7 +3507,7 @@ export default function BookCreateForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
-          primaryAuthor,
+          \\"primary-author\\": primaryAuthor,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -3554,7 +3557,7 @@ export default function BookCreateForm(props) {
           if (onChange) {
             const modelFields = {
               name: value,
-              primaryAuthor,
+              \\"primary-author\\": primaryAuthor,
             };
             const result = onChange(modelFields);
             value = result?.name ?? value;
@@ -3575,10 +3578,10 @@ export default function BookCreateForm(props) {
           if (onChange) {
             const modelFields = {
               name,
-              primaryAuthor: values,
+              \\"primary-author\\": values,
             };
             const result = onChange(modelFields);
-            values = result?.primaryAuthor ?? values;
+            values = result?.[\\"primary-author\\"] ?? values;
           }
           setPrimaryAuthor(values);
           setCurrentPrimaryAuthorValue({});
@@ -3586,7 +3589,7 @@ export default function BookCreateForm(props) {
         currentFieldValue={currentPrimaryAuthorValue}
         label={\\"Primary author\\"}
         items={primaryAuthor}
-        hasError={errors.primaryAuthor?.hasError}
+        hasError={errors?.[\\"primary-author\\"]?.hasError}
         setFieldValue={setCurrentPrimaryAuthorValue}
         inputFieldRef={primaryAuthorRef}
         defaultFieldValue={{}}
@@ -3595,25 +3598,30 @@ export default function BookCreateForm(props) {
           label=\\"Primary author\\"
           isRequired={false}
           isReadOnly={false}
+          value={currentPrimaryAuthorDisplayValue}
+          suggestions={Array.from(authorRecords).map(([key, record]) => ({
+            id: key,
+            label: getDisplayValue[\\"primary-author\\"]?.(record) ?? key,
+          }))}
+          onSuggestionSelect={({ id, label }) => {
+            setCurrentPrimaryAuthorValue(
+              authorRecords.find((r) => r.id === id)
+            );
+            setCurrentPrimaryAuthorDisplayValue(label);
+          }}
           onChange={(e) => {
             let { value } = e.target;
-            if (onChange) {
-              const modelFields = {
-                name,
-                primaryAuthor: value,
-              };
-              const result = onChange(modelFields);
-              value = result?.primaryAuthor ?? value;
+            if (errors[\\"primary-author\\"]?.hasError) {
+              runValidationTasks(\\"primary-author\\", value);
             }
-            if (errors.primaryAuthor?.hasError) {
-              runValidationTasks(\\"primaryAuthor\\", value);
-            }
-            setPrimaryAuthor(value);
+            setCurrentPrimaryAuthorDisplayValue(value);
+            setCurrentPrimaryAuthorValue(undefined);
           }}
-          onBlur={() => runValidationTasks(\\"primaryAuthor\\", primaryAuthor)}
-          errorMessage={errors.primaryAuthor?.errorMessage}
-          hasError={errors.primaryAuthor?.hasError}
-          {...getOverrideProps(overrides, \\"primaryAuthor\\")}
+          onBlur={() => runValidationTasks(\\"primary-author\\", primaryAuthor)}
+          errorMessage={errors[\\"primary-author\\"]?.errorMessage}
+          hasError={errors[\\"primary-author\\"]?.hasError}
+          ref={primaryAuthorRef}
+          {...getOverrideProps(overrides, \\"primary-author\\")}
         ></Autocomplete>
       </ArrayField>
       <Flex
@@ -3661,17 +3669,17 @@ export declare type ValidationResponse = {
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type BookCreateFormInputValues = {
     name?: string;
-    primaryAuthor?: string;
+    \\"primary-author\\"?: string;
 };
 export declare type BookCreateFormValidationValues = {
     name?: ValidationFunction<string>;
-    primaryAuthor?: ValidationFunction<string>;
+    \\"primary-author\\"?: ValidationFunction<string>;
 };
 export declare type FormProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type BookCreateFormOverridesProps = {
     BookCreateFormGrid?: FormProps<GridProps>;
     name?: FormProps<TextFieldProps>;
-    primaryAuthor?: FormProps<AutocompleteProps>;
+    \\"primary-author\\"?: FormProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type BookCreateFormProps = React.PropsWithChildren<{
     overrides?: BookCreateFormOverridesProps | undefined | null;
@@ -4462,7 +4470,7 @@ export default function BlogCreateForm(props) {
             const modelFields = {
               title,
               content,
-              switch: switch1,
+              switch: value,
               published,
               editedAt,
             };

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/display-value.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/display-value.ts
@@ -1,0 +1,195 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { FieldConfigMetadata, isValidVariableName } from '@aws-amplify/codegen-ui';
+import { StudioFormInputFieldProperty } from '@aws-amplify/codegen-ui/lib/types/form/input-config';
+import { Expression, factory, JsxAttribute, PropertyAssignment, SyntaxKind, NodeFlags } from 'typescript';
+import {
+  buildBindingExpression,
+  buildConcatExpression,
+  isBoundProperty,
+  isConcatenatedProperty,
+} from '../../react-component-render-helper';
+import { getRecordsName } from './form-state';
+import { isModelDataType } from './render-checkers';
+
+export const getDisplayValueObjectName = 'getDisplayValue';
+
+/**
+    example:
+    suggestions={Array.from(authorRecords).map(([key, record]) => ({
+        id: key,
+        label: getDisplayValue['primaryAuthor']?.(record) ?? key,
+    }))}
+ */
+export function getAutocompleteSuggestionsPropFromModel({
+  modelName,
+  fieldName,
+}: {
+  modelName: string;
+  fieldName: string;
+}): JsxAttribute {
+  return factory.createJsxAttribute(
+    factory.createIdentifier('suggestions'),
+    factory.createJsxExpression(
+      undefined,
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(
+          factory.createCallExpression(
+            factory.createPropertyAccessExpression(factory.createIdentifier('Array'), factory.createIdentifier('from')),
+            undefined,
+            [factory.createIdentifier(getRecordsName(modelName))],
+          ),
+          factory.createIdentifier('map'),
+        ),
+        undefined,
+        [
+          factory.createArrowFunction(
+            undefined,
+            undefined,
+            [
+              factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                factory.createArrayBindingPattern([
+                  factory.createBindingElement(undefined, undefined, factory.createIdentifier('key'), undefined),
+                  factory.createBindingElement(undefined, undefined, factory.createIdentifier('record'), undefined),
+                ]),
+                undefined,
+                undefined,
+                undefined,
+              ),
+            ],
+            undefined,
+            factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+            factory.createParenthesizedExpression(
+              factory.createObjectLiteralExpression(
+                [
+                  factory.createPropertyAssignment(factory.createIdentifier('id'), factory.createIdentifier('key')),
+                  factory.createPropertyAssignment(
+                    factory.createIdentifier('label'),
+                    factory.createBinaryExpression(
+                      factory.createCallChain(
+                        factory.createElementAccessExpression(
+                          factory.createIdentifier('getDisplayValue'),
+                          factory.createStringLiteral(fieldName),
+                        ),
+                        factory.createToken(SyntaxKind.QuestionDotToken),
+                        undefined,
+                        [factory.createIdentifier('record')],
+                      ),
+                      factory.createToken(SyntaxKind.QuestionQuestionToken),
+                      factory.createIdentifier('key'),
+                    ),
+                  ),
+                ],
+                true,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// impure helper
+/* eslint-disable no-param-reassign */
+function replaceProperty(prop: StudioFormInputFieldProperty, toReplace: string, replaceWith: string): void {
+  if (isBoundProperty(prop) && prop.bindingProperties.property === toReplace) {
+    prop.bindingProperties.property = replaceWith;
+  }
+  if (isConcatenatedProperty(prop)) {
+    prop.concat.forEach((subProp) => replaceProperty(subProp as StudioFormInputFieldProperty, toReplace, replaceWith));
+  }
+}
+/* eslint-enable no-param-reassign */
+
+export function getDisplayValueObject(displayValueFunctions: PropertyAssignment[]) {
+  return factory.createVariableStatement(
+    undefined,
+    factory.createVariableDeclarationList(
+      [
+        factory.createVariableDeclaration(
+          factory.createIdentifier('getDisplayValue'),
+          undefined,
+          undefined,
+          factory.createObjectLiteralExpression(displayValueFunctions, true),
+        ),
+      ],
+      NodeFlags.Const,
+    ),
+  );
+}
+
+// example - primaryAuthor: (record) => record?.name,
+export function buildDisplayValueFunction(fieldName: string, fieldConfig: FieldConfigMetadata): PropertyAssignment {
+  const recordString = 'record';
+  let renderedDisplayValue: Expression = factory.createPropertyAccessChain(
+    factory.createIdentifier(recordString),
+    factory.createToken(SyntaxKind.QuestionDotToken),
+    factory.createIdentifier('id'),
+  );
+
+  if (isModelDataType(fieldConfig) && fieldConfig.valueMappings) {
+    const valueConfig = fieldConfig.valueMappings.values[0];
+    if (valueConfig) {
+      const displayValueProperty = valueConfig.displayValue || valueConfig.value;
+      const modelName = fieldConfig.dataType.model;
+      replaceProperty(displayValueProperty, modelName, recordString);
+      if (isConcatenatedProperty(displayValueProperty)) {
+        renderedDisplayValue = buildConcatExpression(displayValueProperty);
+      } else if (isBoundProperty(displayValueProperty)) {
+        renderedDisplayValue = buildBindingExpression(displayValueProperty);
+      }
+    }
+  }
+
+  return factory.createPropertyAssignment(
+    isValidVariableName(fieldName) ? factory.createIdentifier(fieldName) : factory.createStringLiteral(fieldName),
+    factory.createArrowFunction(
+      undefined,
+      undefined,
+      [
+        factory.createParameterDeclaration(
+          undefined,
+          undefined,
+          undefined,
+          factory.createIdentifier(recordString),
+          undefined,
+          undefined,
+          undefined,
+        ),
+      ],
+      undefined,
+      factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+      renderedDisplayValue,
+    ),
+  );
+}
+
+export function getModelsToImport(fieldConfig: FieldConfigMetadata): string[] {
+  const modelDependencies: string[] = [];
+  if (fieldConfig.valueMappings && fieldConfig.valueMappings.bindingProperties) {
+    Object.values(fieldConfig.valueMappings.bindingProperties).forEach((prop) => {
+      if (prop.type === 'Data' && prop.bindingProperties.model) {
+        modelDependencies.push(prop.bindingProperties.model);
+      }
+    });
+  }
+
+  return modelDependencies;
+}

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
@@ -30,8 +30,14 @@ import {
   PropertyAssignment,
   PropertyName,
 } from 'typescript';
+import { lowerCaseFirst } from '../../helpers';
 
 export const getCurrentValueName = (fieldName: string) => `current${capitalizeFirstLetter(fieldName)}Value`;
+
+export const getCurrentDisplayValueName = (fieldName: string) =>
+  `current${capitalizeFirstLetter(fieldName)}DisplayValue`;
+
+export const getRecordsName = (modelName: string) => `${lowerCaseFirst(modelName)}Records`;
 
 export const getCurrentValueIdentifier = (fieldName: string) =>
   factory.createIdentifier(getCurrentValueName(fieldName));

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/index.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/index.ts
@@ -26,3 +26,5 @@ export { buildResetValuesOnRecordUpdate, buildSetStateFunction } from './form-st
 export { buildValidations, runValidationTasksFunction } from './validation';
 
 export { addFormAttributes } from './all-props';
+
+export { mapFromFieldConfigs } from './map-from-fieldConfigs';

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/map-from-fieldConfigs.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/map-from-fieldConfigs.ts
@@ -1,0 +1,75 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { FieldConfigMetadata } from '@aws-amplify/codegen-ui';
+import { PropertyAssignment } from 'typescript';
+import { buildDisplayValueFunction, getDisplayValueObject, getModelsToImport } from './display-value';
+import { isModelDataType, shouldWrapInArrayField } from './render-checkers';
+import { buildValidationForField, buildValidations } from './validation';
+
+/**
+ * This helper returns an evolving collection of artifacts produced by iterating through
+ * the fieldConfigs object. Its purpose is to prevent iterating through this object
+ * multiple times to shave off compute time.
+ */
+export function mapFromFieldConfigs(fieldConfigs: Record<string, FieldConfigMetadata>) {
+  const validationsForField: PropertyAssignment[] = [];
+  const dataTypesMap: { [dataType: string]: string[] } = {};
+  const displayValueFunctions: PropertyAssignment[] = [];
+  const modelsToImport: string[] = [];
+  let usesArrayField = false;
+
+  Object.entries(fieldConfigs).forEach(([fieldName, fieldConfig]) => {
+    // dataTypesMap
+    let dataTypeKey: string | undefined;
+    if (fieldConfig.dataType) {
+      if (typeof fieldConfig.dataType === 'string') {
+        dataTypeKey = fieldConfig.dataType;
+      }
+    }
+
+    if (dataTypeKey) {
+      if (dataTypesMap[dataTypeKey]) {
+        dataTypesMap[dataTypeKey].push(fieldName);
+      } else {
+        dataTypesMap[dataTypeKey] = [fieldName];
+      }
+    }
+
+    // usesArrayField
+    if (shouldWrapInArrayField(fieldConfig)) {
+      usesArrayField = true;
+    }
+
+    // displayValue
+    if (isModelDataType(fieldConfig)) {
+      displayValueFunctions.push(buildDisplayValueFunction(fieldName, fieldConfig));
+    }
+
+    // modelsToImport
+    modelsToImport.push(...getModelsToImport(fieldConfig));
+
+    // validation
+    validationsForField.push(buildValidationForField(fieldName, fieldConfig.validationRules));
+  });
+
+  return {
+    validationsObject: buildValidations(validationsForField),
+    dataTypesMap,
+    displayValueObject: displayValueFunctions.length ? getDisplayValueObject(displayValueFunctions) : undefined,
+    modelsToImport,
+    usesArrayField,
+  };
+}

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-fields.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-fields.ts
@@ -41,10 +41,15 @@ export const buildModelFieldObject = (
     const { sanitizedFieldName } = fieldConfigs[value];
     const renderedFieldName = sanitizedFieldName || fieldName;
     if (!fieldSet.has(renderedFieldName)) {
-      let assignment = nameOverrides[fieldName]
-        ? nameOverrides[fieldName]
-        : factory.createShorthandPropertyAssignment(factory.createIdentifier(fieldName), undefined);
-      if (sanitizedFieldName) {
+      let assignment: ObjectLiteralElementLike = factory.createShorthandPropertyAssignment(
+        factory.createIdentifier(fieldName),
+        undefined,
+      );
+
+      if (nameOverrides[fieldName]) {
+        assignment = nameOverrides[fieldName];
+      } else if (sanitizedFieldName) {
+        // if overrides present, ignore sanitizedFieldName
         assignment = factory.createPropertyAssignment(
           factory.createStringLiteral(fieldName),
           factory.createIdentifier(sanitizedFieldName),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-checkers.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-checkers.ts
@@ -16,3 +16,8 @@
 import { FieldConfigMetadata } from '@aws-amplify/codegen-ui';
 
 export const shouldWrapInArrayField = (config: FieldConfigMetadata) => config.isArray || config.relationship;
+
+export const isModelDataType = (
+  config: FieldConfigMetadata,
+): config is FieldConfigMetadata & { dataType: { model: string } } =>
+  !!(config.dataType && typeof config.dataType === 'object' && 'model' in config.dataType);

--- a/packages/codegen-ui/example-schemas/datastore/book.json
+++ b/packages/codegen-ui/example-schemas/datastore/book.json
@@ -1,1 +1,146 @@
-{"models":{"Book":{"name":"Book","fields":{"id":{"name":"id","isArray":false,"type":"ID","isRequired":true,"attributes":[]},"name":{"name":"name","isArray":false,"type":"String","isRequired":false,"attributes":[]},"primaryAuthor":{"name":"primaryAuthor","isArray":false,"type":{"model":"Author"},"isRequired":false,"attributes":[],"association":{"connectionType":"HAS_ONE","associatedWith":"id","targetName":"authorId"}},"authorId":{"name":"authorId","isArray":false,"type":"ID","isRequired":false,"attributes":[]},"createdAt":{"name":"createdAt","isArray":false,"type":"AWSDateTime","isRequired":false,"attributes":[],"isReadOnly":true},"updatedAt":{"name":"updatedAt","isArray":false,"type":"AWSDateTime","isRequired":false,"attributes":[],"isReadOnly":true}},"syncable":true,"pluralName":"Books","attributes":[{"type":"model","properties":{}},{"type":"auth","properties":{"rules":[{"allow":"public","operations":["create","update","delete","read"]}]}}]},"Author":{"name":"Author","fields":{"id":{"name":"id","isArray":false,"type":"ID","isRequired":true,"attributes":[]},"name":{"name":"name","isArray":false,"type":"String","isRequired":false,"attributes":[]},"createdAt":{"name":"createdAt","isArray":false,"type":"AWSDateTime","isRequired":false,"attributes":[],"isReadOnly":true},"updatedAt":{"name":"updatedAt","isArray":false,"type":"AWSDateTime","isRequired":false,"attributes":[],"isReadOnly":true}},"syncable":true,"pluralName":"Authors","attributes":[{"type":"model","properties":{}},{"type":"auth","properties":{"rules":[{"allow":"public","operations":["create","update","delete","read"]}]}}]}},"enums":{},"nonModels":{},"version":"f82a568b6f94e51882664a44c5a847fe"}
+{
+    "models": {
+        "Book": {
+            "name": "Book",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "name": {
+                    "name": "name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "primary-author": {
+                    "name": "primary-author",
+                    "isArray": false,
+                    "type": {
+                        "model": "Author"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "HAS_ONE",
+                        "associatedWith": "id",
+                        "targetName": "authorId"
+                    }
+                },
+                "authorId": {
+                    "name": "authorId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Books",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "allow": "public",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "Author": {
+            "name": "Author",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "name": {
+                    "name": "name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Authors",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "allow": "public",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "enums": {},
+    "nonModels": {},
+    "version": "f82a568b6f94e51882664a44c5a847fe"
+}

--- a/packages/codegen-ui/example-schemas/forms/book-datastore-create.json
+++ b/packages/codegen-ui/example-schemas/forms/book-datastore-create.json
@@ -1,1 +1,44 @@
-{"name":"BookCreateForm","dataType":{"dataSourceType":"DataStore","dataTypeName":"Book"},"formActionType":"create","fields":{"primaryAuthor":{"inputType":{"type":"Autocomplete","valueMappings":{"values":[{"value":{"bindingProperties":{"property":"Author","field":"id"}},"displayValue":{"bindingProperties":{"property":"Author","field":"name"}}}],"bindingProperties":{"Author":{"type":"Data","bindingProperties":{"model":"Author"}}}}}}},"sectionalElements":{},"style":{},"cta":{}}
+{
+    "name": "BookCreateForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "Book"
+    },
+    "formActionType": "create",
+    "fields": {
+        "primary-author": {
+            "inputType": {
+                "type": "Autocomplete",
+                "valueMappings": {
+                    "values": [
+                        {
+                            "value": {
+                                "bindingProperties": {
+                                    "property": "Author",
+                                    "field": "id"
+                                }
+                            },
+                            "displayValue": {
+                                "bindingProperties": {
+                                    "property": "Author",
+                                    "field": "name"
+                                }
+                            }
+                        }
+                    ],
+                    "bindingProperties": {
+                        "Author": {
+                            "type": "Data",
+                            "bindingProperties": {
+                                "model": "Author"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+}

--- a/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
@@ -161,7 +161,7 @@ describe('mapFormMetaData', () => {
       });
       expect(mappedFieldNames[0]).toEqual('testFieldName');
       expect(mappedFieldNames[1]).toEqual('testFieldName1');
-      expect(mappedFieldNames[10]).toEqual('testFieldname10');
+      expect(mappedFieldNames[10]).toEqual('testFieldName10');
       expect(usedFieldNames.size).toEqual(mappedFieldNames.length);
       expect(usedFieldNames.has('testFieldName'.toLowerCase())).toBeTruthy();
       expect(usedFieldNames.has('testFieldName1'.toLowerCase())).toBeTruthy();

--- a/packages/codegen-ui/lib/types/form/form-metadata.ts
+++ b/packages/codegen-ui/lib/types/form/form-metadata.ts
@@ -15,6 +15,7 @@
  */
 import { DataFieldDataType, GenericDataRelationshipType } from '../data';
 import { FieldValidationConfiguration } from './form-validation';
+import { StudioFormValueMappings } from './input-config';
 import { FormStyleConfig, StudioFormStyle } from './style';
 
 /**
@@ -33,6 +34,8 @@ export type FieldConfigMetadata = {
   isArray?: boolean;
   componentType: string;
   studioFormComponentType?: string;
+  // used for dynamic mapping of displayValue
+  valueMappings?: StudioFormValueMappings;
 };
 
 export type FormMetadata = {

--- a/packages/codegen-ui/lib/utils/form-component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/form-component-metadata.ts
@@ -13,6 +13,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+
+import { camelCase } from 'change-case';
+
 import {
   FormDefinition,
   FormMetadata,
@@ -37,7 +40,7 @@ export const isValidVariableName = (input: string, resveredNames?: Set<string>):
   return /^[a-zA-Z_$][a-zA-Z_$0-9]*$/g.test(input) && preCheck;
 };
 
-export const filterFieldName = (input: string): string => input.split('.')[0].replace(/[^a-zA-Z_$]/g, '');
+export const formatFieldName = (input: string): string => camelCase(input.split('.')[0].replace(/[^a-zA-Z_$]/g, '-'));
 
 function elementIsInput(element: FormDefinitionElement): element is FormDefinitionInputElement {
   return element.componentType !== 'Text' && element.componentType !== 'Divider' && element.componentType !== 'Heading';
@@ -45,7 +48,7 @@ function elementIsInput(element: FormDefinitionElement): element is FormDefiniti
 
 // create mapping for field name collisions
 export function generateUniqueFieldName(name: string, sanitizedFieldNames: Set<string>) {
-  let sanitizedFieldName = isValidVariableName(name, sanitizedFieldNames) ? name : filterFieldName(name);
+  let sanitizedFieldName = isValidVariableName(name, sanitizedFieldNames) ? name : formatFieldName(name);
   let count = 1;
   if (sanitizedFieldNames.has(sanitizedFieldName.toLowerCase()) && !name.includes('.')) {
     let prospectiveNewName = sanitizedFieldName + count;
@@ -88,6 +91,11 @@ export const mapFormMetadata = (form: StudioForm, formDefinition: FormDefinition
             return updatedValidation;
           });
         }
+
+        if (element.relationship && 'valueMappings' in element) {
+          metadata.valueMappings = element.valueMappings;
+        }
+
         // we add the name of the model as a resvered word
         if (form.dataType.dataSourceType === 'DataStore') {
           sanitizedFieldNames.add(form.dataType.dataTypeName);


### PR DESCRIPTION
*Description of changes:*
- Map props onto the `Autocomplete` component generated by a `HAS_ONE` relationship model-type field
- Build the displayValue object and import required models (removed by prettier until actually used)

*Additional changes:*
- Fix a bug in onChange override where the value was not being set correctly
- Change the snapshot test's field name from `primaryAuthor` to `primary-author` to test out sanitization
- Consolidate fieldConfigs iterations to cut down on run time
- camelCase while sanitizing field names


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
