### PR TITLE
fix: add importCollection to renderComponentOnly return

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
+++ b/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
@@ -70,6 +70,24 @@ export const generateWithAmplifyFormRenderer = (
   return renderer.renderComponent();
 };
 
+export const generateComponentOnlyWithAmplifyFormRenderer = (
+  formJsonFile: string,
+  dataSchemaJsonFile: string | undefined,
+  renderConfig: ReactRenderConfig = defaultCLIRenderConfig,
+) => {
+  let dataSchema: GenericDataSchema | undefined;
+  if (dataSchemaJsonFile) {
+    const dataStoreSchema = loadSchemaFromJSONFile<Schema>(dataSchemaJsonFile);
+    dataSchema = getGenericFromDataStore(dataStoreSchema);
+  }
+  const rendererFactory = new StudioTemplateRendererFactory(
+    (component: StudioForm) => new AmplifyFormRenderer(component, dataSchema, renderConfig),
+  );
+
+  const renderer = rendererFactory.buildRenderer(loadSchemaFromJSONFile<StudioForm>(formJsonFile));
+  return renderer.renderComponentOnly();
+};
+
 export const renderWithAmplifyViewRenderer = (
   viewJsonFile: string,
   dataSchemaJsonFile: string | undefined,

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -13,7 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { generateWithAmplifyFormRenderer } from './__utils__';
+import { ImportSource } from '../imports';
+import { generateComponentOnlyWithAmplifyFormRenderer, generateWithAmplifyFormRenderer } from './__utils__';
 
 describe('amplify form renderer tests', () => {
   describe('datastore form tests', () => {
@@ -283,6 +284,20 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toContain('Flex0');
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
+    });
+
+    it('should use requiredDataModels and importCollection to get model alias', () => {
+      const { requiredDataModels, importCollection } = generateComponentOnlyWithAmplifyFormRenderer(
+        'forms/member-datastore-update-belongs-to',
+        'datastore/project-team-model',
+      );
+
+      const teamAlias = importCollection.importAlias.get(ImportSource.LOCAL_MODELS)?.get('Team');
+
+      const includesTeam = requiredDataModels.includes('Team');
+      expect(teamAlias).toBe('Team0');
+      expect(includesTeam).toBe(true);
+      expect(importCollection).toBeDefined();
     });
 
     describe('custom form tests', () => {

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -96,6 +96,15 @@ import {
   validationResponseType,
 } from './form-renderer-helper/type-helper';
 
+type RenderComponentOnlyResponse = {
+  compText: string;
+  /**
+   * @deprecated Use {@link RenderComponentOnlyResponse.importCollection} instead.
+   */
+  importsText: string;
+  requiredDataModels: string[];
+  importCollection: ImportCollection;
+};
 export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
   string,
   StudioForm,
@@ -151,7 +160,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
   }
 
   @handleCodegenErrors
-  renderComponentOnly() {
+  renderComponentOnly(): RenderComponentOnlyResponse {
     const variableStatements = this.buildVariableStatements();
     const jsx = this.renderJsx(this.formComponent);
 
@@ -176,7 +185,12 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     // do not produce declaration becuase it is not used
     const { componentText: compText } = transpile(result, { ...this.renderConfig, renderTypeDeclarations: false });
 
-    return { compText, importsText, requiredDataModels: this.requiredDataModels };
+    return {
+      compText,
+      importsText,
+      requiredDataModels: this.requiredDataModels,
+      importCollection: this.importCollection,
+    };
   }
 
   renderComponentInternal() {
@@ -558,9 +572,10 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     this.shouldRenderArrayField = usesArrayField;
 
-    this.requiredDataModels.push(...modelsToImport);
-
-    modelsToImport.forEach((model) => this.importCollection.addImport(ImportSource.LOCAL_MODELS, model));
+    modelsToImport.forEach((model) => {
+      this.requiredDataModels.push(model);
+      this.importCollection.addImport(ImportSource.LOCAL_MODELS, model);
+    });
 
     // datastore relationship query
     /**


### PR DESCRIPTION
*Issue #, if available:*

https://app.asana.com/0/1202293561809020/1203468156027560/f

*Description of changes:*

When rendering component only, the client needs to know what the import alias names are for the required data models. This change adds the import aliases to the requiredDataModels value returned by the renderComponentOnly method, so the client knows which alias to use for the data model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
