### PR TITLE
chore: break out form tests by create and update

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
@@ -13,9 +13,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-describe('Forms', () => {
+describe('CreateForms', () => {
   before(() => {
-    cy.visit('http://localhost:3000/form-tests');
+    cy.visit('http://localhost:3000/create-form-tests');
   });
 
   const getInputByLabel = (label) => {

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
@@ -31,6 +31,7 @@ const EXPECTED_SUCCESSFUL_CASES = new Set([
   'ListingExpanderWithComponentSlot',
   'CustomFormCreateDog',
   'DataStoreFormCreateAllSupportedFormFields',
+  'DataStoreFormUpdateAllSupportedFormFields',
   'CustomFormCreateNestedJson',
   'ComponentWithDataBindingWithPredicate',
   'ComponentWithDataBindingWithoutPredicate',

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -13,10 +13,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+describe('UpdateForms', () => {
+  before(() => {
+    cy.visit('http://localhost:3000/update-form-tests');
+  });
 
-/* eslint-disable max-len */
-export { default as CustomFormCreateDog } from './custom-form-create-dog.json';
-export { default as DataStoreFormCreateAllSupportedFormFields } from './datastore-form-create-all-supported-form-fields.json';
-export { default as DataStoreFormUpdateAllSupportedFormFields } from './datastore-form-update-all-supported-form-fields.json';
-
-export { default as CustomFormCreateNestedJson } from './custom-form-nested-json-create.json';
+  describe('DataStoreFormUpdateAllSupportedFormFields', () => {
+    it('should save to DataStore', () => {
+      cy.get('#dataStoreFormUpdateAllSupportedFormFields').within(() => {
+        // TODO
+      });
+    });
+  });
+});

--- a/packages/test-generator/integration-test-templates/src/App.tsx
+++ b/packages/test-generator/integration-test-templates/src/App.tsx
@@ -24,7 +24,8 @@ import SnippetTests from './SnippetTests'; // eslint-disable-line import/extensi
 import WorkflowTests from './WorkflowTests';
 import TwoWayBindingTests from './TwoWayBindingTests';
 import ActionBindingTests from './ActionBindingTests';
-import FormTests from './FormTests';
+import CreateFormTests from './CreateFormTests';
+import UpdateFormTests from './UpdateFormTests';
 import { DATA_STORE_MOCK_EXPORTS, AUTH_MOCK_EXPORTS } from './mock-utils';
 
 // use fake endpoint so useDataStoreBinding does not fail
@@ -66,7 +67,10 @@ const HomePage = () => {
           <a href="/action-binding-tests">Action Binding Test</a>
         </li>
         <li>
-          <a href="/form-tests">Form Tests</a>
+          <a href="/create-form-tests">Create Form Tests</a>
+        </li>
+        <li>
+          <a href="/update-form-tests">Update Form Tests</a>
         </li>
       </ul>
     </div>
@@ -86,7 +90,8 @@ export default function App() {
         <Route path="/view-tests" element={<ViewTests />} />
         <Route path="/two-way-binding-tests" element={<TwoWayBindingTests />} />
         <Route path="/action-binding-tests" element={<ActionBindingTests />} />
-        <Route path="/form-tests" element={<FormTests />} />
+        <Route path="/create-form-tests" element={<CreateFormTests />} />
+        <Route path="/update-form-tests" element={<UpdateFormTests />} />
         <Route path="*" element={<HomePage />} />
       </Routes>
     </Router>

--- a/packages/test-generator/integration-test-templates/src/CreateFormTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/CreateFormTests.tsx
@@ -31,7 +31,7 @@ const initializeUserTestData = async (): Promise<void> => {
   await DataStore.save(new User({ firstName: 'Ringo', lastName: 'Starr', age: 5 }));
 };
 
-export default function FormTests() {
+export default function CreateFormTests() {
   const [customFormCreateDogSubmitResults, setCustomFormCreateDogSubmitResults] = useState<any>({});
 
   const [isInitialized, setInitialized] = useState(false);

--- a/packages/test-generator/integration-test-templates/src/UpdateFormTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/UpdateFormTests.tsx
@@ -1,0 +1,62 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import '@aws-amplify/ui-react/styles.css';
+import { AmplifyProvider, View, Heading } from '@aws-amplify/ui-react';
+import { useState, useEffect, useRef } from 'react';
+import { DataStore } from '@aws-amplify/datastore';
+import { DataStoreFormUpdateAllSupportedFormFields } from './ui-components'; // eslint-disable-line import/extensions, max-len
+import { User } from './models';
+
+const initializeUserTestData = async (): Promise<void> => {
+  await DataStore.save(new User({ firstName: 'John', lastName: 'Lennon', age: 29 }));
+  await DataStore.save(new User({ firstName: 'Paul', lastName: 'McCartney', age: 72 }));
+  await DataStore.save(new User({ firstName: 'George', lastName: 'Harrison', age: 50 }));
+  await DataStore.save(new User({ firstName: 'Ringo', lastName: 'Starr', age: 5 }));
+};
+
+export default function UpdateFormTests() {
+  const [isInitialized, setInitialized] = useState(false);
+
+  const initializeStarted = useRef(false);
+
+  useEffect(() => {
+    const initializeTestState = async () => {
+      if (initializeStarted.current) {
+        return;
+      }
+      // DataStore.clear() doesn't appear to reliably work in this scenario.
+      indexedDB.deleteDatabase('amplify-datastore');
+      await initializeUserTestData();
+      setInitialized(true);
+    };
+
+    initializeTestState();
+    initializeStarted.current = true;
+  }, []);
+
+  if (!isInitialized) {
+    return null;
+  }
+
+  return (
+    <AmplifyProvider>
+      <Heading>DataStore Form - UpdateAllSupportedFormFields</Heading>
+      <View id="dataStoreFormUpdateAllSupportedFormFields">
+        <DataStoreFormUpdateAllSupportedFormFields />
+      </View>
+    </AmplifyProvider>
+  );
+}

--- a/packages/test-generator/lib/forms/datastore-form-update-all-supported-form-fields.json
+++ b/packages/test-generator/lib/forms/datastore-form-update-all-supported-form-fields.json
@@ -1,0 +1,18 @@
+{
+    "id": "123-ds-update-allsupprted",
+    "name": "DataStoreFormUpdateAllSupportedFormFields",
+    "formActionType": "update",
+    "dataType": {
+      "dataSourceType": "DataStore",
+      "dataTypeName": "AllSupportedFormFields"
+    },
+    "fields": {
+      "HasOneUser": {
+        "excluded": true
+      }
+    },
+    "sectionalElements": {},
+    "style": {},
+    "cta": {},
+    "schemaVersion": "1.0"
+  }


### PR DESCRIPTION
*Description of changes:*
Things will get messy with DataStore records, etc. if we keep create and update forms in the same page. This breaks out `FormTest` into separate components - `CreateFormTest` and `UpdateFormTest` and sets up tests accordingly. It also inits the update form for the `AllSupportedFormFields` model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
