### PR TITLE
fix: add temp solution for removing hasOne & belongsTo relationships

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -2722,6 +2722,8 @@ export default function UpdateCPKTeacherForm(props) {
             DataStore.save(
               CPKTeacher.copyOf(cPKTeacherRecord, (updated) => {
                 Object.assign(updated, modelFields);
+                if (!modelFields.CPKStudent)
+                  updated.cPKTeacherCPKStudentId = undefined;
               })
             )
           );
@@ -9074,6 +9076,7 @@ export default function MyMemberForm(props) {
           await DataStore.save(
             Member.copyOf(memberRecord, (updated) => {
               Object.assign(updated, modelFields);
+              if (!modelFields.Team) updated.teamMembersId = undefined;
             })
           );
           if (onSuccess) {

--- a/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
@@ -61,6 +61,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.PrimaryCareGiver.fields.Child.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Child',
+      associatedField: 'primaryCareGiverChildId',
     });
 
     expect(genericSchema.models.PrimaryCareGiver.fields.primaryCareGiverChildId.relationship).toStrictEqual({
@@ -87,6 +88,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Lock.fields.Key.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Key',
+      associatedField: 'lockKeyId',
     });
 
     expect(genericSchema.models.Lock.fields.lockKeyId.relationship).toStrictEqual({
@@ -97,6 +99,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Key.fields.Lock.relationship).toStrictEqual({
       type: 'BELONGS_TO',
       relatedModelName: 'Lock',
+      associatedField: 'keyLockId',
     });
 
     expect(genericSchema.models.Owner.fields.Dog.relationship).toStrictEqual<HasManyRelationshipType>({
@@ -119,6 +122,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.PrimaryCareGiver.fields.Child.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Child',
+      associatedField: 'primaryCareGiverChildId',
     });
 
     expect(genericSchema.models.PrimaryCareGiver.fields.primaryCareGiverChildId.relationship).toStrictEqual({
@@ -145,6 +149,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Lock.fields.Key.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Key',
+      associatedField: 'lockKeyId',
     });
 
     expect(genericSchema.models.Lock.fields.lockKeyId.relationship).toStrictEqual({
@@ -155,6 +160,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Key.fields.Lock.relationship).toStrictEqual({
       type: 'BELONGS_TO',
       relatedModelName: 'Lock',
+      associatedField: 'keyLockId',
     });
 
     expect(genericSchema.models.Owner.fields.Dog.relationship).toStrictEqual<HasManyRelationshipType>({

--- a/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
@@ -123,6 +123,7 @@ describe('mapFormMetaData', () => {
     expect(fieldConfigs.Student.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Student',
+      associatedField: 'TeacherStudentId',
     });
   });
 

--- a/packages/codegen-ui/lib/generic-from-datastore.ts
+++ b/packages/codegen-ui/lib/generic-from-datastore.ts
@@ -139,7 +139,7 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
 
           // note implicit relationship for associated field within same model
           if (
-            relationshipType === 'HAS_ONE' &&
+            (relationshipType === 'HAS_ONE' || relationshipType === 'BELONGS_TO') &&
             ('targetName' in field.association || 'targetNames' in field.association) &&
             (field.association.targetName || field.association.targetNames)
           ) {
@@ -149,12 +149,8 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
                 type: relationshipType,
                 relatedModelName,
               });
-              modelRelationship = { type: relationshipType, relatedModelName };
+              modelRelationship = { type: relationshipType, relatedModelName, associatedField: targetName };
             }
-          }
-
-          if (relationshipType === 'BELONGS_TO') {
-            modelRelationship = { type: relationshipType, relatedModelName };
           }
 
           genericField.relationship = modelRelationship;

--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -43,10 +43,12 @@ export type HasManyRelationshipType = {
 
 export type HasOneRelationshipType = {
   type: 'HAS_ONE';
+  associatedField?: string;
 } & CommonRelationshipType;
 
 export type BelongsToRelationshipType = {
   type: 'BELONGS_TO';
+  associatedField?: string;
 } & CommonRelationshipType;
 
 export type GenericDataRelationshipType = HasManyRelationshipType | HasOneRelationshipType | BelongsToRelationshipType;

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -89,6 +89,28 @@ describe('UpdateForms', () => {
         });
       });
     });
+
+    it('should remove hasOne and belongsTo relationships', () => {
+      // reset state
+      cy.reload();
+
+      cy.get('#dataStoreFormUpdateAllSupportedFormFields').within(() => {
+        // hasOne
+        removeArrayItem('John Lennon');
+
+        // belongsTo
+        removeArrayItem('John');
+
+        cy.contains('Submit').click();
+
+        cy.contains(/My string/).then((recordElement: JQuery) => {
+          const record = JSON.parse(recordElement.text());
+
+          expect('HasOneUser' in record).to.equal(false);
+          expect('BelongsToOwner' in record).to.equal(false);
+        });
+      });
+    });
   });
 
   // this model & related models all use CPK


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We currently can't remove `hasOne` or `belongsTo` relationships.
It's a DataStore issue being tracked here https://github.com/aws-amplify/amplify-js/issues/10750
But in the meanwhile, this is the temporary solution.
Integration tests included.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
