### PR TITLE
chore: add integ test for update hasOne relationship

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
@@ -13,22 +13,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+
+import { getInputByLabel, getArrayFieldButtonByLabel, clickAddToArray } from '../utils/form';
+
 describe('CreateForms', () => {
   before(() => {
     cy.visit('http://localhost:3000/create-form-tests');
   });
-
-  const getInputByLabel = (label) => {
-    return cy.contains('label', label).parent().find('input');
-  };
-
-  const getArrayFieldButtonByLabel = (label) => {
-    return cy.contains(label).next('button');
-  };
-
-  const clickAddToArray = () => {
-    cy.get('.amplify-button--link').contains('Add').click();
-  };
 
   describe('CustomFormCreateDog', () => {
     it('should validate, clear, and submit', () => {
@@ -121,7 +112,7 @@ describe('CreateForms', () => {
         // HasOne Autocomplete
         getArrayFieldButtonByLabel('Has one user').click();
         cy.get(`.amplify-autocomplete`).within(() => {
-          cy.get('input').type(`{downArrow}{enter}`);
+          cy.get('input').type(`John Lennon{downArrow}{enter}`);
         });
         clickAddToArray();
 

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -13,15 +13,34 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+
+import { getArrayFieldButtonByLabel, clickAddToArray, removeArrayItem } from '../utils/form';
+
 describe('UpdateForms', () => {
   before(() => {
     cy.visit('http://localhost:3000/update-form-tests');
   });
 
   describe('DataStoreFormUpdateAllSupportedFormFields', () => {
-    it('should save to DataStore', () => {
+    it('should display current values and save to DataStore', () => {
       cy.get('#dataStoreFormUpdateAllSupportedFormFields').within(() => {
-        // TODO
+        // TODO: check current values on all fields and change
+
+        removeArrayItem('John Lennon');
+
+        getArrayFieldButtonByLabel('Has one user').click();
+        cy.get(`.amplify-autocomplete`).within(() => {
+          cy.get('input').type(`Paul McCartney{downArrow}{enter}`);
+        });
+        clickAddToArray();
+
+        cy.contains('Submit').click();
+
+        cy.contains(/My string/).then((recordElement) => {
+          const record = JSON.parse(recordElement.text());
+
+          expect(record.HasOneUser.firstName).to.equal('Paul');
+        });
       });
     });
   });

--- a/packages/test-generator/integration-test-templates/cypress/utils/form.ts
+++ b/packages/test-generator/integration-test-templates/cypress/utils/form.ts
@@ -1,0 +1,36 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+export const getInputByLabel = (label) => {
+  return cy.contains('label', label).parent().find('input');
+};
+
+export const getArrayFieldButtonByLabel = (label) => {
+  return cy.contains(label).next('button');
+};
+
+export const clickAddToArray = () => {
+  cy.get('.amplify-button--link').contains('Add').click();
+};
+
+export const removeArrayItem = (itemLabel: string) => {
+  // cypress clicks parent w/out the wait
+  // open issue: https://github.com/cypress-io/cypress/issues/20527
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(8000);
+  cy.contains(itemLabel).within(() => {
+    cy.get('svg').trigger('mouseover').trigger('click', { force: true });
+  });
+};

--- a/packages/test-generator/lib/forms/datastore-form-update-all-supported-form-fields.json
+++ b/packages/test-generator/lib/forms/datastore-form-update-all-supported-form-fields.json
@@ -1,27 +1,68 @@
 {
-    "id": "123-ds-update-allsupprted",
-    "name": "DataStoreFormUpdateAllSupportedFormFields",
-    "formActionType": "update",
-    "dataType": {
-      "dataSourceType": "DataStore",
-      "dataTypeName": "AllSupportedFormFields"
-    },
-    "fields": {
-      "HasOneUser": {
-        "excluded": true
-      },
-      "BelongsToOwner": {
-        "excluded": true
-      },
-      "HasManyStudents": {
-        "excluded": true
-      },
-      "ManyToManyTags": {
-        "excluded": true
+  "id": "123-ds-update-allsupprted",
+  "name": "DataStoreFormUpdateAllSupportedFormFields",
+  "formActionType": "update",
+  "dataType": {
+    "dataSourceType": "DataStore",
+    "dataTypeName": "AllSupportedFormFields"
+  },
+  "fields": {
+    "HasOneUser": {
+      "inputType": {
+        "type": "Autocomplete",
+        "valueMappings": {
+          "values": [
+            {
+              "value": {
+                "bindingProperties": {
+                  "property": "User",
+                  "field": "id"
+                }
+              },
+              "displayValue": {
+                "concat": [
+                  {
+                    "bindingProperties": {
+                      "property": "User",
+                      "field": "firstName"
+                    }
+                  },
+                  {
+                    "value": " "
+                  },
+                  {
+                    "bindingProperties": {
+                      "property": "User",
+                      "field": "lastName"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "bindingProperties": {
+            "Author": {
+              "type": "Data",
+              "bindingProperties": {
+                "model": "User"
+              }
+            }
+          }
+        }
       }
     },
-    "sectionalElements": {},
-    "style": {},
-    "cta": {},
-    "schemaVersion": "1.0"
-  }
+    "BelongsToOwner": {
+      "excluded": true
+    },
+    "HasManyStudents": {
+      "excluded": true
+    },
+    "ManyToManyTags": {
+      "excluded": true
+    }
+  },
+  "sectionalElements": {},
+  "style": {},
+  "cta": {},
+  "schemaVersion": "1.0"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- pass in record to datastore update form
- add test for hasOne relationship update
- break out cypress helpers into utils file
- make action more specific in create form test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
