### PR TITLE
chore: rev recommended ui-react to ^4.0.1 and add aws-amplify ^5.0.2

### DIFF
--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -24,8 +24,13 @@ export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<
     return [
       {
         dependencyName: '@aws-amplify/ui-react',
-        supportedSemVerPattern: '^3.1.0',
+        supportedSemVerPattern: '^4.0.1`',
         reason: 'Required to leverage Amplify UI primitives, and Amplify Studio component helper functions.',
+      },
+      {
+        dependencyName: 'aws-amplify',
+        supportedSemVerPattern: '^5.0.2`',
+        reason: 'Required to leverage DataStore.',
       },
     ];
   }


### PR DESCRIPTION
*Motivation:*
- We need v5 of aws-amplify to support relationships
- ui-react 4.0.1 has fixes we need to support aws-amplify v5.

aws-amplify versions - https://www.npmjs.com/package/aws-amplify?activeTab=versions
ui-react versions - https://www.npmjs.com/package/@aws-amplify/ui-react?activeTab=versions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
