### PR TITLE
fix: improve runtime safety for usage of the in operator

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -1305,6 +1305,38 @@ export default function ViewWithButton(
 "
 `;
 
+exports[`amplify render tests complex component tests should generate a component with custom child (malformed property) 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import CustomButton from \\"./CustomButton\\";
+import { View, ViewProps } from \\"@aws-amplify/ui-react\\";
+
+export type ViewWithCustomButtonProps = React.PropsWithChildren<
+  Partial<ViewProps> & {
+    overrides?: EscapeHatchProps | undefined | null;
+  }
+>;
+export default function ViewWithCustomButton(
+  props: ViewWithCustomButtonProps
+): React.ReactElement {
+  const { overrides, ...rest } = props;
+  return (
+    /* @ts-ignore: TS2322 */
+    <View {...rest} {...getOverrideProps(overrides, \\"ViewWithCustomButton\\")}>
+      <CustomButton
+        color={\`\${\\"Concatenated \\"}\${\\"Value!\\"}\`}
+        {...getOverrideProps(overrides, \\"MyCustomButton\\")}
+      ></CustomButton>
+    </View>
+  );
+}
+"
+`;
+
 exports[`amplify render tests complex component tests should generate a component with custom child 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -64,6 +64,11 @@ describe('amplify render tests', () => {
       expect(generatedCode.componentText).toMatchSnapshot();
     });
 
+    it('should generate a component with custom child (malformed property)', () => {
+      const generatedCode = generateWithAmplifyRenderer('customChildMalformedProperty');
+      expect(generatedCode.componentText).toMatchSnapshot();
+    });
+
     it('should generate a component with exposeAs prop', () => {
       const generatedCode = generateWithAmplifyRenderer('exposedAsTest');
       expect(generatedCode.componentText).toMatchSnapshot();

--- a/packages/codegen-ui-react/lib/react-component-render-helper.ts
+++ b/packages/codegen-ui-react/lib/react-component-render-helper.ts
@@ -72,47 +72,51 @@ export function getComponentPropName(componentName?: string): string {
 }
 
 export function isFixedPropertyWithValue(prop: StudioComponentProperty): prop is FixedStudioComponentProperty {
-  return 'value' in prop;
+  return typeof prop === 'object' && 'value' in prop;
 }
 
 export function isBoundProperty(prop: StudioComponentProperty): prop is BoundStudioComponentProperty {
-  return 'bindingProperties' in prop;
+  return typeof prop === 'object' && 'bindingProperties' in prop;
 }
 
 export function isCollectionItemBoundProperty(
   prop: StudioComponentProperty,
 ): prop is CollectionStudioComponentProperty {
-  return 'collectionBindingProperties' in prop;
+  return typeof prop === 'object' && 'collectionBindingProperties' in prop;
 }
 
 export function isConcatenatedProperty(prop: StudioComponentProperty): prop is ConcatenatedStudioComponentProperty {
-  return 'concat' in prop;
+  return typeof prop === 'object' && 'concat' in prop;
 }
 
 export function isConditionalProperty(prop: StudioComponentProperty): prop is ConditionalStudioComponentProperty {
-  return 'condition' in prop;
+  return typeof prop === 'object' && 'condition' in prop;
 }
 
 export function isStateProperty(property: StudioComponentProperty): property is StateStudioComponentProperty {
-  return 'componentName' in property && 'property' in property;
+  return typeof property === 'object' && 'componentName' in property && 'property' in property;
 }
 
 export function isSetStateParameter(parameter: StudioComponentProperty): parameter is MutationActionSetStateParameter {
-  return 'componentName' in parameter && 'property' in parameter && 'set' in parameter;
+  return typeof parameter === 'object' && 'componentName' in parameter && 'property' in parameter && 'set' in parameter;
 }
 
 export function isDefaultValueOnly(
   prop: StudioComponentProperty,
 ): prop is CollectionStudioComponentProperty | BoundStudioComponentProperty {
-  return 'defaultValue' in prop && !(isCollectionItemBoundProperty(prop) || isBoundProperty(prop));
+  return (
+    typeof prop === 'object' &&
+    'defaultValue' in prop &&
+    !(isCollectionItemBoundProperty(prop) || isBoundProperty(prop))
+  );
 }
 
 export function isBoundEvent(event: StudioComponentEvent): event is BoundStudioComponentEvent {
-  return 'bindingEvent' in event;
+  return typeof event === 'object' && 'bindingEvent' in event;
 }
 
 export function isActionEvent(event: StudioComponentEvent): event is ActionStudioComponentEvent {
-  return 'action' in event;
+  return typeof event === 'object' && 'action' in event;
 }
 
 /**
@@ -651,9 +655,9 @@ export function addBindingPropertiesImports(
   component: StudioComponent | StudioComponentChild,
   importCollection: ImportCollection,
 ) {
-  if ('bindingProperties' in component) {
+  if (typeof component === 'object' && 'bindingProperties' in component) {
     Object.entries(component.bindingProperties).forEach(([, binding]) => {
-      if ('bindingProperties' in binding && 'model' in binding.bindingProperties) {
+      if (typeof binding === 'object' && 'bindingProperties' in binding && 'model' in binding.bindingProperties) {
         importCollection.addImport(ImportSource.LOCAL_MODELS, binding.bindingProperties.model);
       }
     });
@@ -683,5 +687,9 @@ export function getSetStateName(stateReference: StateStudioComponentProperty): s
 }
 
 export function hasChildrenProp(componentProperties: StudioComponentProperties): boolean {
-  return !!('children' in componentProperties && componentProperties.children);
+  return !!(
+    typeof componentProperties === 'object' &&
+    'children' in componentProperties &&
+    componentProperties.children
+  );
 }

--- a/packages/codegen-ui-react/lib/react-component-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-renderer.ts
@@ -84,7 +84,7 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
       this.importCollection.addImport(ImportSource.UI_REACT, 'useTheme');
 
       let label = '';
-      if ('value' in this.component.properties.label) {
+      if (typeof this.component.properties.label === 'object' && 'value' in this.component.properties.label) {
         label = this.component.properties.label.value.toString() ?? '';
       }
       return renderArrayFieldComponent(

--- a/packages/codegen-ui/example-schemas/customChildMalformedProperty.json
+++ b/packages/codegen-ui/example-schemas/customChildMalformedProperty.json
@@ -1,0 +1,27 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "View",
+  "name": "ViewWithCustomButton",
+  "properties": {},
+  "children": [
+    {
+      "id": "0987-6543-3211",
+      "componentType": "CustomButton",
+      "name": "MyCustomButton",
+      "properties": {
+        "color": {
+          "concat": [
+            {
+              "value": "Concatenated "
+            },
+            "{atiempo:values.atiempo}",
+            {
+              "value": "Value!"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "schemaVersion": "1.0"
+}

--- a/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
+++ b/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
@@ -7,7 +7,8 @@
     "attend": {
       "inputType": {
         "required": "false",
-        "type": "RadioGroupField"
+        "type": "RadioGroupField",
+        "valueMappings": { "values": [{ "value": "{ value: 'Option' }" }] }
       }
     },
     "maybeSlide": {

--- a/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
@@ -63,8 +63,8 @@ export function generateFormDefinition({
   )
     .map(([fieldName, fieldConfig]) => ({
       name: fieldName,
-      position: 'position' in fieldConfig ? fieldConfig.position : undefined,
-      excluded: 'excluded' in fieldConfig ? fieldConfig.excluded : false,
+      position: typeof fieldConfig === 'object' && 'position' in fieldConfig ? fieldConfig.position : undefined,
+      excluded: typeof fieldConfig === 'object' && 'excluded' in fieldConfig ? fieldConfig.excluded : false,
     }))
     .concat(
       Object.entries(form.sectionalElements).map(([elementName, elementConfig]) => ({

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -69,10 +69,10 @@ function getRadioGroupFieldValueMappings(
   const dataType = config.dataType ?? baseConfig?.dataType;
   if (dataType === 'Boolean') {
     const trueOverride = valueMappings.values.find(
-      ({ value }) => 'value' in value && value.value === 'true',
+      ({ value }) => typeof value === 'object' && 'value' in value && value.value === 'true',
     )?.displayValue;
     const falseOverride = valueMappings.values.find(
-      ({ value }) => 'value' in value && value.value === 'false',
+      ({ value }) => typeof value === 'object' && 'value' in value && value.value === 'false',
     )?.displayValue;
 
     const {
@@ -343,7 +343,7 @@ export function mapFormFieldConfig(
   formDefinition: FormDefinition,
   modelFieldsConfigs: ModelFieldsConfigs,
 ) {
-  if ('excluded' in element.config) {
+  if (typeof element.config === 'object' && 'excluded' in element.config) {
     throw new InternalError(`Attempted to map excluded element ${element.name}`);
   }
   formDefinition.elements[element.name] = getFormDefinitionInputElement(

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/map-cta.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/map-cta.ts
@@ -56,7 +56,7 @@ function getButtonElement(
     },
   };
 
-  if (override && 'children' in override && override.children) {
+  if (typeof override === 'object' && 'children' in override && override.children) {
     element.props.children = override.children;
   }
 
@@ -77,7 +77,7 @@ function mapMatrix(buttons?: StudioFormCTA): string[][] {
   return matrix.map((subArray) => {
     return subArray.filter((element) => {
       if (
-        buttons[element] &&
+        typeof buttons[element] === 'object' &&
         'excluded' in (buttons[element] as StudioFormCTAButton) &&
         (buttons[element] as { excluded: boolean }).excluded
       ) {

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/position.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/position.ts
@@ -74,9 +74,9 @@ export function mapElementMatrix({
         if (previousIndices) {
           removeFromMatrix(previousIndices, formDefinition);
         }
-      } else if (element.position && 'rightOf' in element.position && element.position.rightOf) {
+      } else if (typeof element.position === 'object' && 'rightOf' in element.position && element.position.rightOf) {
         tempRightOf.push(element);
-      } else if (element.position && 'below' in element.position && element.position.below) {
+      } else if (typeof element.position === 'object' && 'below' in element.position && element.position.below) {
         const relationIndices = findIndices(element.position.below, formDefinition.elementMatrix);
         if (!relationIndices) {
           requeued.push(element);
@@ -87,7 +87,11 @@ export function mapElementMatrix({
           }
           formDefinition.elementMatrix.splice(relationIndices[0] + 1, 0, [element.name]);
         }
-      } else if (element.position && 'fixed' in element.position && element.position.fixed === 'first') {
+      } else if (
+        typeof element.position === 'object' &&
+        'fixed' in element.position &&
+        element.position.fixed === 'first'
+      ) {
         const previousIndices = findIndices(element.name, formDefinition.elementMatrix);
         if (previousIndices) {
           removeFromMatrix(previousIndices, formDefinition);
@@ -112,7 +116,7 @@ export function mapElementMatrix({
     const requeued: typeof elementQueue = [];
 
     rightOfElementQueue.forEach((element) => {
-      if (element.position && 'rightOf' in element.position && element.position.rightOf) {
+      if (typeof element.position === 'object' && 'rightOf' in element.position && element.position.rightOf) {
         const relationIndices = findIndices(element.position.rightOf, formDefinition.elementMatrix);
         if (!relationIndices) {
           requeued.push(element);

--- a/packages/codegen-ui/lib/renderer-helper.ts
+++ b/packages/codegen-ui/lib/renderer-helper.ts
@@ -30,11 +30,11 @@ import { breakpointSizes, BreakpointSizeType } from './utils/breakpoint-utils';
 export function isStudioComponentWithBinding(
   component: StudioComponent | StudioComponentChild,
 ): component is StudioComponent {
-  return 'bindingProperties' in component;
+  return typeof component === 'object' && 'bindingProperties' in component;
 }
 
 export function isAuthProperty(prop: StudioComponentProperty): prop is StudioComponentAuthProperty {
-  return 'userAttribute' in prop;
+  return typeof prop === 'object' && 'userAttribute' in prop;
 }
 
 /**
@@ -44,13 +44,20 @@ export function isAuthProperty(prop: StudioComponentProperty): prop is StudioCom
 export function isStudioComponentWithCollectionProperties(
   component: StudioComponent | StudioComponentChild,
 ): component is StudioComponent & Required<Pick<StudioComponent, 'collectionProperties'>> {
-  return 'collectionProperties' in component && component.collectionProperties !== undefined;
+  return (
+    typeof component === 'object' && 'collectionProperties' in component && component.collectionProperties !== undefined
+  );
 }
 
 export function isStudioComponentWithVariants(
   component: StudioComponent | StudioComponentChild,
 ): component is StudioComponent & Required<Pick<StudioComponent, 'variants'>> {
-  return 'variants' in component && component.variants !== undefined && component.variants.length > 0;
+  return (
+    typeof component === 'object' &&
+    'variants' in component &&
+    component.variants !== undefined &&
+    component.variants.length > 0
+  );
 }
 
 export function isStudioComponentWithBreakpoints(
@@ -67,13 +74,14 @@ export function isStudioComponentWithBreakpoints(
 export function isDataPropertyBinding(
   prop: StudioComponentPropertyBinding,
 ): prop is StudioComponentDataPropertyBinding {
-  return 'type' in prop && prop.type === 'Data';
+  return typeof prop === 'object' && 'type' in prop && prop.type === 'Data';
 }
 
 export function isSimplePropertyBinding(
   prop: StudioComponentPropertyBinding,
 ): prop is StudioComponentSimplePropertyBinding {
   return (
+    typeof prop === 'object' &&
     'type' in prop &&
     [
       StudioComponentPropertyType.Boolean.toString(),
@@ -87,9 +95,9 @@ export function isSimplePropertyBinding(
 export function isEventPropertyBinding(
   prop: StudioComponentPropertyBinding,
 ): prop is StudioComponentEventPropertyBinding {
-  return 'type' in prop && prop.type === 'Event';
+  return typeof prop === 'object' && 'type' in prop && prop.type === 'Event';
 }
 
 export function isSlotBinding(prop: StudioComponentPropertyBinding): prop is StudioComponentSlotBinding {
-  return 'type' in prop && prop.type === 'Amplify.Slot';
+  return typeof prop === 'object' && 'type' in prop && prop.type === 'Amplify.Slot';
 }

--- a/packages/codegen-ui/lib/utils/component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/component-metadata.ts
@@ -193,26 +193,29 @@ function computeBindingPropertyMetadata(bindingProperty: StudioComponentProperty
  */
 
 function computePropertyMetadata(property: StudioComponentProperty): ComponentMetadata {
-  return reduceComponentMetadata(
-    ([] as ComponentMetadata[])
-      .concat('concat' in property && property.concat ? property.concat.map(computePropertyMetadata) : [])
-      .concat('userAttribute' in property && property.userAttribute ? [generateAuthBindingMetadata()] : [])
-      .concat(
-        'condition' in property && property.condition && 'then' in property.condition && property.condition.then
-          ? [computePropertyMetadata(property.condition.then)]
-          : [],
-      )
-      .concat(
-        'condition' in property && property.condition && 'else' in property.condition && property.condition.else
-          ? [computePropertyMetadata(property.condition.else)]
-          : [],
-      )
-      .concat(
-        'componentName' in property && property.componentName && 'property' in property && property.property
-          ? [generateReferenceMetadata(property as StateReference)]
-          : [],
-      ),
-  );
+  const meta =
+    typeof property !== 'object'
+      ? []
+      : ([] as ComponentMetadata[])
+          .concat('concat' in property && property.concat ? property.concat.map(computePropertyMetadata) : [])
+          .concat('userAttribute' in property && property.userAttribute ? [generateAuthBindingMetadata()] : [])
+          .concat(
+            'condition' in property && property.condition && 'then' in property.condition && property.condition.then
+              ? [computePropertyMetadata(property.condition.then)]
+              : [],
+          )
+          .concat(
+            'condition' in property && property.condition && 'else' in property.condition && property.condition.else
+              ? [computePropertyMetadata(property.condition.else)]
+              : [],
+          )
+          .concat(
+            'componentName' in property && property.componentName && 'property' in property && property.property
+              ? [generateReferenceMetadata(property as StateReference)]
+              : [],
+          );
+
+  return reduceComponentMetadata(meta);
 }
 
 /**

--- a/packages/codegen-ui/lib/utils/form-to-component/helpers/map-element-children.ts
+++ b/packages/codegen-ui/lib/utils/form-to-component/helpers/map-element-children.ts
@@ -38,7 +38,12 @@ function mapOptions(
       },
     };
 
-    if (element.componentType === 'SelectField' && 'value' in value && value.value === element.defaultValue) {
+    if (
+      element.componentType === 'SelectField' &&
+      typeof value === 'object' &&
+      'value' in value &&
+      value.value === element.defaultValue
+    ) {
       option.properties.selected = { value: true };
     }
 

--- a/packages/codegen-ui/lib/utils/state-reference-metadata.ts
+++ b/packages/codegen-ui/lib/utils/state-reference-metadata.ts
@@ -44,34 +44,40 @@ function reduceDataDependencies(dataDependencies: string[]): string[] {
  */
 
 export function computeDataDependenciesForStudioComponentProperty(property: StudioComponentProperty): string[] {
-  return reduceDataDependencies(
-    ([] as string[])
-      .concat(
-        'concat' in property && property.concat
-          ? property.concat.flatMap(computeDataDependenciesForStudioComponentProperty)
-          : [],
-      )
-      .concat('userAttribute' in property && property.userAttribute ? ['authAttributes'] : [])
-      .concat(
-        'bindingProperties' in property && property.bindingProperties ? [property.bindingProperties.property] : [],
-      )
-      .concat('collectionBindingProperties' in property && property.collectionBindingProperties ? ['items'] : [])
-      .concat(
-        'condition' in property && property.condition && 'property' in property.condition && property.condition.property
-          ? [property.condition.property]
-          : [],
-      )
-      .concat(
-        'condition' in property && property.condition && 'then' in property.condition && property.condition.then
-          ? computeDataDependenciesForStudioComponentProperty(property.condition.then)
-          : [],
-      )
-      .concat(
-        'condition' in property && property.condition && 'else' in property.condition && property.condition.else
-          ? computeDataDependenciesForStudioComponentProperty(property.condition.else)
-          : [],
-      ),
-  );
+  const deps =
+    typeof property !== 'object'
+      ? []
+      : ([] as string[])
+          .concat(
+            'concat' in property && property.concat
+              ? property.concat.flatMap(computeDataDependenciesForStudioComponentProperty)
+              : [],
+          )
+          .concat('userAttribute' in property && property.userAttribute ? ['authAttributes'] : [])
+          .concat(
+            'bindingProperties' in property && property.bindingProperties ? [property.bindingProperties.property] : [],
+          )
+          .concat('collectionBindingProperties' in property && property.collectionBindingProperties ? ['items'] : [])
+          .concat(
+            'condition' in property &&
+              property.condition &&
+              'property' in property.condition &&
+              property.condition.property
+              ? [property.condition.property]
+              : [],
+          )
+          .concat(
+            'condition' in property && property.condition && 'then' in property.condition && property.condition.then
+              ? computeDataDependenciesForStudioComponentProperty(property.condition.then)
+              : [],
+          )
+          .concat(
+            'condition' in property && property.condition && 'else' in property.condition && property.condition.else
+              ? computeDataDependenciesForStudioComponentProperty(property.condition.else)
+              : [],
+          );
+
+  return reduceDataDependencies(deps);
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
customers are encountering runtime exceptions with error logs indicating that the `in` operator is being used for type narrowing but the right hand side is not compatible with the operator (unexpected string value). Adding a `typeof` check to ensure the value is non-primitive prior to narrowing using `in` will grant us additional runtime safety and allow codegen to continue executing without error.

[TS Playground example](https://www.typescriptlang.org/play?ts=4.4.4#code/PTAEEsDsDcEMBtwBMKQA4FcAuBnUkBTAlLAe1ACMDQBjWHLY0e0AA1kgE9XKC6Mc1LAAsCAJ2rg8NUgFs04eAQC0WcLOo5YAMwJZOobaTGgR1VlB6k042GTEA6ALAAoEKlDGk40+QDmeqBiGJBqGqBauvoANKaiQeB+wljKwhxIyjjI1ITEeGSgrjKQDKYEDACS6NgAXBwGALygAN6uoO2gcPAY5TVszV09fQBEjAzDAL6sbR2uE64LLq7uYonJqemZ2aCyAli8+KSQymirsuBq0ARFRzikSg7wpH4AFPo2pNplldVYDoPlUANYGgADkpAoACs+FhQaAAGTwsEAuFQb5YKqYP4AvAAfnRmOw-wQPRwxO61D6oMiBFBAEoANw3Er3AiPZ4vUEojxjDG-cmk0D43mE7Ek8oCylgyCkfY0+lMlxAA)

sample error message:
```
Unhandled Codegen Error Occurred - "TypeError: Cannot use 'in' operator to search for 'value' in {"value": value.ontime}
```
*note: the TypeError message would come from executing something similar to `'value' in '{"value": value.ontime}'`*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
