### PR TITLE
chore: add integ test for create form with belongsTo relationship

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
@@ -125,6 +125,13 @@ describe('CreateForms', () => {
         });
         clickAddToArray();
 
+        // BelongsTo Autocomplete
+        getArrayFieldButtonByLabel('Belongs to owner').click();
+        cy.get(`.amplify-autocomplete`).within(() => {
+          cy.get('input').type(`John{downArrow}{enter}`);
+        });
+        clickAddToArray();
+
         cy.contains('Submit').click();
 
         cy.contains(/MyString/).then((recordElement) => {
@@ -145,6 +152,7 @@ describe('CreateForms', () => {
           expect(record.enum).to.equal('SAN_FRANCISCO');
           expect(record.stringArray[0]).to.equal('String1');
           expect(record.HasOneUser.firstName).to.equal('John');
+          expect(record.BelongsToOwner.name).to.equal('John');
         });
       });
     });

--- a/packages/test-generator/integration-test-templates/cypress/tsconfig.json
+++ b/packages/test-generator/integration-test-templates/cypress/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["cypress"]
+  }
+}

--- a/packages/test-generator/integration-test-templates/src/CreateFormTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/CreateFormTests.tsx
@@ -22,13 +22,17 @@ import {
   DataStoreFormCreateAllSupportedFormFields,
   CustomFormCreateNestedJson,
 } from './ui-components'; // eslint-disable-line import/extensions, max-len
-import { AllSupportedFormFields, User } from './models';
+import { AllSupportedFormFields, Owner, User } from './models';
 
 const initializeUserTestData = async (): Promise<void> => {
   await DataStore.save(new User({ firstName: 'John', lastName: 'Lennon', age: 29 }));
   await DataStore.save(new User({ firstName: 'Paul', lastName: 'McCartney', age: 72 }));
   await DataStore.save(new User({ firstName: 'George', lastName: 'Harrison', age: 50 }));
   await DataStore.save(new User({ firstName: 'Ringo', lastName: 'Starr', age: 5 }));
+  await DataStore.save(new Owner({ name: 'John' }));
+  await DataStore.save(new Owner({ name: 'Paul' }));
+  await DataStore.save(new Owner({ name: 'George' }));
+  await DataStore.save(new Owner({ name: 'Ringo' }));
 };
 
 export default function CreateFormTests() {
@@ -91,7 +95,11 @@ export default function CreateFormTests() {
             const records = await DataStore.query(AllSupportedFormFields);
             const record = records[0];
             setDataStoreFormCreateAllSupportedFormFieldsRecord(
-              JSON.stringify({ ...record, HasOneUser: await record.HasOneUser }),
+              JSON.stringify({
+                ...record,
+                HasOneUser: await record.HasOneUser,
+                BelongsToOwner: await record.BelongsToOwner,
+              }),
             );
           }}
         />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds integration test for create form with a `belongsTo` relationship 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
