### PR TITLE
Add support for update forms with belongsTo relationship

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3,8 +3,6 @@
 exports[`amplify form renderer tests datastore form tests custom form tests should render a custom backed form 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Flex,
@@ -15,6 +13,8 @@ import {
   StepperField,
   TextField,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 export default function CustomDataForm(props) {
   const { onSubmit, onCancel, onValidate, onChange, overrides, ...rest } =
     props;
@@ -343,8 +343,8 @@ export default function CustomDataForm(props) {
 
 exports[`amplify form renderer tests datastore form tests custom form tests should render a custom backed form 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, RadioGroupFieldProps, SelectFieldProps, StepperFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -391,8 +391,6 @@ export default function CustomDataForm(props: CustomDataFormProps): React.ReactE
 exports[`amplify form renderer tests datastore form tests custom form tests should render a custom backed form 3`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Flex,
@@ -404,6 +402,8 @@ import {
   TextAreaField,
   TextField,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 export default function CustomDataForm(props) {
   const {
     initialData,
@@ -757,8 +757,8 @@ export default function CustomDataForm(props) {
 
 exports[`amplify form renderer tests datastore form tests custom form tests should render a custom backed form 4`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, RadioGroupFieldProps, SelectFieldProps, StepperFieldProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -806,8 +806,6 @@ export default function CustomDataForm(props: CustomDataFormProps): React.ReactE
 exports[`amplify form renderer tests datastore form tests custom form tests should render a custom backed form with an array field 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -820,6 +818,8 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 function ArrayField({
   items = [],
   onChange,
@@ -1191,8 +1191,8 @@ export default function CustomDataForm(props) {
 
 exports[`amplify form renderer tests datastore form tests custom form tests should render a custom backed form with an array field 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -1230,9 +1230,6 @@ export default function CustomDataForm(props: CustomDataFormProps): React.ReactE
 exports[`amplify form renderer tests datastore form tests custom form tests should render a datastore backed form with a custom array field 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Post } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -1246,6 +1243,9 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -1749,8 +1749,8 @@ export default function MyPostForm(props) {
 
 exports[`amplify form renderer tests datastore form tests custom form tests should render a datastore backed form with a custom array field 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -1801,8 +1801,6 @@ export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
 exports[`amplify form renderer tests datastore form tests custom form tests should render nested json fields 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -1816,6 +1814,8 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 function ArrayField({
   items = [],
   onChange,
@@ -2373,8 +2373,8 @@ export default function NestedJson(props) {
 
 exports[`amplify form renderer tests datastore form tests custom form tests should render nested json fields 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, HeadingProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -2431,8 +2431,6 @@ export default function NestedJson(props: NestedJsonProps): React.ReactElement;
 exports[`amplify form renderer tests datastore form tests custom form tests should render nested json fields 3`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -2447,6 +2445,8 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 function ArrayField({
   items = [],
   onChange,
@@ -2866,8 +2866,8 @@ export default function NestedJson(props) {
 
 exports[`amplify form renderer tests datastore form tests custom form tests should render nested json fields 4`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, HeadingProps, SelectFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -2916,8 +2916,6 @@ export default function NestedJson(props: NestedJsonProps): React.ReactElement;
 exports[`amplify form renderer tests datastore form tests custom form tests should render sectional elements 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Divider,
@@ -2927,6 +2925,8 @@ import {
   Text,
   TextField,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 export default function CustomWithSectionalElements(props) {
   const { onSubmit, onCancel, onValidate, onChange, overrides, ...rest } =
     props;
@@ -3063,8 +3063,8 @@ export default function CustomWithSectionalElements(props) {
 
 exports[`amplify form renderer tests datastore form tests custom form tests should render sectional elements 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { DividerProps, GridProps, HeadingProps, TextFieldProps, TextProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -3099,9 +3099,6 @@ export default function CustomWithSectionalElements(props: CustomWithSectionalEl
 exports[`amplify form renderer tests datastore form tests should generate a create form 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Post } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Flex,
@@ -3109,6 +3106,9 @@ import {
   TextAreaField,
   TextField,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function MyPostForm(props) {
   const {
@@ -3395,8 +3395,8 @@ export default function MyPostForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate a create form 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -3443,12 +3443,6 @@ export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
 exports[`amplify form renderer tests datastore form tests should generate a create form with belongsTo relationship 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Member, Team as Team0 } from \\"../models\\";
-import {
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 import {
   Autocomplete,
   Badge,
@@ -3462,6 +3456,12 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Member, Team as Team0 } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -3839,9 +3839,9 @@ export default function MyMemberForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate a create form with belongsTo relationship 2`] = `
 "import * as React from \\"react\\";
-import { Team as Team0 } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Team as Team0 } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -3879,12 +3879,6 @@ export default function MyMemberForm(props: MyMemberFormProps): React.ReactEleme
 exports[`amplify form renderer tests datastore form tests should generate a create form with hasOne relationship 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Book, Author } from \\"../models\\";
-import {
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 import {
   Autocomplete,
   Badge,
@@ -3898,6 +3892,12 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Book, Author } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -4284,9 +4284,9 @@ export default function BookCreateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate a create form with hasOne relationship 2`] = `
 "import * as React from \\"react\\";
-import { Author } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Author } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -4324,12 +4324,6 @@ export default function BookCreateForm(props: BookCreateFormProps): React.ReactE
 exports[`amplify form renderer tests datastore form tests should generate a create form with manyToMany relationship 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Tag, Post, TagPost } from \\"../models\\";
-import {
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 import {
   Autocomplete,
   Badge,
@@ -4343,6 +4337,12 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Tag, Post, TagPost } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -4732,9 +4732,9 @@ export default function TagCreateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate a create form with manyToMany relationship 2`] = `
 "import * as React from \\"react\\";
-import { Post } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -4772,12 +4772,6 @@ export default function TagCreateForm(props: TagCreateFormProps): React.ReactEle
 exports[`amplify form renderer tests datastore form tests should generate a create form with multiple hasOne relationships 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Book, Author, Title } from \\"../models\\";
-import {
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 import {
   Autocomplete,
   Badge,
@@ -4791,6 +4785,12 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Book, Author, Title } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -5260,9 +5260,9 @@ export default function BookCreateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate a create form with multiple hasOne relationships 2`] = `
 "import * as React from \\"react\\";
-import { Author, Title } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Author, Title } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -5303,9 +5303,6 @@ export default function BookCreateForm(props: BookCreateFormProps): React.ReactE
 exports[`amplify form renderer tests datastore form tests should generate a update form 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Post } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Flex,
@@ -5313,6 +5310,9 @@ import {
   TextAreaField,
   TextField,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function MyPostForm(props) {
   const {
@@ -5692,9 +5692,9 @@ export default function MyPostForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate a update form 2`] = `
 "import * as React from \\"react\\";
-import { Post } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -5742,15 +5742,9 @@ export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
 "
 `;
 
-exports[`amplify form renderer tests datastore form tests should generate an update form with manyToMany relationship 1`] = `
+exports[`amplify form renderer tests datastore form tests should generate an update form with belongsTo relationship 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Tag, Post, TagPost } from \\"../models\\";
-import {
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 import {
   Autocomplete,
   Badge,
@@ -5764,6 +5758,474 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Member, Team as Team0 } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { DataStore } from \\"aws-amplify\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+}) {
+  const { tokens } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    if (
+      (currentFieldValue !== undefined ||
+        currentFieldValue !== null ||
+        currentFieldValue !== \\"\\") &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return arraySection;
+  }
+  return (
+    <React.Fragment>
+      <Text>{label}</Text>
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button
+            size=\\"small\\"
+            variation=\\"link\\"
+            color={tokens.colors.brand.primary[80]}
+            isDisabled={hasError}
+            onClick={addItem}
+          >
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function MyMemberForm(props) {
+  const {
+    id,
+    member,
+    onSuccess,
+    onError,
+    onSubmit,
+    onCancel,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    name: undefined,
+    Team: undefined,
+  };
+  const [name, setName] = React.useState(initialValues.name);
+  const [Team, setTeam] = React.useState(initialValues.Team);
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    const cleanValues = memberRecord
+      ? { ...initialValues, ...memberRecord }
+      : initialValues;
+    setName(cleanValues.name);
+    setTeam(cleanValues.Team);
+    setCurrentTeamValue(undefined);
+    setCurrentTeamDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [memberRecord, setMemberRecord] = React.useState(member);
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = id ? await DataStore.query(Member, id) : member;
+      setMemberRecord(record);
+    };
+    queryData();
+  }, [id, member]);
+  React.useEffect(() => {
+    const getRelationshipModel = async () => {
+      if (memberRecord) {
+        setTeam(await memberRecord.Team);
+      }
+    };
+    getRelationshipModel();
+  }, [memberRecord]);
+  React.useEffect(resetStateValues, [memberRecord]);
+  const [currentTeamDisplayValue, setCurrentTeamDisplayValue] =
+    React.useState(\\"\\");
+  const [currentTeamValue, setCurrentTeamValue] = React.useState(undefined);
+  const TeamRef = React.createRef();
+  const teamRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: Team0,
+  }).items;
+  const getDisplayValue = {
+    Team: (record) => record?.name,
+  };
+  const validations = {
+    name: [],
+    Team: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          name,
+          Team,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          const original = await DataStore.query(Member, id);
+          await DataStore.save(
+            Member.copyOf(original, (updated) => {
+              Object.assign(updated, modelFields);
+            })
+          );
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+        } catch (err) {
+          if (onError) {
+            onError(modelFields, err.message);
+          }
+        }
+      }}
+      {...rest}
+      {...getOverrideProps(overrides, \\"MyMemberForm\\")}
+    >
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={resetStateValues}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}>
+          <Button
+            children=\\"Cancel\\"
+            type=\\"button\\"
+            onClick={() => {
+              onCancel && onCancel();
+            }}
+            {...getOverrideProps(overrides, \\"CancelButton\\")}
+          ></Button>
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e?.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+      <TextField
+        label=\\"Name\\"
+        isRequired={false}
+        isReadOnly={false}
+        defaultValue={name}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              name: value,
+              Team,
+            };
+            const result = onChange(modelFields);
+            value = result?.name ?? value;
+          }
+          if (errors.name?.hasError) {
+            runValidationTasks(\\"name\\", value);
+          }
+          setName(value);
+        }}
+        onBlur={() => runValidationTasks(\\"name\\", name)}
+        errorMessage={errors.name?.errorMessage}
+        hasError={errors.name?.hasError}
+        {...getOverrideProps(overrides, \\"name\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              Team: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.Team ?? value;
+          }
+          setTeam(value);
+          setCurrentTeamValue(undefined);
+          setCurrentTeamDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentTeamValue}
+        label={\\"Team Label\\"}
+        items={Team ? [Team] : []}
+        hasError={errors.Team?.hasError}
+        getBadgeText={getDisplayValue.Team}
+        setFieldValue={(model) =>
+          setCurrentTeamDisplayValue(getDisplayValue.Team(model))
+        }
+        inputFieldRef={TeamRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Team Label\\"
+          isRequired={false}
+          isReadOnly={false}
+          value={currentTeamDisplayValue}
+          options={teamRecords.map((r) => ({
+            id: r.id,
+            label: getDisplayValue.Team?.(r) ?? r.id,
+          }))}
+          onSelect={({ id, label }) => {
+            setCurrentTeamValue(teamRecords.find((r) => r.id === id));
+            setCurrentTeamDisplayValue(label);
+          }}
+          onClear={() => {
+            setCurrentTeamDisplayValue(\\"\\");
+          }}
+          defaultValue={Team}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.Team?.hasError) {
+              runValidationTasks(\\"Team\\", value);
+            }
+            setCurrentTeamDisplayValue(value);
+            setCurrentTeamValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"Team\\", Team)}
+          errorMessage={errors.Team?.errorMessage}
+          hasError={errors.Team?.hasError}
+          ref={TeamRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"Team\\")}
+        ></Autocomplete>
+      </ArrayField>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests datastore form tests should generate an update form with belongsTo relationship 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Member, Team as Team0 } from \\"../models\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type MyMemberFormInputValues = {
+    name?: string;
+    Team?: Team0;
+};
+export declare type MyMemberFormValidationValues = {
+    name?: ValidationFunction<string>;
+    Team?: ValidationFunction<Team0>;
+};
+export declare type FormProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type MyMemberFormOverridesProps = {
+    MyMemberFormGrid?: FormProps<GridProps>;
+    name?: FormProps<TextFieldProps>;
+    Team?: FormProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type MyMemberFormProps = React.PropsWithChildren<{
+    overrides?: MyMemberFormOverridesProps | undefined | null;
+} & {
+    id?: string;
+    member?: Member;
+    onSubmit?: (fields: MyMemberFormInputValues) => MyMemberFormInputValues;
+    onSuccess?: (fields: MyMemberFormInputValues) => void;
+    onError?: (fields: MyMemberFormInputValues, errorMessage: string) => void;
+    onCancel?: () => void;
+    onChange?: (fields: MyMemberFormInputValues) => MyMemberFormInputValues;
+    onValidate?: MyMemberFormValidationValues;
+} & React.CSSProperties>;
+export default function MyMemberForm(props: MyMemberFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests datastore form tests should generate an update form with manyToMany relationship 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Tag, Post, TagPost } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -6226,9 +6688,9 @@ export default function TagUpdateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should generate an update form with manyToMany relationship 2`] = `
 "import * as React from \\"react\\";
-import { Tag, Post } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Tag, Post } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -6267,9 +6729,6 @@ export default function TagUpdateForm(props: TagUpdateFormProps): React.ReactEle
 exports[`amplify form renderer tests datastore form tests should render a create form with colliding model name 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Flex as Flex0 } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -6282,6 +6741,9 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Flex as Flex0 } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -6784,9 +7246,9 @@ export default function MyFlexUpdateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should render a create form with colliding model name 2`] = `
 "import * as React from \\"react\\";
-import { Flex as Flex0 } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Flex as Flex0 } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -6835,9 +7297,6 @@ export default function MyFlexUpdateForm(props: MyFlexUpdateFormProps): React.Re
 exports[`amplify form renderer tests datastore form tests should render a form with a javascript reserved word as the field name 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Blog } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -6851,6 +7310,9 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Blog } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -7324,8 +7786,8 @@ export default function BlogCreateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should render a form with a javascript reserved word as the field name 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, SwitchFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -7371,9 +7833,6 @@ export default function BlogCreateForm(props: BlogCreateFormProps): React.ReactE
 exports[`amplify form renderer tests datastore form tests should render a form with multiple date types 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { InputGallery } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -7391,6 +7850,9 @@ import {
   ToggleButton,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { InputGallery } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -8167,8 +8629,8 @@ export default function InputGalleryCreateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should render a form with multiple date types 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { CheckboxFieldProps, GridProps, RadioGroupFieldProps, TextAreaFieldProps, TextFieldProps, ToggleButtonProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -8233,9 +8695,6 @@ export default function InputGalleryCreateForm(props: InputGalleryCreateFormProp
 exports[`amplify form renderer tests datastore form tests should render a form with multiple date types 3`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { InputGallery } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -8253,6 +8712,9 @@ import {
   ToggleButton,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { InputGallery } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -9084,9 +9546,9 @@ export default function InputGalleryUpdateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should render a form with multiple date types 4`] = `
 "import * as React from \\"react\\";
-import { InputGallery } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { CheckboxFieldProps, GridProps, RadioGroupFieldProps, TextAreaFieldProps, TextFieldProps, ToggleButtonProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { InputGallery } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -9152,9 +9614,6 @@ export default function InputGalleryUpdateForm(props: InputGalleryUpdateFormProp
 exports[`amplify form renderer tests datastore form tests should render a update form with colliding model name 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Flex as Flex0 } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Badge,
   Button,
@@ -9167,6 +9626,9 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Flex as Flex0 } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -9651,8 +10113,8 @@ export default function MyFlexCreateForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should render a update form with colliding model name 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -9700,9 +10162,6 @@ export default function MyFlexCreateForm(props: MyFlexCreateFormProps): React.Re
 exports[`amplify form renderer tests datastore form tests should render form with a two inputs in row 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Post } from \\"../models\\";
-import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import {
   Button,
   Flex,
@@ -9711,6 +10170,9 @@ import {
   TextAreaField,
   TextField,
 } from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 export default function PostCreateFormRow(props) {
   const {
@@ -10052,8 +10514,8 @@ export default function PostCreateFormRow(props) {
 
 exports[`amplify form renderer tests datastore form tests should render form with a two inputs in row 2`] = `
 "import * as React from \\"react\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { GridProps, SelectFieldProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -10104,12 +10566,6 @@ export default function PostCreateFormRow(props: PostCreateFormRowProps): React.
 exports[`amplify form renderer tests datastore form tests should use proper field overrides for belongsTo relationship 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
-import { fetchByPath, validateField } from \\"./utils\\";
-import { Member, Team as Team0 } from \\"../models\\";
-import {
-  getOverrideProps,
-  useDataStoreBinding,
-} from \\"@aws-amplify/ui-react/internal\\";
 import {
   Autocomplete,
   Badge,
@@ -10123,6 +10579,12 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Member, Team as Team0 } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
   items = [],
@@ -10500,9 +10962,9 @@ export default function MyMemberForm(props) {
 
 exports[`amplify form renderer tests datastore form tests should use proper field overrides for belongsTo relationship 2`] = `
 "import * as React from \\"react\\";
-import { Team as Team0 } from \\"../models\\";
-import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Team as Team0 } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -5928,7 +5928,7 @@ export default function MyMemberForm(props) {
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     const cleanValues = memberRecord
-      ? { ...initialValues, ...memberRecord }
+      ? { ...initialValues, ...memberRecord, Team }
       : initialValues;
     setName(cleanValues.name);
     setTeam(cleanValues.Team);
@@ -5946,7 +5946,7 @@ export default function MyMemberForm(props) {
     };
     queryData();
   }, [id, member]);
-  React.useEffect(resetStateValues, [memberRecord]);
+  React.useEffect(resetStateValues, [memberRecord, Team]);
   const [currentTeamDisplayValue, setCurrentTeamDisplayValue] =
     React.useState(\\"\\");
   const [currentTeamValue, setCurrentTeamValue] = React.useState(undefined);

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -5941,17 +5941,11 @@ export default function MyMemberForm(props) {
     const queryData = async () => {
       const record = id ? await DataStore.query(Member, id) : member;
       setMemberRecord(record);
+      const TeamRecord = record ? await record.Team : undefined;
+      setTeam(TeamRecord);
     };
     queryData();
   }, [id, member]);
-  React.useEffect(() => {
-    const getRelationshipModel = async () => {
-      if (memberRecord) {
-        setTeam(await memberRecord.Team);
-      }
-    };
-    getRelationshipModel();
-  }, [memberRecord]);
   React.useEffect(resetStateValues, [memberRecord]);
   const [currentTeamDisplayValue, setCurrentTeamDisplayValue] =
     React.useState(\\"\\");

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -73,6 +73,21 @@ describe('amplify form renderer tests', () => {
       expect(declaration).toMatchSnapshot();
     });
 
+    it('should generate an update form with belongsTo relationship', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/member-datastore-update-belongs-to',
+        'datastore/project-team-model',
+      );
+      // check nested model is imported
+      expect(componentText).toContain('import { Member, Team as Team0 } from "../models";');
+
+      // check binding call is generated
+      expect(componentText).toContain('const teamRecords = useDataStoreBinding({');
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
+
     it('should use proper field overrides for belongsTo relationship', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/member-datastore-create',

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
@@ -14,7 +14,15 @@
   limitations under the License.
  */
 import { FieldConfigMetadata, HasManyRelationshipType } from '@aws-amplify/codegen-ui/lib/types';
-import { factory, NodeFlags, SyntaxKind, Expression, VariableStatement, ExpressionStatement } from 'typescript';
+import {
+  factory,
+  NodeFlags,
+  SyntaxKind,
+  Expression,
+  VariableStatement,
+  ExpressionStatement,
+  Statement,
+} from 'typescript';
 import { lowerCaseFirst } from '../../helpers';
 import { getDisplayValueObjectName } from './display-value';
 import { getSetNameIdentifier, getLinkedDataName } from './form-state';
@@ -384,7 +392,11 @@ export const onSubmitValidationRun = (shouldUseGetDisplayValue?: boolean) => {
   ];
 };
 
-export const buildUpdateDatastoreQuery = (dataTypeName: string, recordName: string) => {
+export const buildUpdateDatastoreQuery = (
+  dataTypeName: string,
+  recordName: string,
+  relatedModelStatements: Statement[],
+) => {
   // TODO: update this once cpk is supported in datastore
   const pkQueryIdentifier = factory.createIdentifier('id');
   return [
@@ -438,6 +450,8 @@ export const buildUpdateDatastoreQuery = (dataTypeName: string, recordName: stri
                       factory.createIdentifier('record'),
                     ]),
                   ),
+                  // Add logic to pull related relationship models off record
+                  ...relatedModelStatements,
                 ],
                 true,
               ),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
@@ -261,11 +261,7 @@ export const getUseStateHooks = (fieldConfigs: Record<string, FieldConfigMetadat
  *   ....
  * };
  */
-export const resetStateFunction = (
-  fieldConfigs: Record<string, FieldConfigMetadata>,
-  recordName?: string,
-  hasManyFieldConfigs?: [string, FieldConfigMetadata][],
-) => {
+export const resetStateFunction = (fieldConfigs: Record<string, FieldConfigMetadata>, recordName?: string) => {
   const recordOrInitialValues = recordName ? 'cleanValues' : 'initialValues';
 
   const stateNames = new Set<string>();
@@ -318,15 +314,19 @@ export const resetStateFunction = (
     return acc;
   }, []);
 
-  const linkedDataPropertyAssignments: PropertyAssignment[] = [];
-  if (hasManyFieldConfigs && hasManyFieldConfigs.length > 0) {
-    hasManyFieldConfigs.forEach(([fieldName]) => {
-      linkedDataPropertyAssignments.push(
-        factory.createPropertyAssignment(
-          factory.createIdentifier(fieldName),
-          factory.createIdentifier(getLinkedDataName(fieldName)),
-        ),
-      );
+  const linkedDataPropertyAssignments: any[] = [];
+  if (fieldConfigs) {
+    Object.entries(fieldConfigs).forEach(([fieldName, fieldConfig]) => {
+      if (fieldConfig.relationship?.type === 'HAS_MANY') {
+        linkedDataPropertyAssignments.push(
+          factory.createPropertyAssignment(
+            factory.createIdentifier(fieldConfig.sanitizedFieldName || fieldName),
+            factory.createIdentifier(getLinkedDataName(fieldName)),
+          ),
+        );
+      } else if (fieldConfig.relationship?.type === 'BELONGS_TO' || fieldConfig.relationship?.type === 'HAS_ONE') {
+        linkedDataPropertyAssignments.push(factory.createIdentifier(fieldConfig.sanitizedFieldName || fieldName));
+      }
     });
   }
 

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/index.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/index.ts
@@ -34,7 +34,7 @@ export { addFormAttributes } from './all-props';
 
 export { mapFromFieldConfigs, getHasManyFieldConfigs, isManyToManyRelationship } from './map-from-fieldConfigs';
 
-export { buildRelationshipQuery } from './relationship';
+export { buildRelationshipQuery, buildGetRelationshipModels } from './relationship';
 
 export { shouldWrapInArrayField } from './render-checkers';
 

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -1082,46 +1082,27 @@ export const buildManyToManyRelationshipCreateStatements = (
   ];
 };
 
-export const buildGetRelationshipModels = (fieldName: string, recordName: string) => {
+export const buildGetRelationshipModels = (fieldName: string) => {
   return [
     factory.createVariableStatement(
       undefined,
       factory.createVariableDeclarationList(
         [
           factory.createVariableDeclaration(
-            factory.createIdentifier('getRelationshipModel'),
+            factory.createIdentifier(`${fieldName}Record`),
             undefined,
             undefined,
-            factory.createArrowFunction(
-              [factory.createModifier(SyntaxKind.AsyncKeyword)],
-              undefined,
-              [],
-              undefined,
-              factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-              factory.createBlock(
-                [
-                  factory.createIfStatement(
-                    factory.createIdentifier(recordName),
-                    factory.createBlock(
-                      [
-                        factory.createExpressionStatement(
-                          factory.createCallExpression(factory.createIdentifier(`set${fieldName}`), undefined, [
-                            factory.createAwaitExpression(
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier(recordName),
-                                factory.createIdentifier(fieldName),
-                              ),
-                            ),
-                          ]),
-                        ),
-                      ],
-                      true,
-                    ),
-                    undefined,
-                  ),
-                ],
-                true,
+            factory.createConditionalExpression(
+              factory.createIdentifier('record'),
+              factory.createToken(SyntaxKind.QuestionToken),
+              factory.createAwaitExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('record'),
+                  factory.createIdentifier(fieldName),
+                ),
               ),
+              factory.createToken(SyntaxKind.ColonToken),
+              factory.createIdentifier('undefined'),
             ),
           ),
         ],
@@ -1129,7 +1110,9 @@ export const buildGetRelationshipModels = (fieldName: string, recordName: string
       ),
     ),
     factory.createExpressionStatement(
-      factory.createCallExpression(factory.createIdentifier('getRelationshipModel'), undefined, []),
+      factory.createCallExpression(factory.createIdentifier(`set${fieldName}`), undefined, [
+        factory.createIdentifier(`${fieldName}Record`),
+      ]),
     ),
   ];
 };

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -15,7 +15,7 @@
  */
 import { factory, NodeFlags, SyntaxKind } from 'typescript';
 import { FieldConfigMetadata, GenericDataRelationshipType, HasManyRelationshipType } from '@aws-amplify/codegen-ui';
-import { getRecordsName, getLinkedDataName } from './form-state';
+import { getRecordsName, getLinkedDataName, getSetNameIdentifier } from './form-state';
 import { buildBaseCollectionVariableStatement } from '../../react-studio-template-renderer-helper';
 import { ImportCollection, ImportSource } from '../../imports';
 import { lowerCaseFirst } from '../../helpers';
@@ -1110,7 +1110,7 @@ export const buildGetRelationshipModels = (fieldName: string) => {
       ),
     ),
     factory.createExpressionStatement(
-      factory.createCallExpression(factory.createIdentifier(`set${fieldName}`), undefined, [
+      factory.createCallExpression(getSetNameIdentifier(fieldName), undefined, [
         factory.createIdentifier(`${fieldName}Record`),
       ]),
     ),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -1081,3 +1081,55 @@ export const buildManyToManyRelationshipCreateStatements = (
     ),
   ];
 };
+
+export const buildGetRelationshipModels = (fieldName: string, recordName: string) => {
+  return [
+    factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('getRelationshipModel'),
+            undefined,
+            undefined,
+            factory.createArrowFunction(
+              [factory.createModifier(SyntaxKind.AsyncKeyword)],
+              undefined,
+              [],
+              undefined,
+              factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+              factory.createBlock(
+                [
+                  factory.createIfStatement(
+                    factory.createIdentifier(recordName),
+                    factory.createBlock(
+                      [
+                        factory.createExpressionStatement(
+                          factory.createCallExpression(factory.createIdentifier(`set${fieldName}`), undefined, [
+                            factory.createAwaitExpression(
+                              factory.createPropertyAccessExpression(
+                                factory.createIdentifier(recordName),
+                                factory.createIdentifier(fieldName),
+                              ),
+                            ),
+                          ]),
+                        ),
+                      ],
+                      true,
+                    ),
+                    undefined,
+                  ),
+                ],
+                true,
+              ),
+            ),
+          ),
+        ],
+        NodeFlags.Const,
+      ),
+    ),
+    factory.createExpressionStatement(
+      factory.createCallExpression(factory.createIdentifier('getRelationshipModel'), undefined, []),
+    ),
+  ];
+};

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -463,23 +463,21 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
           ),
         );
       } else {
+        const relatedModelStatements: Statement[] = [];
+        // Build effects to grab nested models off target record for relationships
+        Object.entries(formMetadata.fieldConfigs).forEach(([key, value]) => {
+          if (value.relationship?.type === 'BELONGS_TO' || value.relationship?.type === 'HAS_ONE') {
+            // Flatten statments into 1d array
+            relatedModelStatements.push(...buildGetRelationshipModels(key));
+          }
+        });
         statements.push(
           addUseEffectWrapper(
-            buildUpdateDatastoreQuery(modelName, lowerCaseDataTypeNameRecord),
+            buildUpdateDatastoreQuery(modelName, lowerCaseDataTypeNameRecord, relatedModelStatements),
             // TODO: change once cpk is supported in datastore
             ['id', lowerCaseDataTypeName],
           ),
         );
-        // Build effects to grab nested models off target record for relationships
-        Object.entries(formMetadata.fieldConfigs).forEach(([key, value]) => {
-          if (value.relationship) {
-            statements.push(
-              addUseEffectWrapper(buildGetRelationshipModels(key, lowerCaseDataTypeNameRecord), [
-                lowerCaseDataTypeNameRecord,
-              ]),
-            );
-          }
-        });
       }
     }
 

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -439,7 +439,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     }
 
     const hasManyFieldConfigs = getHasManyFieldConfigs(formMetadata.fieldConfigs);
-    statements.push(resetStateFunction(formMetadata.fieldConfigs, defaultValueVariableName, hasManyFieldConfigs));
+    statements.push(resetStateFunction(formMetadata.fieldConfigs, defaultValueVariableName));
 
     const linkedDataNames: string[] = [];
     if (isDataStoreUpdateForm) {
@@ -467,8 +467,10 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
         // Build effects to grab nested models off target record for relationships
         Object.entries(formMetadata.fieldConfigs).forEach(([key, value]) => {
           if (value.relationship?.type === 'BELONGS_TO' || value.relationship?.type === 'HAS_ONE') {
+            const fieldName = value.sanitizedFieldName || key;
+            linkedDataNames.push(fieldName);
             // Flatten statments into 1d array
-            relatedModelStatements.push(...buildGetRelationshipModels(key));
+            relatedModelStatements.push(...buildGetRelationshipModels(fieldName));
           }
         });
         statements.push(

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -76,6 +76,7 @@ import {
   getHasManyFieldConfigs,
   getLinkedDataName,
   buildRelationshipQuery,
+  buildGetRelationshipModels,
 } from './form-renderer-helper';
 import {
   buildUseStateExpression,
@@ -172,13 +173,13 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
   renderComponentInternal() {
     const { printer, file } = buildPrinter(this.fileName, this.renderConfig);
 
+    const propsDeclaration = this.renderBindingPropsType();
+
     // build form related variable statments
     const variableStatements = this.buildVariableStatements();
     const jsx = this.renderJsx(this.formComponent);
 
     const wrappedFunction = this.renderFunctionWrapper(this.component.name, variableStatements, jsx, true);
-    const propsDeclaration = this.renderBindingPropsType();
-
     const imports = this.importCollection.buildImportStatements();
 
     let componentText = `/* eslint-disable */${EOL}`;
@@ -469,6 +470,16 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
             ['id', lowerCaseDataTypeName],
           ),
         );
+        // Build effects to grab nested models off target record for relationships
+        Object.entries(formMetadata.fieldConfigs).forEach(([key, value]) => {
+          if (value.relationship) {
+            statements.push(
+              addUseEffectWrapper(buildGetRelationshipModels(key, lowerCaseDataTypeNameRecord), [
+                lowerCaseDataTypeNameRecord,
+              ]),
+            );
+          }
+        });
       }
     }
 

--- a/packages/codegen-ui/example-schemas/forms/member-datastore-update-belongs-to.json
+++ b/packages/codegen-ui/example-schemas/forms/member-datastore-update-belongs-to.json
@@ -1,0 +1,45 @@
+{
+  "name": "MyMemberForm",
+  "formActionType": "update",
+  "dataType": {
+    "dataSourceType": "DataStore",
+    "dataTypeName": "Member"
+  },
+  "fields": {
+    "Team": {
+      "inputType": {
+        "type": "Autocomplete",
+        "valueMappings": {
+          "values": [
+            {
+              "value": {
+                "bindingProperties": {
+                  "property": "Team",
+                  "field": "id"
+                }
+              },
+              "displayValue": {
+                "bindingProperties": {
+                  "property": "Team",
+                  "field": "name"
+                }
+              }
+            }
+          ],
+          "bindingProperties": {
+            "Team": { "type": "Data", "bindingProperties": { "model": "Team" } }
+          }
+        }
+      },
+      "label": "Team Label"
+    }
+  },
+  "sectionalElements": {},
+  "style": {},
+  "cta": {
+    "position": "top",
+    "clear": {},
+    "cancel": {},
+    "submit": {}
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds support for belongsTo relationships in update forms by grabbing the nested model from the target record to update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
