### PR TITLE
chore: pin cypress to 11

### DIFF
--- a/scripts/integ-setup.bat
+++ b/scripts/integ-setup.bat
@@ -20,7 +20,7 @@ call lerna add --scope integration-test @aws-amplify/codegen-ui-react
 call lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator
 call lerna add --no-ci --scope integration-test react-router-dom
 call lerna add --no-ci --scope integration-test @types/react-router-dom
-call lerna add --no-ci --dev --scope integration-test cypress
+call lerna add --no-ci --dev --scope integration-test cypress@11.2.0
 call lerna add --no-ci --dev --scope integration-test wait-on
 call lerna add --no-ci --scope integration-test os-browserify
 call lerna add --no-ci --scope integration-test path-browserify

--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -20,7 +20,7 @@ lerna add --scope integration-test @aws-amplify/codegen-ui-react
 lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator
 lerna add --no-ci --scope integration-test react-router-dom
 lerna add --no-ci --scope integration-test @types/react-router-dom
-lerna add --no-ci --dev --scope integration-test cypress
+lerna add --no-ci --dev --scope integration-test cypress@11.2.0
 lerna add --no-ci --dev --scope integration-test wait-on
 lerna add --no-ci --scope integration-test os-browserify
 lerna add --no-ci --scope integration-test path-browserify


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cypress did a major version bump and it's breaking our integ tests. Looking to rev our tests to accommodate, but in the meanwhile, unblocking merges w/ this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
