### PR TITLE
fix: refresh stale data on update form

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           path: amplify-cli
           repository: aws-amplify/amplify-cli
-      - name: Setup Node.js LTS
+      - name: Setup Node.js LTS/gallium
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: lts/gallium
       - name: Build amplify-codegen-ui
         working-directory: amplify-codegen-ui
         run: |
@@ -83,10 +83,10 @@ jobs:
     steps:
       - name: Checkout Studio Codegen
         uses: actions/checkout@v2
-      - name: Setup Node.js LTS/gallium
+      - name: Setup Node.js LTS
         uses: actions/setup-node@v2
         with:
-          node-version: lts/gallium
+          node-version: lts/*
       - name: Install packages
         run: npm ci
       - name: Lerna bootstrap

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,10 +83,10 @@ jobs:
     steps:
       - name: Checkout Studio Codegen
         uses: actions/checkout@v2
-      - name: Setup Node.js LTS
+      - name: Setup Node.js LTS/gallium
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: lts/gallium
       - name: Install packages
         run: npm ci
       - name: Lerna bootstrap

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -417,7 +417,7 @@ export default function CustomDataForm(props) {
   };
   const [name, setName] = React.useState(initialValues.name);
   const [email, setEmail] = React.useState(initialValues.email);
-  const [metadataField, setMetadataField] = React.useState(
+  const [metadatafield, setMetadatafield] = React.useState(
     initialValues[\\"metadata-field\\"]
   );
   const [city, setCity] = React.useState(initialValues.city);
@@ -428,7 +428,7 @@ export default function CustomDataForm(props) {
     const cleanValues = { ...initialValues, ...initialData };
     setName(cleanValues.name);
     setEmail(cleanValues.email);
-    setMetadataField(cleanValues[\\"metadata-field\\"]);
+    setMetadatafield(cleanValues[\\"metadata-field\\"]);
     setCity(cleanValues.city);
     setCategory(cleanValues.category);
     setPages(cleanValues.pages);
@@ -439,7 +439,7 @@ export default function CustomDataForm(props) {
     if (initialData) {
       setName(initialData.name);
       setEmail(initialData.email);
-      setMetadataField(initialData[\\"metadata-field\\"]);
+      setMetadatafield(initialData[\\"metadata-field\\"]);
       setCity(initialData.city);
       setCategory(initialData.category);
       setPages(initialData.pages);
@@ -473,7 +473,7 @@ export default function CustomDataForm(props) {
         const modelFields = {
           name,
           email,
-          \\"metadata-field\\": metadataField,
+          \\"metadata-field\\": metadatafield,
           city,
           category,
           pages,
@@ -513,7 +513,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name: value,
               email,
-              \\"metadata-field\\": metadataField,
+              \\"metadata-field\\": metadatafield,
               city,
               category,
               pages,
@@ -542,7 +542,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email: value,
-              \\"metadata-field\\": metadataField,
+              \\"metadata-field\\": metadatafield,
               city,
               category,
               pages,
@@ -563,14 +563,14 @@ export default function CustomDataForm(props) {
       <TextAreaField
         label=\\"Metadata\\"
         isRequired={true}
-        defaultValue={metadataField}
+        defaultValue={metadatafield}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadataField,
+              \\"metadata-field\\": metadatafield,
               city,
               category,
               pages,
@@ -581,9 +581,9 @@ export default function CustomDataForm(props) {
           if (errors[\\"metadata-field\\"]?.hasError) {
             runValidationTasks(\\"metadata-field\\", value);
           }
-          setMetadataField(value);
+          setMetadatafield(value);
         }}
-        onBlur={() => runValidationTasks(\\"metadata-field\\", metadataField)}
+        onBlur={() => runValidationTasks(\\"metadata-field\\", metadatafield)}
         errorMessage={errors[\\"metadata-field\\"]?.errorMessage}
         hasError={errors[\\"metadata-field\\"]?.hasError}
         {...getOverrideProps(overrides, \\"metadata-field\\")}
@@ -598,7 +598,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadataField,
+              \\"metadata-field\\": metadatafield,
               city: value,
               category,
               pages,
@@ -644,7 +644,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadataField,
+              \\"metadata-field\\": metadatafield,
               city,
               category: value,
               pages,
@@ -687,7 +687,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadataField,
+              \\"metadata-field\\": metadatafield,
               city,
               category,
               pages: value,
@@ -1907,7 +1907,7 @@ export default function NestedJson(props) {
   const [lastName, setLastName] = React.useState(initialValues.lastName);
   const [bio, setBio] = React.useState(initialValues.bio);
   const [Nicknames1, setNicknames1] = React.useState(initialValues.Nicknames1);
-  const [nickNames, setNickNames] = React.useState(
+  const [nicknames, setNicknames] = React.useState(
     initialValues[\\"nick-names2\\"]
   );
   const [firstName1, setFirstName1] = React.useState(
@@ -1920,17 +1920,17 @@ export default function NestedJson(props) {
     setBio(initialValues.bio);
     setNicknames1(initialValues.Nicknames1);
     setCurrentNicknames1Value(undefined);
-    setNickNames(initialValues[\\"nick-names2\\"]);
-    setCurrentNickNamesValue(undefined);
+    setNicknames(initialValues[\\"nick-names2\\"]);
+    setCurrentNicknamesValue(undefined);
     setFirstName1(initialValues[\\"first Name\\"]);
     setErrors({});
   };
   const [currentNicknames1Value, setCurrentNicknames1Value] =
     React.useState(undefined);
   const Nicknames1Ref = React.createRef();
-  const [currentNickNamesValue, setCurrentNickNamesValue] =
+  const [currentNicknamesValue, setCurrentNicknamesValue] =
     React.useState(undefined);
-  const nickNamesRef = React.createRef();
+  const nicknamesRef = React.createRef();
   const validations = {
     \\"first-Name\\": [],
     lastName: [],
@@ -1962,7 +1962,7 @@ export default function NestedJson(props) {
           lastName,
           bio,
           Nicknames1,
-          \\"nick-names2\\": nickNames,
+          \\"nick-names2\\": nicknames,
           \\"first Name\\": firstName1,
         };
         const validationResponses = await Promise.all(
@@ -1999,7 +1999,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nickNames,
+              \\"nick-names2\\": nicknames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2025,7 +2025,7 @@ export default function NestedJson(props) {
               lastName: value,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nickNames,
+              \\"nick-names2\\": nicknames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2056,7 +2056,7 @@ export default function NestedJson(props) {
               lastName,
               bio: { ...bio, [\\"favorite Quote\\"]: value },
               Nicknames1,
-              \\"nick-names2\\": nickNames,
+              \\"nick-names2\\": nicknames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2084,7 +2084,7 @@ export default function NestedJson(props) {
               lastName,
               bio: { ...bio, [\\"favorite-Animal\\"]: value },
               Nicknames1,
-              \\"nick-names2\\": nickNames,
+              \\"nick-names2\\": nicknames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2111,7 +2111,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1: values,
-              \\"nick-names2\\": nickNames,
+              \\"nick-names2\\": nicknames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2155,21 +2155,21 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nickNames,
+              \\"nick-names2\\": nicknames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
             values = result?.[\\"nick-names2\\"] ?? values;
           }
-          setNickNames(values);
-          setCurrentNickNamesValue(undefined);
+          setNicknames(values);
+          setCurrentNicknamesValue(undefined);
         }}
-        currentFieldValue={currentNickNamesValue}
+        currentFieldValue={currentNicknamesValue}
         label={\\"nick-Names2\\"}
-        items={nickNames}
+        items={nicknames}
         hasError={errors?.[\\"nick-names2\\"]?.hasError}
-        setFieldValue={setCurrentNickNamesValue}
-        inputFieldRef={nickNamesRef}
+        setFieldValue={setCurrentNicknamesValue}
+        inputFieldRef={nicknamesRef}
         defaultFieldValue={undefined}
       >
         <TextField
@@ -2179,14 +2179,14 @@ export default function NestedJson(props) {
             if (errors[\\"nick-names2\\"]?.hasError) {
               runValidationTasks(\\"nick-names2\\", value);
             }
-            setCurrentNickNamesValue(value);
+            setCurrentNicknamesValue(value);
           }}
           onBlur={() =>
-            runValidationTasks(\\"nick-names2\\", currentNickNamesValue)
+            runValidationTasks(\\"nick-names2\\", currentNicknamesValue)
           }
           errorMessage={errors[\\"nick-names2\\"]?.errorMessage}
           hasError={errors[\\"nick-names2\\"]?.hasError}
-          ref={nickNamesRef}
+          ref={nicknamesRef}
           {...getOverrideProps(overrides, \\"nick-names2\\")}
         ></TextField>
       </ArrayField>
@@ -2200,7 +2200,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nickNames,
+              \\"nick-names2\\": nicknames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -417,7 +417,7 @@ export default function CustomDataForm(props) {
   };
   const [name, setName] = React.useState(initialValues.name);
   const [email, setEmail] = React.useState(initialValues.email);
-  const [metadatafield, setMetadatafield] = React.useState(
+  const [metadataField, setMetadataField] = React.useState(
     initialValues[\\"metadata-field\\"]
   );
   const [city, setCity] = React.useState(initialValues.city);
@@ -428,7 +428,7 @@ export default function CustomDataForm(props) {
     const cleanValues = { ...initialValues, ...initialData };
     setName(cleanValues.name);
     setEmail(cleanValues.email);
-    setMetadatafield(cleanValues[\\"metadata-field\\"]);
+    setMetadataField(cleanValues[\\"metadata-field\\"]);
     setCity(cleanValues.city);
     setCategory(cleanValues.category);
     setPages(cleanValues.pages);
@@ -439,7 +439,7 @@ export default function CustomDataForm(props) {
     if (initialData) {
       setName(initialData.name);
       setEmail(initialData.email);
-      setMetadatafield(initialData[\\"metadata-field\\"]);
+      setMetadataField(initialData[\\"metadata-field\\"]);
       setCity(initialData.city);
       setCategory(initialData.category);
       setPages(initialData.pages);
@@ -473,7 +473,7 @@ export default function CustomDataForm(props) {
         const modelFields = {
           name,
           email,
-          \\"metadata-field\\": metadatafield,
+          \\"metadata-field\\": metadataField,
           city,
           category,
           pages,
@@ -513,7 +513,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name: value,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category,
               pages,
@@ -542,7 +542,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email: value,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category,
               pages,
@@ -563,14 +563,14 @@ export default function CustomDataForm(props) {
       <TextAreaField
         label=\\"Metadata\\"
         isRequired={true}
-        defaultValue={metadatafield}
+        defaultValue={metadataField}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category,
               pages,
@@ -581,9 +581,9 @@ export default function CustomDataForm(props) {
           if (errors[\\"metadata-field\\"]?.hasError) {
             runValidationTasks(\\"metadata-field\\", value);
           }
-          setMetadatafield(value);
+          setMetadataField(value);
         }}
-        onBlur={() => runValidationTasks(\\"metadata-field\\", metadatafield)}
+        onBlur={() => runValidationTasks(\\"metadata-field\\", metadataField)}
         errorMessage={errors[\\"metadata-field\\"]?.errorMessage}
         hasError={errors[\\"metadata-field\\"]?.hasError}
         {...getOverrideProps(overrides, \\"metadata-field\\")}
@@ -598,7 +598,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city: value,
               category,
               pages,
@@ -644,7 +644,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category: value,
               pages,
@@ -687,7 +687,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": metadataField,
               city,
               category,
               pages: value,
@@ -1907,7 +1907,7 @@ export default function NestedJson(props) {
   const [lastName, setLastName] = React.useState(initialValues.lastName);
   const [bio, setBio] = React.useState(initialValues.bio);
   const [Nicknames1, setNicknames1] = React.useState(initialValues.Nicknames1);
-  const [nicknames, setNicknames] = React.useState(
+  const [nickNames, setNickNames] = React.useState(
     initialValues[\\"nick-names2\\"]
   );
   const [firstName1, setFirstName1] = React.useState(
@@ -1920,17 +1920,17 @@ export default function NestedJson(props) {
     setBio(initialValues.bio);
     setNicknames1(initialValues.Nicknames1);
     setCurrentNicknames1Value(undefined);
-    setNicknames(initialValues[\\"nick-names2\\"]);
-    setCurrentNicknamesValue(undefined);
+    setNickNames(initialValues[\\"nick-names2\\"]);
+    setCurrentNickNamesValue(undefined);
     setFirstName1(initialValues[\\"first Name\\"]);
     setErrors({});
   };
   const [currentNicknames1Value, setCurrentNicknames1Value] =
     React.useState(undefined);
   const Nicknames1Ref = React.createRef();
-  const [currentNicknamesValue, setCurrentNicknamesValue] =
+  const [currentNickNamesValue, setCurrentNickNamesValue] =
     React.useState(undefined);
-  const nicknamesRef = React.createRef();
+  const nickNamesRef = React.createRef();
   const validations = {
     \\"first-Name\\": [],
     lastName: [],
@@ -1962,7 +1962,7 @@ export default function NestedJson(props) {
           lastName,
           bio,
           Nicknames1,
-          \\"nick-names2\\": nicknames,
+          \\"nick-names2\\": nickNames,
           \\"first Name\\": firstName1,
         };
         const validationResponses = await Promise.all(
@@ -1999,7 +1999,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2025,7 +2025,7 @@ export default function NestedJson(props) {
               lastName: value,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2056,7 +2056,7 @@ export default function NestedJson(props) {
               lastName,
               bio: { ...bio, [\\"favorite Quote\\"]: value },
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2084,7 +2084,7 @@ export default function NestedJson(props) {
               lastName,
               bio: { ...bio, [\\"favorite-Animal\\"]: value },
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2111,7 +2111,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1: values,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2155,21 +2155,21 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
             values = result?.[\\"nick-names2\\"] ?? values;
           }
-          setNicknames(values);
-          setCurrentNicknamesValue(undefined);
+          setNickNames(values);
+          setCurrentNickNamesValue(undefined);
         }}
-        currentFieldValue={currentNicknamesValue}
+        currentFieldValue={currentNickNamesValue}
         label={\\"nick-Names2\\"}
-        items={nicknames}
+        items={nickNames}
         hasError={errors?.[\\"nick-names2\\"]?.hasError}
-        setFieldValue={setCurrentNicknamesValue}
-        inputFieldRef={nicknamesRef}
+        setFieldValue={setCurrentNickNamesValue}
+        inputFieldRef={nickNamesRef}
         defaultFieldValue={undefined}
       >
         <TextField
@@ -2179,14 +2179,14 @@ export default function NestedJson(props) {
             if (errors[\\"nick-names2\\"]?.hasError) {
               runValidationTasks(\\"nick-names2\\", value);
             }
-            setCurrentNicknamesValue(value);
+            setCurrentNickNamesValue(value);
           }}
           onBlur={() =>
-            runValidationTasks(\\"nick-names2\\", currentNicknamesValue)
+            runValidationTasks(\\"nick-names2\\", currentNickNamesValue)
           }
           errorMessage={errors[\\"nick-names2\\"]?.errorMessage}
           hasError={errors[\\"nick-names2\\"]?.hasError}
-          ref={nicknamesRef}
+          ref={nickNamesRef}
           {...getOverrideProps(overrides, \\"nick-names2\\")}
         ></TextField>
       </ArrayField>
@@ -2200,7 +2200,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": nickNames,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -3421,8 +3421,9 @@ export default function MyPostForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          const original = await DataStore.query(Post, id);
           await DataStore.save(
-            Post.copyOf(postRecord, (updated) => {
+            Post.copyOf(original, (updated) => {
               Object.assign(updated, modelFields);
             })
           );
@@ -5042,8 +5043,9 @@ export default function InputGalleryUpdateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          const original = await DataStore.query(InputGallery, id);
           await DataStore.save(
-            InputGallery.copyOf(inputGalleryRecord, (updated) => {
+            InputGallery.copyOf(original, (updated) => {
               Object.assign(updated, modelFields);
             })
           );

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -580,6 +580,29 @@ export const buildOnChangeStatement = (
 export const buildDataStoreExpression = (dataStoreActionType: 'update' | 'create', modelName: string) => {
   if (dataStoreActionType === 'update') {
     return [
+      factory.createVariableStatement(
+        undefined,
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              factory.createIdentifier('original'),
+              undefined,
+              undefined,
+              factory.createAwaitExpression(
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('DataStore'),
+                    factory.createIdentifier('query'),
+                  ),
+                  undefined,
+                  [factory.createIdentifier(modelName), factory.createIdentifier('id')],
+                ),
+              ),
+            ),
+          ],
+          NodeFlags.Const,
+        ),
+      ),
       factory.createExpressionStatement(
         factory.createAwaitExpression(
           factory.createCallExpression(
@@ -596,7 +619,7 @@ export const buildDataStoreExpression = (dataStoreActionType: 'update' | 'create
                 ),
                 undefined,
                 [
-                  factory.createIdentifier(`${lowerCaseFirst(modelName)}Record`),
+                  factory.createIdentifier('original'),
                   factory.createArrowFunction(
                     undefined,
                     undefined,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update forms fail to update data after the first update due to stale data.  By performing a fresh query before submit, we ensure we are performing mutations on the latest state.  
See https://docs.amplify.aws/lib/datastore/data-access/q/platform/js/#create-and-update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
![Screen Shot 2022-10-27 at 8 55 09 AM](https://user-images.githubusercontent.com/1263887/198339295-ed1267ca-6278-464c-9302-33d3510c0714.png)
![Screen Shot 2022-10-27 at 8 55 04 AM](https://user-images.githubusercontent.com/1263887/198339302-3c901a99-75f3-4699-946c-0cbcb22e1281.png)

