### PR TITLE
fix: remove existing element in matrix when requeued

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -344,13 +344,41 @@ it('should requeue if related element is not yet found', () => {
       },
       sectionalElements: {
         Heading123: { type: 'Heading', position: { fixed: 'first' }, level: 1, text: 'Create Dog' },
+        Heading456: { type: 'Heading', position: { below: 'color' }, level: 1, text: 'Dog Created' },
       },
-
       style: {},
       cta: {},
     },
+    dataSchema: {
+      dataSourceType: 'DataStore',
+      models: {
+        Event: {
+          fields: {
+            name: {
+              dataType: 'String',
+              required: false,
+              readOnly: false,
+              isArray: false,
+            },
+            age: {
+              dataType: 'String',
+              required: false,
+              readOnly: false,
+              isArray: false,
+            },
+          },
+        },
+      },
+      enums: {},
+      nonModels: {},
+    },
   });
-  expect(formDefinition.elementMatrix).toStrictEqual([['Heading123'], ['name', 'age', 'weight'], ['color']]);
+  expect(formDefinition.elementMatrix).toStrictEqual([
+    ['Heading123'],
+    ['name', 'age', 'weight'],
+    ['color'],
+    ['Heading456'],
+  ]);
 });
 
 it('should handle fields without position', () => {
@@ -370,7 +398,6 @@ it('should handle fields without position', () => {
       sectionalElements: {
         Heading123: { type: 'Heading', position: { fixed: 'first' }, level: 1, text: 'Create Dog' },
       },
-
       style: {},
       cta: {},
     },
@@ -387,7 +414,6 @@ it('should fill out styles using defaults', () => {
       dataType: { dataSourceType: 'Custom', dataTypeName: 'dfkjad' },
       fields: {},
       sectionalElements: {},
-
       style: {},
       cta: {},
     },

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/position.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/position.ts
@@ -78,13 +78,13 @@ export function mapElementMatrix({
         tempRightOf.push(element);
       } else if (typeof element.position === 'object' && 'below' in element.position && element.position.below) {
         const relationIndices = findIndices(element.position.below, formDefinition.elementMatrix);
+        const previousIndices = findIndices(element.name, formDefinition.elementMatrix);
+        if (previousIndices) {
+          removeFromMatrix(previousIndices, formDefinition);
+        }
         if (!relationIndices) {
           requeued.push(element);
         } else {
-          const previousIndices = findIndices(element.name, formDefinition.elementMatrix);
-          if (previousIndices) {
-            removeFromMatrix(previousIndices, formDefinition);
-          }
           formDefinition.elementMatrix.splice(relationIndices[0] + 1, 0, [element.name]);
         }
       } else if (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove existing element in matrix when requeued
- fixes bug while reordering elements in UI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
