### PR TITLE
fix: fix ArrayField label

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -864,7 +864,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -921,10 +920,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -1108,6 +1107,7 @@ export default function CustomDataForm(props) {
           errorMessage={errors.email?.errorMessage}
           hasError={errors.email?.hasError}
           ref={emailRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"email\\")}
         ></TextField>
       </ArrayField>
@@ -1151,6 +1151,7 @@ export default function CustomDataForm(props) {
           errorMessage={errors.phone?.errorMessage}
           hasError={errors.phone?.hasError}
           ref={phoneRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"phone\\")}
         ></TextField>
       </ArrayField>
@@ -1292,7 +1293,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -1349,10 +1349,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -1655,6 +1655,7 @@ export default function MyPostForm(props) {
           errorMessage={errors.Customtags?.errorMessage}
           hasError={errors.Customtags?.hasError}
           ref={CustomtagsRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"Customtags\\")}
         ></TextField>
       </ArrayField>
@@ -1863,7 +1864,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -1920,10 +1920,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -2227,6 +2227,7 @@ export default function NestedJson(props) {
           errorMessage={errors[\\"bio.favorite-trees\\"]?.errorMessage}
           hasError={errors[\\"bio.favorite-trees\\"]?.hasError}
           ref={bioFavoritetreesRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"bio.favorite-trees\\")}
         ></TextField>
       </ArrayField>
@@ -2272,6 +2273,7 @@ export default function NestedJson(props) {
           errorMessage={errors.Nicknames1?.errorMessage}
           hasError={errors.Nicknames1?.hasError}
           ref={Nicknames1Ref}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"Nicknames1\\")}
         ></TextField>
       </ArrayField>
@@ -2317,6 +2319,7 @@ export default function NestedJson(props) {
           errorMessage={errors[\\"nick-names2\\"]?.errorMessage}
           hasError={errors[\\"nick-names2\\"]?.hasError}
           ref={nickNamesRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"nick-names2\\")}
         ></TextField>
       </ArrayField>
@@ -2494,7 +2497,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -2551,10 +2553,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -2777,6 +2779,7 @@ export default function NestedJson(props) {
           errorMessage={errors.lastName?.errorMessage}
           hasError={errors.lastName?.hasError}
           ref={lastName1Ref}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"lastName\\")}
         ></TextField>
       </ArrayField>
@@ -3510,7 +3513,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -3567,10 +3569,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -3829,6 +3831,7 @@ export default function MyMemberForm(props) {
           errorMessage={errors.Team?.errorMessage}
           hasError={errors.Team?.hasError}
           ref={TeamRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"Team\\")}
         ></Autocomplete>
       </ArrayField>
@@ -3946,7 +3949,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -4003,10 +4005,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -4272,6 +4274,7 @@ export default function BookCreateForm(props) {
           errorMessage={errors.primaryAuthor?.errorMessage}
           hasError={errors.primaryAuthor?.hasError}
           ref={primaryAuthorRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"primaryAuthor\\")}
         ></Autocomplete>
       </ArrayField>
@@ -4389,7 +4392,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -4446,10 +4448,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -4692,6 +4694,7 @@ export default function TagCreateForm(props) {
           errorMessage={errors.Posts?.errorMessage}
           hasError={errors.Posts?.hasError}
           ref={PostsRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"Posts\\")}
         ></Autocomplete>
       </ArrayField>
@@ -4837,7 +4840,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -4894,10 +4896,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -5184,6 +5186,7 @@ export default function BookCreateForm(props) {
           errorMessage={errors.primaryAuthor?.errorMessage}
           hasError={errors.primaryAuthor?.hasError}
           ref={primaryAuthorRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"primaryAuthor\\")}
         ></Autocomplete>
       </ArrayField>
@@ -5241,6 +5244,7 @@ export default function BookCreateForm(props) {
           errorMessage={errors.primaryTitle?.errorMessage}
           hasError={errors.primaryTitle?.hasError}
           ref={primaryTitleRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"primaryTitle\\")}
         ></Autocomplete>
       </ArrayField>
@@ -5797,7 +5801,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -5854,10 +5857,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -6168,6 +6171,7 @@ export default function MyFlexUpdateForm(props) {
           errorMessage={errors.Customtags?.errorMessage}
           hasError={errors.Customtags?.hasError}
           ref={CustomtagsRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"Customtags\\")}
         ></TextField>
       </ArrayField>
@@ -6212,6 +6216,7 @@ export default function MyFlexUpdateForm(props) {
           errorMessage={errors.tags?.errorMessage}
           hasError={errors.tags?.hasError}
           ref={tagsRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"tags\\")}
         ></TextField>
       </ArrayField>
@@ -6365,7 +6370,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -6422,10 +6426,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -6762,6 +6766,7 @@ export default function BlogCreateForm(props) {
           errorMessage={errors.editedAt?.errorMessage}
           hasError={errors.editedAt?.hasError}
           ref={editedAtRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"editedAt\\")}
         ></TextField>
       </ArrayField>
@@ -6907,7 +6912,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -6964,10 +6968,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -7406,6 +7410,7 @@ export default function InputGalleryCreateForm(props) {
           errorMessage={errors.arrayTypeField?.errorMessage}
           hasError={errors.arrayTypeField?.hasError}
           ref={arrayTypeFieldRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"arrayTypeField\\")}
         ></TextField>
       </ArrayField>
@@ -7456,6 +7461,7 @@ export default function InputGalleryCreateForm(props) {
           errorMessage={errors.jsonArray?.errorMessage}
           hasError={errors.jsonArray?.hasError}
           ref={jsonArrayRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"jsonArray\\")}
         ></TextAreaField>
       </ArrayField>
@@ -7770,7 +7776,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -7827,10 +7832,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -8316,6 +8321,7 @@ export default function InputGalleryUpdateForm(props) {
           errorMessage={errors.arrayTypeField?.errorMessage}
           hasError={errors.arrayTypeField?.hasError}
           ref={arrayTypeFieldRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"arrayTypeField\\")}
         ></TextField>
       </ArrayField>
@@ -8366,6 +8372,7 @@ export default function InputGalleryUpdateForm(props) {
           errorMessage={errors.jsonArray?.errorMessage}
           hasError={errors.jsonArray?.hasError}
           ref={jsonArrayRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"jsonArray\\")}
         ></TextAreaField>
       </ArrayField>
@@ -8683,7 +8690,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -8740,10 +8746,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -9039,6 +9045,7 @@ export default function MyFlexCreateForm(props) {
           errorMessage={errors.Customtags?.errorMessage}
           hasError={errors.Customtags?.hasError}
           ref={CustomtagsRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"Customtags\\")}
         ></TextField>
       </ArrayField>
@@ -9083,6 +9090,7 @@ export default function MyFlexCreateForm(props) {
           errorMessage={errors.tags?.errorMessage}
           hasError={errors.tags?.hasError}
           ref={tagsRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"tags\\")}
         ></TextField>
       </ArrayField>
@@ -9640,7 +9648,6 @@ function ArrayField({
   };
   const arraySection = (
     <React.Fragment>
-      <Text>{label}</Text>
       {!!items?.length && (
         <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
           {items.map((value, index) => {
@@ -9697,10 +9704,10 @@ function ArrayField({
   }
   return (
     <React.Fragment>
+      <Text>{label}</Text>
       {isEditing && children}
       {!isEditing ? (
         <>
-          <Text>{label}</Text>
           <Button
             onClick={() => {
               setIsEditing(true);
@@ -9959,6 +9966,7 @@ export default function MyMemberForm(props) {
           errorMessage={errors.Team?.errorMessage}
           hasError={errors.Team?.hasError}
           ref={TeamRef}
+          labelHidden={true}
           {...getOverrideProps(overrides, \\"Team\\")}
         ></Autocomplete>
       </ArrayField>

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
@@ -119,6 +119,14 @@ export const addFormAttributes = (component: StudioComponent | StudioComponentCh
           factory.createJsxExpression(undefined, factory.createIdentifier(getArrayChildRefName(renderedVariableName))),
         ),
       );
+
+      // labelHidden={true}. Label rendered on ArrayField instead
+      attributes.push(
+        factory.createJsxAttribute(
+          factory.createIdentifier('labelHidden'),
+          factory.createJsxExpression(undefined, factory.createTrue()),
+        ),
+      );
     }
   }
   if (componentName === 'ClearButton' || componentName === 'ResetButton') {

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -379,15 +379,6 @@ export const generateArrayFieldComponent = () => {
                 factory.createJsxAttributes([]),
               ),
               [
-                factory.createJsxElement(
-                  factory.createJsxOpeningElement(
-                    factory.createIdentifier('Text'),
-                    undefined,
-                    factory.createJsxAttributes([]),
-                  ),
-                  [factory.createJsxExpression(undefined, factory.createIdentifier('label'))],
-                  factory.createJsxClosingElement(factory.createIdentifier('Text')),
-                ),
                 factory.createJsxExpression(
                   undefined,
                   factory.createBinaryExpression(
@@ -814,6 +805,15 @@ export const generateArrayFieldComponent = () => {
             factory.createJsxAttributes([]),
           ),
           [
+            factory.createJsxElement(
+              factory.createJsxOpeningElement(
+                factory.createIdentifier('Text'),
+                undefined,
+                factory.createJsxAttributes([]),
+              ),
+              [factory.createJsxExpression(undefined, factory.createIdentifier('label'))],
+              factory.createJsxClosingElement(factory.createIdentifier('Text')),
+            ),
             factory.createJsxExpression(
               undefined,
               factory.createBinaryExpression(
@@ -822,7 +822,6 @@ export const generateArrayFieldComponent = () => {
                 factory.createIdentifier('children'),
               ),
             ),
-            // here?
             factory.createJsxExpression(
               undefined,
               factory.createConditionalExpression(
@@ -832,16 +831,6 @@ export const generateArrayFieldComponent = () => {
                   factory.createJsxFragment(
                     factory.createJsxOpeningFragment(),
                     [
-                      factory.createJsxElement(
-                        factory.createJsxOpeningElement(
-                          factory.createIdentifier('Text'),
-                          undefined,
-                          factory.createJsxAttributes([]),
-                        ),
-                        [factory.createJsxExpression(undefined, factory.createIdentifier('label'))],
-                        factory.createJsxClosingElement(factory.createIdentifier('Text')),
-                      ),
-
                       factory.createJsxElement(
                         factory.createJsxOpeningElement(
                           factory.createIdentifier('Button'),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The label field for ArrayField was rendering in two places if the child field was anything other than `Autocomplete`. This fixes it so it's in one place only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
