### PR TITLE
fix: allow empty string for url field

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           path: amplify-cli
           repository: aws-amplify/amplify-cli
-      - name: Setup Node.js LTS
+      - name: Setup Node.js LTS/gallium
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: lts/gallium
       - name: Build amplify-codegen-ui
         working-directory: amplify-codegen-ui
         run: |

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1422,9 +1422,9 @@ export default function MyPostForm(props) {
           username,
           caption,
           Customtags,
-          post_url,
+          post_url: post_url || undefined,
           metadata,
-          profile_url,
+          profile_url: profile_url || undefined,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -3045,9 +3045,9 @@ export default function MyPostForm(props) {
         let modelFields = {
           caption,
           username,
-          post_url,
+          post_url: post_url || undefined,
           metadata,
-          profile_url,
+          profile_url: profile_url || undefined,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -3400,8 +3400,8 @@ export default function MyPostForm(props) {
           TextAreaFieldbbd63464,
           caption,
           username,
-          profile_url,
-          post_url,
+          profile_url: profile_url || undefined,
+          post_url: post_url || undefined,
           metadata,
         };
         const validationResponses = await Promise.all(
@@ -5832,8 +5832,8 @@ export default function PostCreateFormRow(props) {
         let modelFields = {
           username,
           caption,
-          post_url,
-          profile_url,
+          post_url: post_url || undefined,
+          profile_url: profile_url || undefined,
           status,
           metadata,
         };

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -893,7 +893,7 @@ export const buildModelFieldObject = (
   const fieldSet = new Set<string>();
   const fields = Object.keys(fieldConfigs).reduce<ObjectLiteralElementLike[]>((acc, value) => {
     const fieldName = value.split('.')[0];
-    const { sanitizedFieldName } = fieldConfigs[value];
+    const { sanitizedFieldName, dataType } = fieldConfigs[value];
     const renderedFieldName = sanitizedFieldName || fieldName;
     if (!fieldSet.has(renderedFieldName)) {
       let assignment = nameOverrides[fieldName]
@@ -903,6 +903,22 @@ export const buildModelFieldObject = (
         assignment = factory.createPropertyAssignment(
           factory.createStringLiteral(fieldName),
           factory.createIdentifier(sanitizedFieldName),
+        );
+      }
+      /*
+       Empty string value for not required url field fails to save at datastore
+       let modelFields = {
+        url: url || undefined,
+       }
+      */
+      if (dataType === 'AWSURL' && !shouldBeConst) {
+        assignment = factory.createPropertyAssignment(
+          factory.createStringLiteral(fieldName),
+          factory.createBinaryExpression(
+            factory.createIdentifier(renderedFieldName),
+            factory.createToken(SyntaxKind.BarBarToken),
+            factory.createIdentifier('undefined'),
+          ),
         );
       }
 

--- a/scripts/integ-test.sh
+++ b/scripts/integ-test.sh
@@ -2,6 +2,6 @@
 
 (cd packages/integration-test && (
   (npm start &> /dev/null & npx --no-install wait-on http://localhost:3000) &&
-  npx --no-install cypress run -C cypress.config.ts
+  TZ=UTC npx --no-install cypress run -C cypress.config.ts
   kill -9 `lsof -t -i :3000 -s`
 ))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- if url field value is empty string fallback to undefined for datastore

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
