### PR TITLE
chore: support not-model HAS_ONE relationships

### DIFF
--- a/packages/codegen-ui-golden-files/lib/react/forms/datastore-create-form-with-has-one-relationship/BookCreateForm.jsx
+++ b/packages/codegen-ui-golden-files/lib/react/forms/datastore-create-form-with-has-one-relationship/BookCreateForm.jsx
@@ -338,9 +338,9 @@ export default function BookCreateForm(props) {
             setCurrentPrimaryAuthorDisplayValue(value);
             setCurrentPrimaryAuthorValue(undefined); // empty out prev selected option
           }}
-          suggestions={Array.from(authorRecords).map(([key, record]) => ({
-            id: key,
-            label: getDisplayValue['primaryAuthor']?.(record) ?? key,
+          suggestions={authorRecords.map((r) => ({
+            id: r.id,
+            label: getDisplayValue['primaryAuthor']?.(record) ?? r.id,
           }))}
           onSuggestionSelect={({ id, label }) => {
             setCurrentPrimaryAuthorValue(authorRecords.find((r) => r.id === id));

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -50,7 +50,14 @@ export default function CustomDataForm(props) {
     pages: [],
     phone: [{ type: \\"Required\\" }, { type: \\"Phone\\" }],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -453,7 +460,14 @@ export default function CustomDataForm(props) {
     category: [],
     pages: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -971,7 +985,14 @@ export default function CustomDataForm(props) {
     email: [{ type: \\"Required\\" }],
     phone: [{ type: \\"Required\\" }, { type: \\"Phone\\" }],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -1415,7 +1436,14 @@ export default function MyPostForm(props) {
     metadata: [{ type: \\"JSON\\" }],
     profile_url: [{ type: \\"URL\\" }],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -1963,7 +1991,14 @@ export default function NestedJson(props) {
     \\"nick-names2\\": [],
     \\"first Name\\": [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -2520,7 +2555,14 @@ export default function NestedJson(props) {
     \\"bio.favoriteQuote\\": [],
     \\"bio.favoriteAnimal\\": [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -2822,7 +2864,14 @@ export default function CustomWithSectionalElements(props) {
   const validations = {
     name: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -3027,7 +3076,14 @@ export default function MyPostForm(props) {
     metadata: [{ type: \\"JSON\\" }],
     profile_url: [{ type: \\"URL\\" }],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -3481,17 +3537,21 @@ export default function BookCreateForm(props) {
   const initialValues = {
     name: undefined,
     \\"primary-author\\": undefined,
+    authorId: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
   const [primaryAuthor, setPrimaryAuthor] = React.useState(
     initialValues[\\"primary-author\\"]
   );
+  const [authorId, setAuthorId] = React.useState(initialValues.authorId);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     setName(initialValues.name);
     setPrimaryAuthor(initialValues[\\"primary-author\\"]);
     setCurrentPrimaryAuthorValue(undefined);
     setCurrentPrimaryAuthorDisplayValue(undefined);
+    setAuthorId(initialValues.authorId);
+    setCurrentAuthorIdValue(undefined);
     setErrors({});
   };
   const [
@@ -3501,6 +3561,13 @@ export default function BookCreateForm(props) {
   const [currentPrimaryAuthorValue, setCurrentPrimaryAuthorValue] =
     React.useState(undefined);
   const primaryAuthorRef = React.createRef();
+  const [currentAuthorIdValue, setCurrentAuthorIdValue] =
+    React.useState(undefined);
+  const authorIdRef = React.createRef();
+  const authorRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: Author,
+  }).items;
   const authorRecords = useDataStoreBinding({
     type: \\"collection\\",
     model: Author,
@@ -3511,8 +3578,16 @@ export default function BookCreateForm(props) {
   const validations = {
     name: [],
     \\"primary-author\\": [],
+    authorId: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -3532,19 +3607,28 @@ export default function BookCreateForm(props) {
         let modelFields = {
           name,
           \\"primary-author\\": primaryAuthor,
+          authorId,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
             if (Array.isArray(modelFields[fieldName])) {
               promises.push(
                 ...modelFields[fieldName].map((item) =>
-                  runValidationTasks(fieldName, item)
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
                 )
               );
               return promises;
             }
             promises.push(
-              runValidationTasks(fieldName, modelFields[fieldName])
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
             );
             return promises;
           }, [])
@@ -3582,6 +3666,7 @@ export default function BookCreateForm(props) {
             const modelFields = {
               name: value,
               \\"primary-author\\": primaryAuthor,
+              authorId,
             };
             const result = onChange(modelFields);
             value = result?.name ?? value;
@@ -3604,6 +3689,7 @@ export default function BookCreateForm(props) {
             const modelFields = {
               name,
               \\"primary-author\\": value,
+              authorId,
             };
             const result = onChange(modelFields);
             value = result?.[\\"primary-author\\"] ?? value;
@@ -3626,9 +3712,9 @@ export default function BookCreateForm(props) {
           isRequired={false}
           isReadOnly={false}
           value={currentPrimaryAuthorDisplayValue}
-          suggestions={Array.from(authorRecords).map(([key, record]) => ({
-            id: key,
-            label: getDisplayValue[\\"primary-author\\"]?.(record) ?? key,
+          suggestions={authorRecords.map((r) => ({
+            id: r.id,
+            label: getDisplayValue[\\"primary-author\\"]?.(r) ?? r.id,
           }))}
           onSuggestionSelect={({ id, label }) => {
             setCurrentPrimaryAuthorValue(
@@ -3649,6 +3735,56 @@ export default function BookCreateForm(props) {
           hasError={errors[\\"primary-author\\"]?.hasError}
           ref={primaryAuthorRef}
           {...getOverrideProps(overrides, \\"primary-author\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              \\"primary-author\\": primaryAuthor,
+              authorId: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.authorId ?? value;
+          }
+          setAuthorId(value);
+          setCurrentAuthorIdValue(undefined);
+        }}
+        currentFieldValue={currentAuthorIdValue}
+        label={\\"Author id\\"}
+        items={[authorId]}
+        hasError={errors.authorId?.hasError}
+        setFieldValue={setCurrentAuthorIdValue}
+        inputFieldRef={authorIdRef}
+        defaultFieldValue={undefined}
+      >
+        <Autocomplete
+          label=\\"Author id\\"
+          isRequired={false}
+          isReadOnly={false}
+          value={currentAuthorIdValue}
+          suggestions={authorRecords.map((r) => ({
+            id: r.id,
+            label: r.id,
+          }))}
+          onSuggestionSelect={({ id }) => {
+            setCurrentAuthorIdValue(id);
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.authorId?.hasError) {
+              runValidationTasks(\\"authorId\\", value);
+            }
+            setCurrentAuthorIdValue(value);
+          }}
+          onBlur={() => runValidationTasks(\\"authorId\\", authorId)}
+          errorMessage={errors.authorId?.errorMessage}
+          hasError={errors.authorId?.hasError}
+          ref={authorIdRef}
+          {...getOverrideProps(overrides, \\"authorId\\")}
         ></Autocomplete>
       </ArrayField>
       <Flex
@@ -3689,16 +3825,19 @@ export declare type ValidationFunction<T> = (value: T, validationResponse: Valid
 export declare type BookCreateFormInputValues = {
     name?: string;
     \\"primary-author\\"?: string;
+    authorId?: string;
 };
 export declare type BookCreateFormValidationValues = {
     name?: ValidationFunction<string>;
     \\"primary-author\\"?: ValidationFunction<string>;
+    authorId?: ValidationFunction<string>;
 };
 export declare type FormProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type BookCreateFormOverridesProps = {
     BookCreateFormGrid?: FormProps<GridProps>;
     name?: FormProps<TextFieldProps>;
     \\"primary-author\\"?: FormProps<AutocompleteProps>;
+    authorId?: FormProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type BookCreateFormProps = React.PropsWithChildren<{
     overrides?: BookCreateFormOverridesProps | undefined | null;
@@ -3921,7 +4060,14 @@ export default function BookCreateForm(props) {
     name: [],
     primaryAuthor: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -3947,13 +4093,21 @@ export default function BookCreateForm(props) {
             if (Array.isArray(modelFields[fieldName])) {
               promises.push(
                 ...modelFields[fieldName].map((item) =>
-                  runValidationTasks(fieldName, item)
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
                 )
               );
               return promises;
             }
             promises.push(
-              runValidationTasks(fieldName, modelFields[fieldName])
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
             );
             return promises;
           }, [])
@@ -4053,7 +4207,7 @@ export default function BookCreateForm(props) {
         label={\\"Primary author\\"}
         items={[primaryAuthor]}
         hasError={errors.primaryAuthor?.hasError}
-        getBadgeText={getDisplayValue[primaryAuthor]}
+        getBadgeText={getDisplayValue.primaryAuthor}
         setFieldValue={currentPrimaryAuthorDisplayValue}
         inputFieldRef={primaryAuthorRef}
         defaultFieldValue={undefined}
@@ -4063,9 +4217,9 @@ export default function BookCreateForm(props) {
           isRequired={false}
           isReadOnly={false}
           value={currentPrimaryAuthorDisplayValue}
-          suggestions={Array.from(authorRecords).map(([key, record]) => ({
-            id: key,
-            label: getDisplayValue[\\"primaryAuthor\\"]?.(record) ?? key,
+          suggestions={authorRecords.map((r) => ({
+            id: r.id,
+            label: getDisplayValue.primaryAuthor?.(r) ?? r.id,
           }))}
           onSuggestionSelect={({ id, label }) => {
             setCurrentPrimaryAuthorValue(
@@ -4335,15 +4489,15 @@ export default function BookCreateForm(props) {
   const [currentPrimaryAuthorValue, setCurrentPrimaryAuthorValue] =
     React.useState(undefined);
   const primaryAuthorRef = React.createRef();
-  const authorRecords = useDataStoreBinding({
-    type: \\"collection\\",
-    model: Author,
-  }).items;
   const [currentPrimaryTitleDisplayValue, setCurrentPrimaryTitleDisplayValue] =
     React.useState(undefined);
   const [currentPrimaryTitleValue, setCurrentPrimaryTitleValue] =
     React.useState(undefined);
   const primaryTitleRef = React.createRef();
+  const authorRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: Author,
+  }).items;
   const titleRecords = useDataStoreBinding({
     type: \\"collection\\",
     model: Title,
@@ -4357,7 +4511,14 @@ export default function BookCreateForm(props) {
     primaryAuthor: [],
     primaryTitle: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -4384,13 +4545,21 @@ export default function BookCreateForm(props) {
             if (Array.isArray(modelFields[fieldName])) {
               promises.push(
                 ...modelFields[fieldName].map((item) =>
-                  runValidationTasks(fieldName, item)
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
                 )
               );
               return promises;
             }
             promises.push(
-              runValidationTasks(fieldName, modelFields[fieldName])
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
             );
             return promises;
           }, [])
@@ -4492,7 +4661,7 @@ export default function BookCreateForm(props) {
         label={\\"Primary author\\"}
         items={[primaryAuthor]}
         hasError={errors.primaryAuthor?.hasError}
-        getBadgeText={getDisplayValue[primaryAuthor]}
+        getBadgeText={getDisplayValue.primaryAuthor}
         setFieldValue={currentPrimaryAuthorDisplayValue}
         inputFieldRef={primaryAuthorRef}
         defaultFieldValue={undefined}
@@ -4502,9 +4671,9 @@ export default function BookCreateForm(props) {
           isRequired={false}
           isReadOnly={false}
           value={currentPrimaryAuthorDisplayValue}
-          suggestions={Array.from(authorRecords).map(([key, record]) => ({
-            id: key,
-            label: getDisplayValue[\\"primaryAuthor\\"]?.(record) ?? key,
+          suggestions={authorRecords.map((r) => ({
+            id: r.id,
+            label: getDisplayValue.primaryAuthor?.(r) ?? r.id,
           }))}
           onSuggestionSelect={({ id, label }) => {
             setCurrentPrimaryAuthorValue(
@@ -4548,7 +4717,7 @@ export default function BookCreateForm(props) {
         label={\\"Primary title\\"}
         items={[primaryTitle]}
         hasError={errors.primaryTitle?.hasError}
-        getBadgeText={getDisplayValue[primaryTitle]}
+        getBadgeText={getDisplayValue.primaryTitle}
         setFieldValue={currentPrimaryTitleDisplayValue}
         inputFieldRef={primaryTitleRef}
         defaultFieldValue={undefined}
@@ -4558,9 +4727,9 @@ export default function BookCreateForm(props) {
           isRequired={false}
           isReadOnly={false}
           value={currentPrimaryTitleDisplayValue}
-          suggestions={Array.from(titleRecords).map(([key, record]) => ({
-            id: key,
-            label: getDisplayValue[\\"primaryTitle\\"]?.(record) ?? key,
+          suggestions={titleRecords.map((r) => ({
+            id: r.id,
+            label: getDisplayValue.primaryTitle?.(r) ?? r.id,
           }))}
           onSuggestionSelect={({ id, label }) => {
             setCurrentPrimaryTitleValue(titleRecords.find((r) => r.id === id));
@@ -4703,7 +4872,14 @@ export default function MyPostForm(props) {
     post_url: [{ type: \\"URL\\" }],
     metadata: [{ type: \\"JSON\\" }],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -5257,7 +5433,14 @@ export default function BlogCreateForm(props) {
     published: [],
     editedAt: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -5804,7 +5987,14 @@ export default function InputGalleryCreateForm(props) {
     ippy: [{ type: \\"IpAddress\\" }],
     timeisnow: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -6542,7 +6732,14 @@ export default function InputGalleryUpdateForm(props) {
     ippy: [{ type: \\"IpAddress\\" }],
     timeisnow: [],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {
@@ -7147,7 +7344,14 @@ export default function PostCreateFormRow(props) {
     status: [],
     metadata: [{ type: \\"JSON\\" }],
   };
-  const runValidationTasks = async (fieldName, value) => {
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
     let validationResponse = validateField(value, validations[fieldName]);
     const customValidator = fetchByPath(onValidate, fieldName);
     if (customValidator) {

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -29,6 +29,7 @@ import { buildDataStoreExpression } from '../forms';
 import { onSubmitValidationRun, buildModelFieldObject } from '../forms/form-renderer-helper';
 import { hasTokenReference } from '../utils/forms/layout-helpers';
 import { resetFunctionCheck } from '../forms/form-renderer-helper/value-props';
+import { isModelDataType } from '../forms/form-renderer-helper/render-checkers';
 
 export default class FormRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -185,6 +186,10 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
       dataType: { dataSourceType },
     } = this.form;
     const { formMetadata } = this.componentMetadata;
+
+    const hasModelField =
+      formMetadata?.fieldConfigs && Object.values(formMetadata.fieldConfigs).some((config) => isModelDataType(config));
+
     return factory.createJsxAttribute(
       factory.createIdentifier('onSubmit'),
       factory.createJsxExpression(
@@ -218,7 +223,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                 ),
               ),
               buildModelFieldObject(dataSourceType !== 'DataStore', formMetadata?.fieldConfigs),
-              ...onSubmitValidationRun,
+              ...onSubmitValidationRun(hasModelField),
               ...this.getOnSubmitDSCall(),
             ],
             false,

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
@@ -19,8 +19,8 @@ import { buildComponentSpecificAttributes } from './static-props';
 import { renderValueAttribute, renderDefaultValueAttribute, isControlledComponent } from './value-props';
 import { buildOnChangeStatement, buildOnBlurStatement, buildOnSuggestionSelect } from './event-handler-props';
 import { resetValuesName } from './form-state';
-import { isModelDataType, shouldWrapInArrayField } from './render-checkers';
-import { getAutocompleteSuggestionsPropFromModel } from './display-value';
+import { shouldWrapInArrayField } from './render-checkers';
+import { getAutocompleteSuggestionsProp } from './display-value';
 
 export const addFormAttributes = (component: StudioComponent | StudioComponentChild, formMetadata: FormMetadata) => {
   const { name: componentName, componentType } = component;
@@ -71,10 +71,10 @@ export const addFormAttributes = (component: StudioComponent | StudioComponentCh
       attributes.push(valueAttribute);
     }
 
-    if (fieldConfig.componentType === 'Autocomplete' && isModelDataType(fieldConfig)) {
-      const modelName = fieldConfig.dataType.model;
-      attributes.push(getAutocompleteSuggestionsPropFromModel({ fieldName: componentName, modelName }));
-      attributes.push(buildOnSuggestionSelect({ sanitizedFieldName: renderedVariableName, modelName }));
+    // TODO: Allow for other relationship types once valueMappings available
+    if (fieldConfig.componentType === 'Autocomplete' && fieldConfig.relationship?.type === 'HAS_ONE') {
+      attributes.push(getAutocompleteSuggestionsProp({ fieldName: componentName, fieldConfig }));
+      attributes.push(buildOnSuggestionSelect({ sanitizedFieldName: renderedVariableName, fieldConfig }));
     }
 
     if (formMetadata.formActionType === 'update' && !fieldConfig.isArray && !isControlledComponent(componentType)) {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
@@ -13,8 +13,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { factory, NodeFlags, SyntaxKind } from 'typescript';
+import { factory, NodeFlags, SyntaxKind, Expression } from 'typescript';
 import { lowerCaseFirst } from '../../helpers';
+import { getDisplayValueObjectName } from './display-value';
 import { getSetNameIdentifier } from './form-state';
 
 export const buildDataStoreExpression = (dataStoreActionType: 'update' | 'create', modelName: string) => {
@@ -98,218 +99,241 @@ export const buildDataStoreExpression = (dataStoreActionType: 'update' | 'create
 };
 
 /**
-        const validationResponses = await Promise.all(
-          Object.keys(validations).reduce((promises, fieldName) => {
-              if (Array.isArray(modelFields[fieldName])) {
-                  promises.push(...modelFields[fieldName].map(item => runValidationTasks(fieldName, item)));
-              }
-              promises.push(runValidationTasks(fieldName, modelFields[fieldName]))
-              return promises
-          }, [])
+  example: const validationResponses = await Promise.all(
+    Object.keys(validations).reduce((promises, fieldName) => {
+      if (Array.isArray(modelFields[fieldName])) {
+        promises.push(
+          ...modelFields[fieldName].map((item) =>
+            runValidationTasks(fieldName, item, getDisplayValue[fieldName]),
+          ),
         );
-      
-        if (validationResponses.some((r) => r.hasError)) {
-          return;
-        }
-       */
+        return promises;
+      }
+      promises.push(runValidationTasks(fieldName, modelFields[fieldName], getDisplayValue[fieldName]));
+      return promises;
+    }, []),
+  );
+  if (validationResponses.some((r) => r.hasError)) {
+    return;
+  }
+*/
 
-export const onSubmitValidationRun = [
-  factory.createVariableStatement(
-    undefined,
-    factory.createVariableDeclarationList(
-      [
-        factory.createVariableDeclaration(
-          factory.createIdentifier('validationResponses'),
-          undefined,
-          undefined,
-          factory.createAwaitExpression(
-            factory.createCallExpression(
-              factory.createPropertyAccessExpression(
-                factory.createIdentifier('Promise'),
-                factory.createIdentifier('all'),
-              ),
-              undefined,
-              [
-                factory.createCallExpression(
-                  factory.createPropertyAccessExpression(
-                    factory.createCallExpression(
-                      factory.createPropertyAccessExpression(
-                        factory.createIdentifier('Object'),
-                        factory.createIdentifier('keys'),
+export const onSubmitValidationRun = (shouldUseGetDisplayValue?: boolean) => {
+  const getDisplayValueAccess = factory.createElementAccessExpression(
+    factory.createIdentifier(getDisplayValueObjectName),
+    factory.createIdentifier('fieldName'),
+  );
+
+  const runValidationTasksArgsForArray: Expression[] = [
+    factory.createIdentifier('fieldName'),
+    factory.createIdentifier('item'),
+  ];
+
+  const runValidationTasksArgs = [
+    factory.createIdentifier('fieldName'),
+    factory.createElementAccessExpression(
+      factory.createIdentifier('modelFields'),
+      factory.createIdentifier('fieldName'),
+    ),
+  ];
+
+  if (shouldUseGetDisplayValue) {
+    runValidationTasksArgsForArray.push(getDisplayValueAccess);
+    runValidationTasksArgs.push(getDisplayValueAccess);
+  }
+
+  return [
+    factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('validationResponses'),
+            undefined,
+            undefined,
+            factory.createAwaitExpression(
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('Promise'),
+                  factory.createIdentifier('all'),
+                ),
+                undefined,
+                [
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createCallExpression(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier('Object'),
+                          factory.createIdentifier('keys'),
+                        ),
+                        undefined,
+                        [factory.createIdentifier('validations')],
                       ),
-                      undefined,
-                      [factory.createIdentifier('validations')],
+                      factory.createIdentifier('reduce'),
                     ),
-                    factory.createIdentifier('reduce'),
-                  ),
-                  undefined,
-                  [
-                    factory.createArrowFunction(
-                      undefined,
-                      undefined,
-                      [
-                        factory.createParameterDeclaration(
-                          undefined,
-                          undefined,
-                          undefined,
-                          factory.createIdentifier('promises'),
-                          undefined,
-                          undefined,
-                        ),
-                        factory.createParameterDeclaration(
-                          undefined,
-                          undefined,
-                          undefined,
-                          factory.createIdentifier('fieldName'),
-                          undefined,
-                          undefined,
-                        ),
-                      ],
-                      undefined,
-                      factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                      factory.createBlock(
+                    undefined,
+                    [
+                      factory.createArrowFunction(
+                        undefined,
+                        undefined,
                         [
-                          factory.createIfStatement(
-                            factory.createCallExpression(
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier('Array'),
-                                factory.createIdentifier('isArray'),
-                              ),
-                              undefined,
-                              [
-                                factory.createElementAccessExpression(
-                                  factory.createIdentifier('modelFields'),
-                                  factory.createIdentifier('fieldName'),
-                                ),
-                              ],
-                            ),
-                            factory.createBlock(
-                              [
-                                factory.createExpressionStatement(
-                                  factory.createCallExpression(
-                                    factory.createPropertyAccessExpression(
-                                      factory.createIdentifier('promises'),
-                                      factory.createIdentifier('push'),
-                                    ),
-                                    undefined,
-                                    [
-                                      factory.createSpreadElement(
-                                        factory.createCallExpression(
-                                          factory.createPropertyAccessExpression(
-                                            factory.createElementAccessExpression(
-                                              factory.createIdentifier('modelFields'),
-                                              factory.createIdentifier('fieldName'),
-                                            ),
-                                            factory.createIdentifier('map'),
-                                          ),
-                                          undefined,
-                                          [
-                                            factory.createArrowFunction(
-                                              undefined,
-                                              undefined,
-                                              [
-                                                factory.createParameterDeclaration(
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  factory.createIdentifier('item'),
-                                                  undefined,
-                                                  undefined,
-                                                ),
-                                              ],
-                                              undefined,
-                                              factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                                              factory.createCallExpression(
-                                                factory.createIdentifier('runValidationTasks'),
-                                                undefined,
-                                                [
-                                                  factory.createIdentifier('fieldName'),
-                                                  factory.createIdentifier('item'),
-                                                ],
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                                factory.createReturnStatement(factory.createIdentifier('promises')),
-                              ],
-                              true,
-                            ),
+                          factory.createParameterDeclaration(
+                            undefined,
+                            undefined,
+                            undefined,
+                            factory.createIdentifier('promises'),
+                            undefined,
+                            undefined,
                             undefined,
                           ),
-                          factory.createExpressionStatement(
-                            factory.createCallExpression(
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier('promises'),
-                                factory.createIdentifier('push'),
+                          factory.createParameterDeclaration(
+                            undefined,
+                            undefined,
+                            undefined,
+                            factory.createIdentifier('fieldName'),
+                            undefined,
+                            undefined,
+                            undefined,
+                          ),
+                        ],
+                        undefined,
+                        factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                        factory.createBlock(
+                          [
+                            factory.createIfStatement(
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('Array'),
+                                  factory.createIdentifier('isArray'),
+                                ),
+                                undefined,
+                                [
+                                  factory.createElementAccessExpression(
+                                    factory.createIdentifier('modelFields'),
+                                    factory.createIdentifier('fieldName'),
+                                  ),
+                                ],
+                              ),
+                              factory.createBlock(
+                                [
+                                  factory.createExpressionStatement(
+                                    factory.createCallExpression(
+                                      factory.createPropertyAccessExpression(
+                                        factory.createIdentifier('promises'),
+                                        factory.createIdentifier('push'),
+                                      ),
+                                      undefined,
+                                      [
+                                        factory.createSpreadElement(
+                                          factory.createCallExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createElementAccessExpression(
+                                                factory.createIdentifier('modelFields'),
+                                                factory.createIdentifier('fieldName'),
+                                              ),
+                                              factory.createIdentifier('map'),
+                                            ),
+                                            undefined,
+                                            [
+                                              factory.createArrowFunction(
+                                                undefined,
+                                                undefined,
+                                                [
+                                                  factory.createParameterDeclaration(
+                                                    undefined,
+                                                    undefined,
+                                                    undefined,
+                                                    factory.createIdentifier('item'),
+                                                    undefined,
+                                                    undefined,
+                                                    undefined,
+                                                  ),
+                                                ],
+                                                undefined,
+                                                factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                                                factory.createCallExpression(
+                                                  factory.createIdentifier('runValidationTasks'),
+                                                  undefined,
+                                                  runValidationTasksArgsForArray,
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  factory.createReturnStatement(factory.createIdentifier('promises')),
+                                ],
+                                true,
                               ),
                               undefined,
-                              [
-                                factory.createCallExpression(
-                                  factory.createIdentifier('runValidationTasks'),
-                                  undefined,
-                                  [
-                                    factory.createIdentifier('fieldName'),
-                                    factory.createElementAccessExpression(
-                                      factory.createIdentifier('modelFields'),
-                                      factory.createIdentifier('fieldName'),
-                                    ),
-                                  ],
-                                ),
-                              ],
                             ),
-                          ),
-                          factory.createReturnStatement(factory.createIdentifier('promises')),
-                        ],
-                        true,
+                            factory.createExpressionStatement(
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('promises'),
+                                  factory.createIdentifier('push'),
+                                ),
+                                undefined,
+                                [
+                                  factory.createCallExpression(
+                                    factory.createIdentifier('runValidationTasks'),
+                                    undefined,
+                                    runValidationTasksArgs,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            factory.createReturnStatement(factory.createIdentifier('promises')),
+                          ],
+                          true,
+                        ),
                       ),
-                    ),
-                    factory.createArrayLiteralExpression([], false),
-                  ],
-                ),
-              ],
+                      factory.createArrayLiteralExpression([], false),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
-        ),
-      ],
-      NodeFlags.Const,
-    ),
-  ),
-  factory.createIfStatement(
-    factory.createCallExpression(
-      factory.createPropertyAccessExpression(
-        factory.createIdentifier('validationResponses'),
-        factory.createIdentifier('some'),
+        ],
+        NodeFlags.Const,
       ),
-      undefined,
-      [
-        factory.createArrowFunction(
-          undefined,
-          undefined,
-          [
-            factory.createParameterDeclaration(
-              undefined,
-              undefined,
-              undefined,
-              factory.createIdentifier('r'),
-              undefined,
-              undefined,
-              undefined,
-            ),
-          ],
-          undefined,
-          factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-          factory.createPropertyAccessExpression(factory.createIdentifier('r'), factory.createIdentifier('hasError')),
-        ),
-      ],
     ),
-    factory.createBlock([factory.createReturnStatement(undefined)], true),
-    undefined,
-  ),
-];
+    factory.createIfStatement(
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('validationResponses'),
+          factory.createIdentifier('some'),
+        ),
+        undefined,
+        [
+          factory.createArrowFunction(
+            undefined,
+            undefined,
+            [
+              factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                factory.createIdentifier('r'),
+                undefined,
+                undefined,
+                undefined,
+              ),
+            ],
+            undefined,
+            factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+            factory.createPropertyAccessExpression(factory.createIdentifier('r'), factory.createIdentifier('hasError')),
+          ),
+        ],
+      ),
+      factory.createBlock([factory.createReturnStatement(undefined)], true),
+      undefined,
+    ),
+  ];
+};
 
 export const buildUpdateDatastoreQuery = (dataTypeName: string, recordName: string) => {
   // TODO: update this once cpk is supported in datastore

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
@@ -31,6 +31,7 @@ import {
   PropertyName,
 } from 'typescript';
 import { lowerCaseFirst } from '../../helpers';
+import { getElementAccessExpression } from './invalid-variable-helpers';
 import { isModelDataType, shouldWrapInArrayField } from './render-checkers';
 
 export const getCurrentValueName = (fieldName: string) => `current${capitalizeFirstLetter(fieldName)}Value`;
@@ -246,15 +247,7 @@ export const resetStateFunction = (fieldConfigs: Record<string, FieldConfigMetad
     const stateName = name.split('.')[0];
     const renderedName = sanitizedFieldName || stateName;
     if (!stateNames.has(stateName)) {
-      const accessExpression = isValidVariableName(stateName)
-        ? factory.createPropertyAccessExpression(
-            factory.createIdentifier(recordOrInitialValues),
-            factory.createIdentifier(stateName),
-          )
-        : factory.createElementAccessExpression(
-            factory.createIdentifier(recordOrInitialValues),
-            factory.createStringLiteral(stateName),
-          );
+      const accessExpression = getElementAccessExpression(recordOrInitialValues, stateName);
 
       acc.push(
         setStateExpression(

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/invalid-variable-helpers.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/invalid-variable-helpers.ts
@@ -17,10 +17,14 @@ import { isValidVariableName } from '@aws-amplify/codegen-ui';
 import { factory } from 'typescript';
 
 export function getElementAccessExpression(elementName: string, propertyName: string) {
+  if (isValidVariableName(propertyName)) {
+    return factory.createPropertyAccessExpression(
+      factory.createIdentifier(elementName),
+      factory.createIdentifier(propertyName),
+    );
+  }
   return factory.createElementAccessExpression(
     factory.createIdentifier(elementName),
-    isValidVariableName(propertyName)
-      ? factory.createIdentifier(propertyName)
-      : factory.createStringLiteral(propertyName),
+    factory.createStringLiteral(propertyName),
   );
 }

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -15,16 +15,11 @@
  */
 import { factory } from 'typescript';
 import { GenericDataRelationshipType } from '@aws-amplify/codegen-ui';
-import { ImportCollection, ImportValue } from '../../imports';
 import { getRecordsName } from './form-state';
 import { buildBaseCollectionVariableStatement } from '../../react-studio-template-renderer-helper';
 
-export const buildRelationshipQuery = (
-  relationship: GenericDataRelationshipType,
-  importCollection: ImportCollection,
-) => {
+export const buildRelationshipQuery = (relationship: GenericDataRelationshipType) => {
   const { relatedModelName } = relationship;
-  importCollection.addMappedImport(ImportValue.USE_DATA_STORE_BINDING);
   const itemsName = getRecordsName(relatedModelName);
   const objectProperties = [
     factory.createPropertyAssignment(factory.createIdentifier('type'), factory.createStringLiteral('collection')),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/validation.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/validation.ts
@@ -136,14 +136,16 @@ export function getOnChangeValidationBlock(fieldName: string) {
 }
 
 /**
-    const runValidationTasks = async (fieldName, value) => {
-      let validationResponse = validateField(value, validations[fieldName]);
-      if (onValidate?.[fieldName]) {
-        validationResponse = await onValidate[fieldName](value, validationResponse);
-      }
-      setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
-      return validationResponse;
-    };
+  const runValidationTasks = async (fieldName, currentValue, getDisplayValue) => {
+    const value = getDisplayValue ? getDisplayValue(currentValue) : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
    */
 
 export const runValidationTasksFunction = factory.createVariableStatement(
@@ -171,7 +173,16 @@ export const runValidationTasksFunction = factory.createVariableStatement(
               undefined,
               undefined,
               undefined,
-              factory.createIdentifier('value'),
+              factory.createIdentifier('currentValue'),
+              undefined,
+              undefined,
+              undefined,
+            ),
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              undefined,
+              factory.createIdentifier('getDisplayValue'),
               undefined,
               undefined,
               undefined,
@@ -181,6 +192,28 @@ export const runValidationTasksFunction = factory.createVariableStatement(
           factory.createToken(SyntaxKind.EqualsGreaterThanToken),
           factory.createBlock(
             [
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createIdentifier('value'),
+                      undefined,
+                      undefined,
+                      factory.createConditionalExpression(
+                        factory.createIdentifier('getDisplayValue'),
+                        factory.createToken(SyntaxKind.QuestionToken),
+                        factory.createCallExpression(factory.createIdentifier('getDisplayValue'), undefined, [
+                          factory.createIdentifier('currentValue'),
+                        ]),
+                        factory.createToken(SyntaxKind.ColonToken),
+                        factory.createIdentifier('currentValue'),
+                      ),
+                    ),
+                  ],
+                  NodeFlags.Const,
+                ),
+              ),
               factory.createVariableStatement(
                 undefined,
                 factory.createVariableDeclarationList(

--- a/packages/codegen-ui/example-schemas/forms/book-datastore-create.json
+++ b/packages/codegen-ui/example-schemas/forms/book-datastore-create.json
@@ -6,6 +6,7 @@
     },
     "formActionType": "create",
     "fields": {
+        "authorId": {},
         "primary-author": {
             "inputType": {
                 "type": "Autocomplete",

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -244,6 +244,10 @@ describe('mapModelFieldsConfigs', () => {
           type: 'Autocomplete',
           value: 'ownerId',
           isArray: false,
+          valueMappings: {
+            values: [{ value: { bindingProperties: { property: 'Owner', field: 'id' } } }],
+            bindingProperties: { Owner: { type: 'Data', bindingProperties: { model: 'Owner' } } },
+          },
         },
         label: 'Owner id',
         relationship: { relatedModelName: 'Owner', type: 'HAS_ONE' },

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -70,15 +70,14 @@ function getValueMappings({
   // if relationship
   if (field.relationship) {
     // if model & HAS_ONE
-    if (typeof field.dataType === 'object' && 'model' in field.dataType && field.relationship.type === 'HAS_ONE') {
-      const modelName = field.dataType.model;
+    if (field.relationship.type === 'HAS_ONE') {
+      const modelName = field.relationship.relatedModelName;
       return {
+        // TODO: map field dynamically as part of cpk task
         values: [{ value: { bindingProperties: { property: modelName, field: 'id' } } }],
         bindingProperties: { [modelName]: { type: 'Data', bindingProperties: { model: modelName } } },
       };
     }
-
-    // TODO: handle relationship fields that are not model, e.g. ID
   }
 
   return undefined;


### PR DESCRIPTION
*Description of changes:*
- support fields that are not of model type but has relationship

*Additional changes:*
Bug fixes like:
- DataStore query rendering twice when model used twice
- runValidationTasks need to use display value
- Autocomplete suggestions assume wrong shape of model records
- Helper for property access was wrong


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
