### PR TITLE
fix: fix value passed to onChange override

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -570,7 +570,7 @@ export default function CustomDataForm(props) {
             const modelFields = {
               name,
               email,
-              \\"metadata-field\\": metadatafield,
+              \\"metadata-field\\": value,
               city,
               category,
               pages,
@@ -2002,7 +2002,7 @@ export default function NestedJson(props) {
           let { value } = e.target;
           if (onChange) {
             const modelFields = {
-              \\"first-Name\\": firstName,
+              \\"first-Name\\": value,
               lastName,
               bio,
               Nicknames1,
@@ -2211,7 +2211,7 @@ export default function NestedJson(props) {
               lastName,
               bio,
               Nicknames1,
-              \\"nick-names2\\": nicknames,
+              \\"nick-names2\\": values,
               \\"first Name\\": firstName1,
             };
             const result = onChange(modelFields);
@@ -2258,7 +2258,7 @@ export default function NestedJson(props) {
               bio,
               Nicknames1,
               \\"nick-names2\\": nicknames,
-              \\"first Name\\": firstName1,
+              \\"first Name\\": value,
             };
             const result = onChange(modelFields);
             value = result?.[\\"first Name\\"] ?? value;
@@ -2645,7 +2645,7 @@ export default function NestedJson(props) {
           if (onChange) {
             const modelFields = {
               firstName,
-              \\"last-Name\\": lastName,
+              \\"last-Name\\": value,
               lastName: lastName1,
               bio,
             };
@@ -2669,7 +2669,7 @@ export default function NestedJson(props) {
             const modelFields = {
               firstName,
               \\"last-Name\\": lastName,
-              lastName: lastName1,
+              lastName: values,
               bio,
             };
             const result = onChange(modelFields);
@@ -4685,7 +4685,7 @@ export default function BlogCreateForm(props) {
             const modelFields = {
               title,
               content,
-              switch: switch1,
+              switch: value,
               published,
               editedAt,
             };

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper.ts
@@ -405,9 +405,7 @@ export const buildOverrideOnChangeStatement = (
   const keyName = keyPath[0];
   const valueName = valueNameOverride ?? factory.createIdentifier('value');
   let keyValueExpression = factory.createPropertyAssignment(
-    isValidVariableName(keyName)
-      ? factory.createIdentifier(keyName)
-      : factory.createComputedPropertyName(factory.createStringLiteral(keyName)),
+    isValidVariableName(keyName) ? factory.createIdentifier(keyName) : factory.createStringLiteral(keyName),
     valueName,
   );
   if (keyPath.length > 1) {
@@ -920,10 +918,15 @@ export const buildModelFieldObject = (
     const { sanitizedFieldName, dataType } = fieldConfigs[value];
     const renderedFieldName = sanitizedFieldName || fieldName;
     if (!fieldSet.has(renderedFieldName)) {
-      let assignment = nameOverrides[fieldName]
-        ? nameOverrides[fieldName]
-        : factory.createShorthandPropertyAssignment(factory.createIdentifier(fieldName), undefined);
-      if (sanitizedFieldName) {
+      let assignment: ObjectLiteralElementLike = factory.createShorthandPropertyAssignment(
+        factory.createIdentifier(fieldName),
+        undefined,
+      );
+
+      if (nameOverrides[fieldName]) {
+        assignment = nameOverrides[fieldName];
+      } else if (sanitizedFieldName) {
+        // if overrides present, ignore sanitizedFieldName
         assignment = factory.createPropertyAssignment(
           factory.createStringLiteral(fieldName),
           factory.createIdentifier(sanitizedFieldName),


### PR DESCRIPTION
*Description of changes:*
- pass in the current value instead of the prev one into the `onChange` override
- style change: remove brackets from key (it used to render when `value` specified as value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
