### PR TITLE
chore: set timezone to UTC before starting cypress tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           path: amplify-cli
           repository: aws-amplify/amplify-cli
-      - name: Setup Node.js LTS
+      - name: Setup Node.js LTS/gallium
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: lts/gallium
       - name: Build amplify-codegen-ui
         working-directory: amplify-codegen-ui
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Open Bugs](https://img.shields.io/github/issues/aws-amplify/amplify-codegen-ui/bug?color=d73a4a&label=bugs)](https://github.com/aws-amplify/amplify-codegen-ui/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 [![Feature Requests](https://img.shields.io/github/issues/aws-amplify/amplify-codegen-ui/feature-request?color=ff9001&label=feature%20requests)](https://github.com/aws-amplify/amplify-codegen-ui/issues?q=is%3Aissue+label%3Afeature-request+is%3Aopen)
 
-Generate React components for use in an AWS Amplify project.
+Generate React components for use in an AWS Amplify project..
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Open Bugs](https://img.shields.io/github/issues/aws-amplify/amplify-codegen-ui/bug?color=d73a4a&label=bugs)](https://github.com/aws-amplify/amplify-codegen-ui/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 [![Feature Requests](https://img.shields.io/github/issues/aws-amplify/amplify-codegen-ui/feature-request?color=ff9001&label=feature%20requests)](https://github.com/aws-amplify/amplify-codegen-ui/issues?q=is%3Aissue+label%3Afeature-request+is%3Aopen)
 
-Generate React components for use in an AWS Amplify project..
+Generate React components for use in an AWS Amplify project.
 
 ## Usage
 

--- a/scripts/integ-test.sh
+++ b/scripts/integ-test.sh
@@ -2,6 +2,6 @@
 
 (cd packages/integration-test && (
   (npm start &> /dev/null & npx --no-install wait-on http://localhost:3000) &&
-  npx --no-install cypress run -C cypress.config.ts
+  TZ=UTC npx --no-install cypress run -C cypress.config.ts
   kill -9 `lsof -t -i :3000 -s`
 ))


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds `TZ=UTC` env variable setup before running cypress integration tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
