### PR TITLE
chore: add back integration tests

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
@@ -132,11 +132,10 @@ describe('Generated Components', () => {
     });
 
     describe('DataStore Binding With Predicate', () => {
-      // TODO: once ui-react patch out, add back in
-      // it('Renders with and without overrides', () => {
-      //   cy.get('#dataStoreBindingWithPredicateNoOverrideNoModel').contains('Buddy');
-      //   cy.get('#dataStoreBindingWithPredicateWithOverride').contains('Override Name');
-      // });
+      it('Renders with and without overrides', () => {
+        cy.get('#dataStoreBindingWithPredicateNoOverrideNoModel').contains('Buddy');
+        cy.get('#dataStoreBindingWithPredicateWithOverride').contains('Override Name');
+      });
 
       describe('Auth Binding', () => {
         it('Renders if user data is not available', () => {
@@ -173,30 +172,29 @@ describe('Generated Components', () => {
       cy.get('#collectionWithBindingAndOverrides button').eq(0).contains('Yankee');
       cy.get('#collectionWithBindingAndOverrides button').eq(1).contains('Feather');
     });
-    // TODO: once ui-react patch out, add back in
-    // it('It renders data pulled from local datastore', () => {
-    //   cy.get('#collectionWithBindingNoOverrides button').eq(0).contains('Real');
-    //   cy.get('#collectionWithBindingNoOverrides button').eq(1).contains('Another');
-    //   cy.get('#collectionWithBindingNoOverrides button').eq(2).contains('Last');
-    // });
 
-    // it('It respects sort functionality', () => {
-    //   cy.get('#collectionWithSort button').eq(0).contains('LUser1');
-    //   cy.get('#collectionWithSort button').eq(1).contains('LUser2');
-    //   cy.get('#collectionWithSort button').eq(2).contains('LUser3');
-    // });
+    it('It renders data pulled from local datastore', () => {
+      cy.get('#collectionWithBindingNoOverrides button').eq(0).contains('Real');
+      cy.get('#collectionWithBindingNoOverrides button').eq(1).contains('Another');
+      cy.get('#collectionWithBindingNoOverrides button').eq(2).contains('Last');
+    });
+
+    it('It respects sort functionality', () => {
+      cy.get('#collectionWithSort button').eq(0).contains('LUser1');
+      cy.get('#collectionWithSort button').eq(1).contains('LUser2');
+      cy.get('#collectionWithSort button').eq(2).contains('LUser3');
+    });
 
     it('It renders a list of override values with collectionProperty named items', () => {
       cy.get('#collectionWithBindingItemsNameWithOverrides button').eq(0).contains('Yankee');
       cy.get('#collectionWithBindingItemsNameWithOverrides button').eq(1).contains('Feather');
     });
 
-    // TODO: once ui-react patch out, add back in
-    // it('It renders data pulled from local datastore with collectionProperty named items', () => {
-    //   cy.get('#collectionWithBindingItemsNameNoOverrides button').eq(0).contains('Real');
-    //   cy.get('#collectionWithBindingItemsNameNoOverrides button').eq(1).contains('Another');
-    //   cy.get('#collectionWithBindingItemsNameNoOverrides button').eq(2).contains('Last');
-    // });
+    it('It renders data pulled from local datastore with collectionProperty named items', () => {
+      cy.get('#collectionWithBindingItemsNameNoOverrides button').eq(0).contains('Real');
+      cy.get('#collectionWithBindingItemsNameNoOverrides button').eq(1).contains('Another');
+      cy.get('#collectionWithBindingItemsNameNoOverrides button').eq(2).contains('Last');
+    });
 
     it('It renders paginated collections', () => {
       cy.get('#paginatedCollection').contains('Mountain Retreat - $1800');

--- a/packages/test-generator/integration-test-templates/cypress/e2e/views-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/views-spec.cy.ts
@@ -28,12 +28,10 @@ describe('Expander', () => {
     });
   });
 
-  // TODO: once ui-react patch out, add back in
-
-  // it('renders expander with predicateOverride prop', () => {
-  //   cy.get('#expanderWithPredicateOverride').within(() => {
-  //     // predicateOverride filters out all items but one.
-  //     cy.get(`[data-testid=expander-item]`).should('have.length', 1);
-  //   });
-  // });
+  it('renders expander with predicateOverride prop', () => {
+    cy.get('#expanderWithPredicateOverride').within(() => {
+      // predicateOverride filters out all items but one.
+      cy.get(`[data-testid=expander-item]`).should('have.length', 1);
+    });
+  });
 });


### PR DESCRIPTION
*Description of changes:*
The Amplify UI team released a patch that allows our integ tests to pass again

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
