### PR TITLE
fix: fix variables for nested arrays

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -2129,10 +2129,10 @@ export default function NestedJson(props) {
         }}
         currentFieldValue={currentBioFavoritetreesValue}
         label={\\"favorite trees\\"}
-        items={bio.favorite - trees ?? []}
+        items={bio?.[\\"favorite-trees\\"] ?? []}
         hasError={errors?.[\\"bio.favorite-trees\\"]?.hasError}
         setFieldValue={setCurrentBioFavoritetreesValue}
-        inputFieldRef={bio.favorite - treesRef}
+        inputFieldRef={bioFavoritetreesRef}
         defaultFieldValue={undefined}
       >
         <TextField

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -17,6 +17,8 @@ import { FieldConfigMetadata } from '@aws-amplify/codegen-ui/lib/types';
 import { isValidVariableName } from '@aws-amplify/codegen-ui';
 import { factory, JsxChild, JsxTagNamePropertyAccess, NodeFlags, SyntaxKind } from 'typescript';
 import {
+  buildAccessChain,
+  getArrayChildRefName,
   getCurrentValueIdentifier,
   getCurrentValueName,
   getDefaultValueExpression,
@@ -1074,10 +1076,10 @@ export const renderArrayFieldComponent = (
           factory.createIdentifier('items'),
           factory.createJsxExpression(
             undefined,
-            // render `?? []` if nested.
+            // render `?? []` if nested && build access chain
             renderedFieldName.includes('.')
               ? factory.createBinaryExpression(
-                  factory.createIdentifier(renderedFieldName),
+                  buildAccessChain(renderedFieldName.split('.'), true),
                   factory.createToken(SyntaxKind.QuestionQuestionToken),
                   factory.createArrayLiteralExpression([], false),
                 )
@@ -1110,7 +1112,7 @@ export const renderArrayFieldComponent = (
         ),
         factory.createJsxAttribute(
           factory.createIdentifier('inputFieldRef'),
-          factory.createJsxExpression(undefined, factory.createIdentifier(`${renderedFieldName}Ref`)),
+          factory.createJsxExpression(undefined, factory.createIdentifier(getArrayChildRefName(renderedFieldName))),
         ),
         factory.createJsxAttribute(
           factory.createIdentifier('defaultFieldValue'),


### PR DESCRIPTION
*Description of changes:*
- fix variable name for `items` and `inputFieldRef` on `ArrayField` when the associated field is a nested array with a name that does not work as a js variable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
