### PR TITLE
fix: stringify existing AWSJSON field value

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3414,7 +3414,11 @@ export default function MyPostForm(props) {
     setUsername(cleanValues.username);
     setProfile_url(cleanValues.profile_url);
     setPost_url(cleanValues.post_url);
-    setMetadata(cleanValues.metadata);
+    setMetadata(
+      typeof cleanValues.metadata === \\"string\\"
+        ? cleanValues.metadata
+        : JSON.stringify(cleanValues.metadata)
+    );
     setErrors({});
   };
   const [postRecord, setPostRecord] = React.useState(post);


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1202293561809020/1203339958100504/f

*Description of changes:*

For AWSJSON type fields, when a field value was being from an existing record (from a datastore record for example) the field value could be a JavaScript object. So the field value would show the toString output of the object which was the old [object Object] string which looks bad and broken.

With this update, the form will stringify the object so the field will display the string version of the JSON as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
