### PR TITLE
chore: set primary key fields to read only

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -2758,7 +2758,7 @@ export default function UpdateCPKTeacherForm(props) {
       <TextField
         label=\\"Special teacher id\\"
         isRequired={true}
-        isReadOnly={false}
+        isReadOnly={true}
         defaultValue={specialTeacherId}
         onChange={(e) => {
           let { value } = e.target;

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -521,3 +521,47 @@ it('should skip adding id field if it has no overrides', () => {
   expect(formDefinition.elements).toStrictEqual({});
   expect(formDefinition.elementMatrix).toStrictEqual([]);
 });
+
+it('should make primary key read-only', () => {
+  const formDefinition = generateFormDefinition({
+    form: {
+      id: '123',
+      name: 'mySampleForm',
+      formActionType: 'create',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Student' },
+      fields: {
+        specialStudentId: { position: { below: 'Heading123' }, inputType: { type: 'TextField' } },
+        grade: { position: { rightOf: 'age' }, inputType: { type: 'TextField' } },
+        age: { position: { below: 'specialStudentId' }, inputType: { type: 'TextField' } },
+      },
+      sectionalElements: {
+        Heading123: { type: 'Heading', position: { fixed: 'first' }, level: 1, text: 'Create Student' },
+      },
+      style: {},
+      cta: {},
+    },
+    dataSchema: {
+      dataSourceType: 'DataStore',
+      enums: {},
+      nonModels: {},
+      models: {
+        Student: {
+          primaryKeys: ['specialStudentId'],
+          fields: {
+            id: { dataType: 'ID', readOnly: false, required: true, isArray: false },
+            specialStudentId: { dataType: 'ID', readOnly: false, required: true, isArray: false },
+            grade: { dataType: 'Int', readOnly: false, required: true, isArray: false },
+            age: { dataType: 'Int', readOnly: false, required: true, isArray: false },
+          },
+        },
+      },
+    },
+  });
+
+  expect(formDefinition.elementMatrix).toStrictEqual([['Heading123'], ['specialStudentId'], ['age', 'grade']]);
+  expect(formDefinition.elements.specialStudentId.props).toStrictEqual({
+    label: 'Special student id',
+    isRequired: true,
+    isReadOnly: true,
+  });
+});

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -121,7 +121,7 @@ describe('mapModelFieldsConfigs', () => {
         dataType: 'ID',
         inputType: {
           name: 'id',
-          readOnly: false,
+          readOnly: true,
           required: true,
           type: 'TextField',
           value: 'id',

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -85,10 +85,12 @@ export function getFieldConfigFromModelField({
   fieldName,
   field,
   dataSchema,
+  isPrimaryKey,
 }: {
   fieldName: string;
   field: GenericDataField;
   dataSchema: GenericDataSchema;
+  isPrimaryKey: boolean;
 }): ExtendedStudioGenericFieldConfig {
   const fieldTypeMapKey = getFieldTypeMapKey(field);
 
@@ -109,13 +111,18 @@ export function getFieldConfigFromModelField({
     dataType = { model: field.relationship.relatedModelName };
   }
 
+  let { readOnly } = field;
+  if (isPrimaryKey) {
+    readOnly = true;
+  }
+
   const config: ExtendedStudioGenericFieldConfig & { inputType: StudioFieldInputConfig } = {
     label: sentenceCase(fieldName),
     dataType,
     inputType: {
       type: defaultComponent,
       required: field.required,
-      readOnly: field.readOnly,
+      readOnly,
       name: fieldName,
       value: fieldName,
       isArray: field.isArray,
@@ -164,7 +171,9 @@ export function mapModelFieldsConfigs({
       formDefinition.elementMatrix.push([fieldName]);
     }
 
-    modelFieldsConfigs[fieldName] = getFieldConfigFromModelField({ fieldName, field, dataSchema });
+    const isPrimaryKey = model.primaryKeys.includes(fieldName);
+
+    modelFieldsConfigs[fieldName] = getFieldConfigFromModelField({ fieldName, field, dataSchema, isPrimaryKey });
   });
 
   return modelFieldsConfigs;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update model field config to set field's readOnly value to true if the field is a primary key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
