### PR TITLE
fix: fix grammar in pull warning message

### DIFF
--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -25,7 +25,7 @@ export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<
       {
         dependencyName: '@aws-amplify/ui-react',
         supportedSemVerPattern: '^3.1.0',
-        reason: 'Required to leverage amplify ui primitives, and studio component helper functions.',
+        reason: 'Required to leverage Amplify UI primitives, and Amplify Studio component helper functions.',
       },
     ];
   }


### PR DESCRIPTION
*Issue #, if available:*
[#11397 on amplify-cli](https://github.com/aws-amplify/amplify-cli/issues/11397)

*Description of changes:*
I changed some capitalization and added the word Amplify in front of Studio to fix some grammar issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
