### PR TITLE
fix: refresh stale data on update form

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3427,8 +3427,9 @@ export default function MyPostForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          const original = await DataStore.query(Post, id);
           await DataStore.save(
-            Post.copyOf(postRecord, (updated) => {
+            Post.copyOf(original, (updated) => {
               Object.assign(updated, modelFields);
             })
           );
@@ -5281,8 +5282,9 @@ export default function InputGalleryUpdateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          const original = await DataStore.query(InputGallery, id);
           await DataStore.save(
-            InputGallery.copyOf(inputGalleryRecord, (updated) => {
+            InputGallery.copyOf(original, (updated) => {
               Object.assign(updated, modelFields);
             })
           );

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -549,6 +549,29 @@ export const buildOnChangeStatement = (
 export const buildDataStoreExpression = (dataStoreActionType: 'update' | 'create', modelName: string) => {
   if (dataStoreActionType === 'update') {
     return [
+      factory.createVariableStatement(
+        undefined,
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              factory.createIdentifier('original'),
+              undefined,
+              undefined,
+              factory.createAwaitExpression(
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('DataStore'),
+                    factory.createIdentifier('query'),
+                  ),
+                  undefined,
+                  [factory.createIdentifier(modelName), factory.createIdentifier('id')],
+                ),
+              ),
+            ),
+          ],
+          NodeFlags.Const,
+        ),
+      ),
       factory.createExpressionStatement(
         factory.createAwaitExpression(
           factory.createCallExpression(
@@ -565,7 +588,7 @@ export const buildDataStoreExpression = (dataStoreActionType: 'update' | 'create
                 ),
                 undefined,
                 [
-                  factory.createIdentifier(`${lowerCaseFirst(modelName)}Record`),
+                  factory.createIdentifier('original'),
                   factory.createArrowFunction(
                     undefined,
                     undefined,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update forms fail to update data after the first update due to stale data. By performing a fresh query before submit, we ensure we are performing mutations on the latest state.
See https://docs.amplify.aws/lib/datastore/data-access/q/platform/js/#create-and-update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
