### PR TITLE
Revert "chore: temporarily typecast custom theme"

### DIFF
--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -155,9 +155,8 @@ export default function ComponentTests() {
     return null;
   }
 
-  // TODO: remove typecasting once ui-react issue settled
   return (
-    <AmplifyProvider theme={MyTheme as any}>
+    <AmplifyProvider theme={MyTheme}>
       <h1>Generated Component Tests</h1>
       <div id={'basic-components'}>
         <h2>Basic Components</h2>

--- a/packages/test-generator/integration-test-templates/src/ViewTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ViewTests.tsx
@@ -50,9 +50,8 @@ export default function FormTests() {
   if (!isInitialized) {
     return null;
   }
-  // TODO: remove typecasting once ui-react issue settled
   return (
-    <AmplifyProvider theme={MyTheme as any}>
+    <AmplifyProvider theme={MyTheme}>
       <View id="expanderWithSlot">
         <Heading>Expander with Component Slot</Heading>
         <ListingExpanderWithComponentSlot />


### PR DESCRIPTION
This reverts commit 018975d3f0381c662529e11296ef6c6140509e3a.

*Issue #, if available:*

*Description of changes:*
Amplify UI pushed the fix for the breaking types so we can revert this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
