### PR TITLE
fix: forms checkbox use checked instead of defaultChecked to support …

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -4193,7 +4193,7 @@ export default function InputGalleryCreateForm(props) {
     rootbeer: undefined,
     attend: undefined,
     maybeSlide: false,
-    maybeCheck: undefined,
+    maybeCheck: false,
     arrayTypeField: [],
     timestamp: undefined,
     ippy: undefined,
@@ -4465,7 +4465,7 @@ export default function InputGalleryCreateForm(props) {
         name=\\"maybeCheck\\"
         value=\\"maybeCheck\\"
         isDisabled={false}
-        defaultChecked={false}
+        checked={maybeCheck}
         onChange={(e) => {
           let value = e.target.checked;
           if (onChange) {
@@ -4910,7 +4910,7 @@ export default function InputGalleryUpdateForm(props) {
     rootbeer: undefined,
     attend: undefined,
     maybeSlide: false,
-    maybeCheck: undefined,
+    maybeCheck: false,
     arrayTypeField: [],
     timestamp: undefined,
     ippy: undefined,
@@ -5222,7 +5222,7 @@ export default function InputGalleryUpdateForm(props) {
         name=\\"maybeCheck\\"
         value=\\"maybeCheck\\"
         isDisabled={false}
-        defaultChecked={false}
+        checked={maybeCheck}
         defaultValue={maybeCheck}
         onChange={(e) => {
           let value = e.target.checked;

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -497,6 +497,12 @@ export const buildComponentSpecificAttributes = ({
         factory.createJsxExpression(undefined, valueIdentifier),
       ),
     ],
+    CheckboxField: [
+      factory.createJsxAttribute(
+        factory.createIdentifier('checked'),
+        factory.createJsxExpression(undefined, valueIdentifier),
+      ),
+    ],
     NumberField: [factory.createJsxAttribute(factory.createIdentifier('step'), factory.createStringLiteral('any'))],
   };
 

--- a/packages/codegen-ui-react/lib/forms/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-state.ts
@@ -104,6 +104,7 @@ export const getDefaultValueExpression = (
   const componentTypeToDefaultValueMap: { [key: string]: Expression } = {
     ToggleButton: factory.createFalse(),
     SwitchField: factory.createFalse(),
+    CheckboxField: factory.createFalse(),
     StepperField: factory.createNumericLiteral(0),
     SliderField: factory.createNumericLiteral(0),
   };

--- a/packages/codegen-ui-react/lib/workflow/mutation.ts
+++ b/packages/codegen-ui-react/lib/workflow/mutation.ts
@@ -53,7 +53,6 @@ const genericEventToReactEventImplementationOverrides: PrimitiveLevelPropConfigu
 
 const PrimitiveDefaultValuePropMapping: PrimitiveLevelPropConfiguration<string> = new Proxy(
   {
-    [Primitive.CheckboxField]: { checked: 'defaultChecked' },
     [Primitive.SwitchField]: { isChecked: 'defaultChecked' },
   },
   {

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/form-field.test.ts
@@ -469,13 +469,12 @@ describe('getFormDefinitionInputElement', () => {
     const config = {
       inputType: {
         type: 'CheckboxField',
-        defaultChecked: true,
       },
     };
 
     expect(getFormDefinitionInputElement(config)).toStrictEqual({
       componentType: 'CheckboxField',
-      props: { label: 'Label', name: 'fieldName', value: 'fieldName', defaultChecked: true },
+      props: { label: 'Label', name: 'fieldName', value: 'fieldName' },
     });
   });
 

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -282,8 +282,6 @@ export function getFormDefinitionInputElement(
           value:
             config.inputType?.value || baseConfig?.inputType?.value || FORM_DEFINITION_DEFAULTS.field.inputType.value,
           isDisabled: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
-          defaultChecked:
-            getFirstDefinedValue([config.inputType?.defaultChecked, baseConfig?.inputType?.defaultChecked]) || false,
         },
       };
       break;

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -127,7 +127,7 @@ export type FormDefinitionToggleButtonElement = {
 
 export type FormDefinitionCheckboxFieldElement = {
   componentType: 'CheckboxField';
-  props: { label: string; value: string; name: string; isDisabled?: boolean; defaultChecked?: boolean };
+  props: { label: string; value: string; name: string; isDisabled?: boolean; checked?: boolean };
 };
 
 export type FormDefinitionRadioGroupFieldElement = {


### PR DESCRIPTION
…checked state

*Issue #, if available:*

*Description of changes:*
Make CheckboxField a controlled component similar to ToggleButton so that the field properly renders a default state of "checked" when it's supposed to.

Update form setting checkbox to checked, and then reload form
https://user-images.githubusercontent.com/1263887/198681650-ed1fb596-4883-414c-a248-c793194a60fd.mov

Current experience, loading form with checkbox in "checked" state does not set it to checked properly
https://user-images.githubusercontent.com/1263887/198681863-de079ca6-ae7b-42fb-8124-3406ba92d164.mov

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
