### PR TITLE
fix: return aliases with required models api

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
+++ b/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
@@ -70,6 +70,24 @@ export const generateWithAmplifyFormRenderer = (
   return renderer.renderComponent();
 };
 
+export const generateComponentOnlyWithAmplifyFormRenderer = (
+  formJsonFile: string,
+  dataSchemaJsonFile: string | undefined,
+  renderConfig: ReactRenderConfig = defaultCLIRenderConfig,
+) => {
+  let dataSchema: GenericDataSchema | undefined;
+  if (dataSchemaJsonFile) {
+    const dataStoreSchema = loadSchemaFromJSONFile<Schema>(dataSchemaJsonFile);
+    dataSchema = getGenericFromDataStore(dataStoreSchema);
+  }
+  const rendererFactory = new StudioTemplateRendererFactory(
+    (component: StudioForm) => new AmplifyFormRenderer(component, dataSchema, renderConfig),
+  );
+
+  const renderer = rendererFactory.buildRenderer(loadSchemaFromJSONFile<StudioForm>(formJsonFile));
+  return renderer.renderComponentOnly();
+};
+
 export const renderWithAmplifyViewRenderer = (
   viewJsonFile: string,
   dataSchemaJsonFile: string | undefined,

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { generateWithAmplifyFormRenderer } from './__utils__';
+import { generateComponentOnlyWithAmplifyFormRenderer, generateWithAmplifyFormRenderer } from './__utils__';
 
 describe('amplify form renderer tests', () => {
   describe('datastore form tests', () => {
@@ -283,6 +283,16 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toContain('Flex0');
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
+    });
+
+    it('should return import aliases in requredDataModels', () => {
+      const { requiredDataModels } = generateComponentOnlyWithAmplifyFormRenderer(
+        'forms/member-datastore-update-belongs-to',
+        'datastore/project-team-model',
+      );
+
+      const { importAlias } = requiredDataModels.get('Team') ?? { importAlias: 'Will Fail' };
+      expect(importAlias).toEqual('Team0');
     });
 
     describe('custom form tests', () => {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/type-helper.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/type-helper.ts
@@ -68,8 +68,8 @@ const getTypeNode = ({ componentType, dataType, isArray, isValidation, importCol
 
   if (dataType && typeof dataType === 'object' && 'model' in dataType) {
     const modelName = dataType.model;
-    const aliasedModel = importCollection?.addImport(ImportSource.LOCAL_MODELS, modelName);
-    typeNode = factory.createTypeReferenceNode(factory.createIdentifier(aliasedModel || modelName));
+    const addImportResponse = importCollection?.addImport(ImportSource.LOCAL_MODELS, modelName);
+    typeNode = factory.createTypeReferenceNode(factory.createIdentifier(addImportResponse?.importAlias || modelName));
   }
 
   if (isValidation) {

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -118,7 +118,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
   public fileName: string;
 
-  protected requiredDataModels: string[] = [];
+  protected requiredDataModels: Map<string, { importAlias: string | undefined }> = new Map();
 
   protected shouldRenderArrayField = false;
 
@@ -314,8 +314,8 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     // add model import for datastore type
     if (dataSourceType === 'DataStore') {
-      this.requiredDataModels.push(dataTypeName);
-      modelName = this.importCollection.addImport(ImportSource.LOCAL_MODELS, dataTypeName);
+      const { importName, importAlias } = this.importCollection.addImport(ImportSource.LOCAL_MODELS, dataTypeName);
+      modelName = importAlias ?? importName;
     }
 
     return [
@@ -374,7 +374,8 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     // add model import for datastore type
     if (dataSourceType === 'DataStore') {
-      modelName = this.importCollection.addImport(ImportSource.LOCAL_MODELS, dataTypeName);
+      const { importName, importAlias } = this.importCollection.addImport(ImportSource.LOCAL_MODELS, dataTypeName);
+      modelName = importAlias ?? importName;
     }
 
     const elements: BindingElement[] = [
@@ -560,9 +561,10 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     this.shouldRenderArrayField = usesArrayField;
 
-    this.requiredDataModels.push(...modelsToImport);
-
-    modelsToImport.forEach((model) => this.importCollection.addImport(ImportSource.LOCAL_MODELS, model));
+    modelsToImport.forEach((model) => {
+      const { importName, importAlias } = this.importCollection.addImport(ImportSource.LOCAL_MODELS, model);
+      this.requiredDataModels.set(importName, { importAlias });
+    });
 
     // datastore relationship query
     /**

--- a/packages/codegen-ui-react/lib/imports/import-collection.ts
+++ b/packages/codegen-ui-react/lib/imports/import-collection.ts
@@ -40,7 +40,7 @@ export class ImportCollection {
     this.addImport(importPackage, importValue);
   }
 
-  addImport(packageName: string, importName: string) {
+  addImport(packageName: string, importName: string): { importName: string; importAlias: string | undefined } {
     if (!this.#collection.has(packageName)) {
       this.#collection.set(packageName, new Set());
     }
@@ -54,11 +54,13 @@ export class ImportCollection {
       }
     }
 
+    let modelAlias: string | undefined;
+
     if (packageName === ImportSource.LOCAL_MODELS) {
       const existingPackageAlias = this.importAlias.get(packageName);
       const existingAlias = existingPackageAlias?.get(importName);
-      if (existingAlias) return existingAlias;
-      const modelAlias = createUniqueName(
+      if (existingAlias) return { importName, importAlias: existingAlias };
+      modelAlias = createUniqueName(
         importName,
         (input) =>
           this.importedNames.has(input) || (input.endsWith('Props') && isPrimitive(input.replace(/Props/g, ''))),
@@ -71,9 +73,9 @@ export class ImportCollection {
         this.importAlias.set(packageName, aliasMap);
       }
       this.importedNames.add(modelAlias);
-      return modelAlias;
+      return { importName, importAlias: modelAlias };
     }
-    return importName;
+    return { importName, importAlias: modelAlias };
   }
 
   removeImportSource(packageImport: ImportSource) {

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -914,7 +914,8 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     if (isStudioComponentWithCollectionProperties(component)) {
       Object.entries(component.collectionProperties).forEach((collectionProp) => {
         const [propName, { model, sort, predicate }] = collectionProp;
-        const modelName = this.importCollection.addImport(ImportSource.LOCAL_MODELS, model);
+        const { importName, importAlias } = this.importCollection.addImport(ImportSource.LOCAL_MODELS, model);
+        const modelName = importAlias ?? importName;
 
         if (predicate) {
           statements.push(this.buildPredicateDeclaration(propName, predicate));
@@ -989,7 +990,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
           const { bindingProperties } = binding;
           if ('predicate' in bindingProperties && bindingProperties.predicate !== undefined) {
             this.importCollection.addMappedImport(ImportValue.USE_DATA_STORE_BINDING);
-            const modelName = this.importCollection.addImport(ImportSource.LOCAL_MODELS, bindingProperties.model);
+            const { importName, importAlias } = this.importCollection.addImport(
+              ImportSource.LOCAL_MODELS,
+              bindingProperties.model,
+            );
+            const modelName = importAlias ?? importName;
 
             /* const buttonColorFilter = {
              *   field: "userID",
@@ -1139,7 +1144,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       Object.entries(this.dataSchema.models[model].fields).forEach(([key, field]) => {
         if (field.relationship?.type === 'HAS_MANY') {
           const { relatedModelName, relatedModelField } = field.relationship;
-          const modelName = this.importCollection.addImport(ImportSource.LOCAL_MODELS, relatedModelName);
+          const { importName, importAlias } = this.importCollection.addImport(
+            ImportSource.LOCAL_MODELS,
+            relatedModelName,
+          );
+          const modelName = importAlias ?? importName;
           const itemsName = getActionIdentifier(relatedModelName, 'Items');
           statements.push(
             buildBaseCollectionVariableStatement(

--- a/packages/codegen-ui-react/lib/workflow/action.ts
+++ b/packages/codegen-ui-react/lib/workflow/action.ts
@@ -207,8 +207,8 @@ export function getActionParameterValue(
   importCollection: ImportCollection,
 ): Expression {
   if (key === 'model') {
-    const modelName = importCollection.addImport(ImportSource.LOCAL_MODELS, value as string);
-    return factory.createIdentifier(modelName);
+    const { importName, importAlias } = importCollection.addImport(ImportSource.LOCAL_MODELS, value as string);
+    return factory.createIdentifier(importAlias ?? importName);
   }
   if (key === 'fields') {
     return factory.createObjectLiteralExpression(

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-react",
-			"version": "2.5.4",
+			"version": "2.5.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript/vfs": "~1.3.5",

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui",
-			"version": "2.5.4",
+			"version": "2.5.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"change-case": "^4.1.2",

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-test-generator",
-			"version": "2.5.4",
+			"version": "2.5.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "^15.12.1",


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1202293561809020/1203468156027560/f

*Description of changes:*

When rendering component only, the client needs to know what the import alias names are for the required data models. This change adds the import aliases to the requiredDataModels value returned by the renderComponentOnly method, so the client knows which alias to use for the data model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
