### PR TITLE
fix: add form datamodel to requiredDataModels for renderComponentOnly

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -292,11 +292,13 @@ describe('amplify form renderer tests', () => {
         'datastore/project-team-model',
       );
 
-      const teamAlias = importCollection.importAlias.get(ImportSource.LOCAL_MODELS)?.get('Team');
+      const teamAlias = importCollection.getMappedAlias(ImportSource.LOCAL_MODELS, 'Team');
 
       const includesTeam = requiredDataModels.includes('Team');
+      const includesMember = requiredDataModels.includes('Member');
       expect(teamAlias).toBe('Team0');
       expect(includesTeam).toBe(true);
+      expect(includesMember).toBe(true);
       expect(importCollection).toBeDefined();
     });
 

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -386,6 +386,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     // add model import for datastore type
     if (dataSourceType === 'DataStore') {
+      this.requiredDataModels.push(dataTypeName);
       modelName = this.importCollection.addImport(ImportSource.LOCAL_MODELS, dataTypeName);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add datamodel to requiredDataModels for renderComponentOnly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
