### PR TITLE
chore: account for all associated fields in automapping and removing …

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -2458,8 +2458,6 @@ export default function UpdateCompositeDogForm(props) {
     CompositeOwner: undefined,
     CompositeToys: [],
     CompositeVets: [],
-    compositeDogCompositeBowlSize: undefined,
-    compositeDogCompositeOwnerFirstName: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
   const [description, setDescription] = React.useState(
@@ -2477,12 +2475,6 @@ export default function UpdateCompositeDogForm(props) {
   const [CompositeVets, setCompositeVets] = React.useState(
     initialValues.CompositeVets
   );
-  const [compositeDogCompositeBowlSize, setCompositeDogCompositeBowlSize] =
-    React.useState(initialValues.compositeDogCompositeBowlSize);
-  const [
-    compositeDogCompositeOwnerFirstName,
-    setCompositeDogCompositeOwnerFirstName,
-  ] = React.useState(initialValues.compositeDogCompositeOwnerFirstName);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     const cleanValues = compositeDogRecord
@@ -2509,10 +2501,6 @@ export default function UpdateCompositeDogForm(props) {
     setCompositeVets(cleanValues.CompositeVets ?? []);
     setCurrentCompositeVetsValue(undefined);
     setCurrentCompositeVetsDisplayValue(\\"\\");
-    setCompositeDogCompositeBowlSize(cleanValues.compositeDogCompositeBowlSize);
-    setCompositeDogCompositeOwnerFirstName(
-      cleanValues.compositeDogCompositeOwnerFirstName
-    );
     setErrors({});
   };
   const [compositeDogRecord, setCompositeDogRecord] =
@@ -2642,8 +2630,6 @@ export default function UpdateCompositeDogForm(props) {
     CompositeOwner: [],
     CompositeToys: [],
     CompositeVets: [],
-    compositeDogCompositeBowlSize: [],
-    compositeDogCompositeOwnerFirstName: [],
   };
   const runValidationTasks = async (
     fieldName,
@@ -2676,8 +2662,6 @@ export default function UpdateCompositeDogForm(props) {
           CompositeOwner,
           CompositeToys,
           CompositeVets,
-          compositeDogCompositeBowlSize,
-          compositeDogCompositeOwnerFirstName,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -2815,10 +2799,14 @@ export default function UpdateCompositeDogForm(props) {
             DataStore.save(
               CompositeDog.copyOf(compositeDogRecord, (updated) => {
                 Object.assign(updated, modelFields);
-                if (!modelFields.CompositeBowl)
+                if (!modelFields.CompositeBowl) {
                   updated.compositeDogCompositeBowlShape = undefined;
-                if (!modelFields.CompositeOwner)
+                  updated.compositeDogCompositeBowlSize = undefined;
+                }
+                if (!modelFields.CompositeOwner) {
                   updated.compositeDogCompositeOwnerLastName = undefined;
+                  updated.compositeDogCompositeOwnerFirstName = undefined;
+                }
               })
             )
           );
@@ -2850,8 +2838,6 @@ export default function UpdateCompositeDogForm(props) {
               CompositeOwner,
               CompositeToys,
               CompositeVets,
-              compositeDogCompositeBowlSize,
-              compositeDogCompositeOwnerFirstName,
             };
             const result = onChange(modelFields);
             value = result?.name ?? value;
@@ -2881,8 +2867,6 @@ export default function UpdateCompositeDogForm(props) {
               CompositeOwner,
               CompositeToys,
               CompositeVets,
-              compositeDogCompositeBowlSize,
-              compositeDogCompositeOwnerFirstName,
             };
             const result = onChange(modelFields);
             value = result?.description ?? value;
@@ -2909,8 +2893,6 @@ export default function UpdateCompositeDogForm(props) {
               CompositeOwner,
               CompositeToys,
               CompositeVets,
-              compositeDogCompositeBowlSize,
-              compositeDogCompositeOwnerFirstName,
             };
             const result = onChange(modelFields);
             value = result?.CompositeBowl ?? value;
@@ -2988,8 +2970,6 @@ export default function UpdateCompositeDogForm(props) {
               CompositeOwner: value,
               CompositeToys,
               CompositeVets,
-              compositeDogCompositeBowlSize,
-              compositeDogCompositeOwnerFirstName,
             };
             const result = onChange(modelFields);
             value = result?.CompositeOwner ?? value;
@@ -3066,8 +3046,6 @@ export default function UpdateCompositeDogForm(props) {
               CompositeOwner,
               CompositeToys: values,
               CompositeVets,
-              compositeDogCompositeBowlSize,
-              compositeDogCompositeOwnerFirstName,
             };
             const result = onChange(modelFields);
             values = result?.CompositeToys ?? values;
@@ -3145,8 +3123,6 @@ export default function UpdateCompositeDogForm(props) {
               CompositeOwner,
               CompositeToys,
               CompositeVets: values,
-              compositeDogCompositeBowlSize,
-              compositeDogCompositeOwnerFirstName,
             };
             const result = onChange(modelFields);
             values = result?.CompositeVets ?? values;
@@ -3213,78 +3189,6 @@ export default function UpdateCompositeDogForm(props) {
           {...getOverrideProps(overrides, \\"CompositeVets\\")}
         ></Autocomplete>
       </ArrayField>
-      <TextField
-        label=\\"Composite dog composite bowl size\\"
-        isRequired={false}
-        isReadOnly={false}
-        defaultValue={compositeDogCompositeBowlSize}
-        onChange={(e) => {
-          let { value } = e.target;
-          if (onChange) {
-            const modelFields = {
-              name,
-              description,
-              CompositeBowl,
-              CompositeOwner,
-              CompositeToys,
-              CompositeVets,
-              compositeDogCompositeBowlSize: value,
-              compositeDogCompositeOwnerFirstName,
-            };
-            const result = onChange(modelFields);
-            value = result?.compositeDogCompositeBowlSize ?? value;
-          }
-          if (errors.compositeDogCompositeBowlSize?.hasError) {
-            runValidationTasks(\\"compositeDogCompositeBowlSize\\", value);
-          }
-          setCompositeDogCompositeBowlSize(value);
-        }}
-        onBlur={() =>
-          runValidationTasks(
-            \\"compositeDogCompositeBowlSize\\",
-            compositeDogCompositeBowlSize
-          )
-        }
-        errorMessage={errors.compositeDogCompositeBowlSize?.errorMessage}
-        hasError={errors.compositeDogCompositeBowlSize?.hasError}
-        {...getOverrideProps(overrides, \\"compositeDogCompositeBowlSize\\")}
-      ></TextField>
-      <TextField
-        label=\\"Composite dog composite owner first name\\"
-        isRequired={false}
-        isReadOnly={false}
-        defaultValue={compositeDogCompositeOwnerFirstName}
-        onChange={(e) => {
-          let { value } = e.target;
-          if (onChange) {
-            const modelFields = {
-              name,
-              description,
-              CompositeBowl,
-              CompositeOwner,
-              CompositeToys,
-              CompositeVets,
-              compositeDogCompositeBowlSize,
-              compositeDogCompositeOwnerFirstName: value,
-            };
-            const result = onChange(modelFields);
-            value = result?.compositeDogCompositeOwnerFirstName ?? value;
-          }
-          if (errors.compositeDogCompositeOwnerFirstName?.hasError) {
-            runValidationTasks(\\"compositeDogCompositeOwnerFirstName\\", value);
-          }
-          setCompositeDogCompositeOwnerFirstName(value);
-        }}
-        onBlur={() =>
-          runValidationTasks(
-            \\"compositeDogCompositeOwnerFirstName\\",
-            compositeDogCompositeOwnerFirstName
-          )
-        }
-        errorMessage={errors.compositeDogCompositeOwnerFirstName?.errorMessage}
-        hasError={errors.compositeDogCompositeOwnerFirstName?.hasError}
-        {...getOverrideProps(overrides, \\"compositeDogCompositeOwnerFirstName\\")}
-      ></TextField>
       <Flex
         justifyContent=\\"space-between\\"
         {...getOverrideProps(overrides, \\"CTAFlex\\")}
@@ -3331,8 +3235,6 @@ export declare type UpdateCompositeDogFormInputValues = {
     CompositeOwner?: CompositeOwner0;
     CompositeToys?: CompositeToy[];
     CompositeVets?: CompositeVet[];
-    compositeDogCompositeBowlSize?: string;
-    compositeDogCompositeOwnerFirstName?: string;
 };
 export declare type UpdateCompositeDogFormValidationValues = {
     name?: ValidationFunction<string>;
@@ -3341,8 +3243,6 @@ export declare type UpdateCompositeDogFormValidationValues = {
     CompositeOwner?: ValidationFunction<CompositeOwner0>;
     CompositeToys?: ValidationFunction<CompositeToy>;
     CompositeVets?: ValidationFunction<CompositeVet>;
-    compositeDogCompositeBowlSize?: ValidationFunction<string>;
-    compositeDogCompositeOwnerFirstName?: ValidationFunction<string>;
 };
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type UpdateCompositeDogFormOverridesProps = {
@@ -3353,8 +3253,6 @@ export declare type UpdateCompositeDogFormOverridesProps = {
     CompositeOwner?: PrimitiveOverrideProps<AutocompleteProps>;
     CompositeToys?: PrimitiveOverrideProps<AutocompleteProps>;
     CompositeVets?: PrimitiveOverrideProps<AutocompleteProps>;
-    compositeDogCompositeBowlSize?: PrimitiveOverrideProps<TextFieldProps>;
-    compositeDogCompositeOwnerFirstName?: PrimitiveOverrideProps<TextFieldProps>;
 } & EscapeHatchProps;
 export declare type UpdateCompositeDogFormProps = React.PropsWithChildren<{
     overrides?: UpdateCompositeDogFormOverridesProps | undefined | null;
@@ -3853,8 +3751,9 @@ export default function UpdateCPKTeacherForm(props) {
             DataStore.save(
               CPKTeacher.copyOf(cPKTeacherRecord, (updated) => {
                 Object.assign(updated, modelFields);
-                if (!modelFields.CPKStudent)
+                if (!modelFields.CPKStudent) {
                   updated.cPKTeacherCPKStudentId = undefined;
+                }
               })
             )
           );
@@ -10359,7 +10258,9 @@ export default function MyMemberForm(props) {
           await DataStore.save(
             Member.copyOf(memberRecord, (updated) => {
               Object.assign(updated, modelFields);
-              if (!modelFields.Team) updated.teamMembersId = undefined;
+              if (!modelFields.Team) {
+                updated.teamMembersId = undefined;
+              }
             })
           );
           if (onSuccess) {

--- a/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
@@ -1701,3 +1701,507 @@ export const schemaWithCPK: Schema = {
   version: '38a1a46479c6cd75d21439d7f3122c1d',
   codegenVersion: '000000',
 };
+
+export const schemaWithCompositeKeys: Schema = {
+  models: {
+    CompositeDog: {
+      name: 'CompositeDog',
+      fields: {
+        name: {
+          name: 'name',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        description: {
+          name: 'description',
+          isArray: false,
+          type: 'String',
+          isRequired: true,
+          attributes: [],
+        },
+        CompositeBowl: {
+          name: 'CompositeBowl',
+          isArray: false,
+          type: {
+            model: 'CompositeBowl',
+          },
+          isRequired: false,
+          attributes: [],
+          association: {
+            connectionType: 'HAS_ONE',
+            associatedWith: ['shape', 'size'],
+            targetNames: ['compositeDogCompositeBowlShape', 'compositeDogCompositeBowlSize'],
+          },
+        },
+        CompositeOwner: {
+          name: 'CompositeOwner',
+          isArray: false,
+          type: {
+            model: 'CompositeOwner',
+          },
+          isRequired: false,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['compositeDogCompositeOwnerLastName', 'compositeDogCompositeOwnerFirstName'],
+          },
+        },
+        CompositeToys: {
+          name: 'CompositeToys',
+          isArray: true,
+          type: {
+            model: 'CompositeToy',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['compositeDogCompositeToysName', 'compositeDogCompositeToysDescription'],
+          },
+        },
+        CompositeVets: {
+          name: 'CompositeVets',
+          isArray: true,
+          type: {
+            model: 'CompositeDogCompositeVet',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['compositeDog'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        compositeDogCompositeBowlShape: {
+          name: 'compositeDogCompositeBowlShape',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeDogCompositeBowlSize: {
+          name: 'compositeDogCompositeBowlSize',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeDogCompositeOwnerLastName: {
+          name: 'compositeDogCompositeOwnerLastName',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeDogCompositeOwnerFirstName: {
+          name: 'compositeDogCompositeOwnerFirstName',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+      },
+      syncable: true,
+      pluralName: 'CompositeDogs',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['name', 'description'],
+          },
+        },
+      ],
+    },
+    CompositeBowl: {
+      name: 'CompositeBowl',
+      fields: {
+        shape: {
+          name: 'shape',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        size: {
+          name: 'size',
+          isArray: false,
+          type: 'String',
+          isRequired: true,
+          attributes: [],
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'CompositeBowls',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['shape', 'size'],
+          },
+        },
+      ],
+    },
+    CompositeOwner: {
+      name: 'CompositeOwner',
+      fields: {
+        lastName: {
+          name: 'lastName',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        firstName: {
+          name: 'firstName',
+          isArray: false,
+          type: 'String',
+          isRequired: true,
+          attributes: [],
+        },
+        CompositeDog: {
+          name: 'CompositeDog',
+          isArray: false,
+          type: {
+            model: 'CompositeDog',
+          },
+          isRequired: false,
+          attributes: [],
+          association: {
+            connectionType: 'HAS_ONE',
+            associatedWith: ['CompositeOwner'],
+            targetNames: ['compositeOwnerCompositeDogName', 'compositeOwnerCompositeDogDescription'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        compositeOwnerCompositeDogName: {
+          name: 'compositeOwnerCompositeDogName',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeOwnerCompositeDogDescription: {
+          name: 'compositeOwnerCompositeDogDescription',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+      },
+      syncable: true,
+      pluralName: 'CompositeOwners',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['lastName', 'firstName'],
+          },
+        },
+      ],
+    },
+    CompositeToy: {
+      name: 'CompositeToy',
+      fields: {
+        kind: {
+          name: 'kind',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        color: {
+          name: 'color',
+          isArray: false,
+          type: 'String',
+          isRequired: true,
+          attributes: [],
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        compositeDogCompositeToysName: {
+          name: 'compositeDogCompositeToysName',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeDogCompositeToysDescription: {
+          name: 'compositeDogCompositeToysDescription',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+      },
+      syncable: true,
+      pluralName: 'CompositeToys',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['kind', 'color'],
+          },
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'gsi-CompositeDog.CompositeToys',
+            fields: ['compositeDogCompositeToysName', 'compositeDogCompositeToysDescription'],
+          },
+        },
+      ],
+    },
+    CompositeVet: {
+      name: 'CompositeVet',
+      fields: {
+        specialty: {
+          name: 'specialty',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        city: {
+          name: 'city',
+          isArray: false,
+          type: 'String',
+          isRequired: true,
+          attributes: [],
+        },
+        CompositeDogs: {
+          name: 'CompositeDogs',
+          isArray: true,
+          type: {
+            model: 'CompositeDogCompositeVet',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['compositeVet'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'CompositeVets',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['specialty', 'city'],
+          },
+        },
+      ],
+    },
+    CompositeDogCompositeVet: {
+      name: 'CompositeDogCompositeVet',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        compositeDogName: {
+          name: 'compositeDogName',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeDogdescription: {
+          name: 'compositeDogdescription',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeVetSpecialty: {
+          name: 'compositeVetSpecialty',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeVetcity: {
+          name: 'compositeVetcity',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        compositeDog: {
+          name: 'compositeDog',
+          isArray: false,
+          type: {
+            model: 'CompositeDog',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['compositeDogName', 'compositeDogdescription'],
+          },
+        },
+        compositeVet: {
+          name: 'compositeVet',
+          isArray: false,
+          type: {
+            model: 'CompositeVet',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['compositeVetSpecialty', 'compositeVetcity'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'CompositeDogCompositeVets',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCompositeDog',
+            fields: ['compositeDogName', 'compositeDogdescription'],
+          },
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCompositeVet',
+            fields: ['compositeVetSpecialty', 'compositeVetcity'],
+          },
+        },
+      ],
+    },
+  },
+  enums: {},
+  nonModels: {},
+  codegenVersion: '3.3.2',
+  version: '8f8e59ee8fb2e3ca4efda3aa25b0211f',
+};

--- a/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
@@ -22,6 +22,7 @@ import {
   schemaWithRelationshipsV2,
   schemaWithAssumptions,
   schemaWithCPK,
+  schemaWithCompositeKeys,
 } from './__utils__/mock-schemas';
 
 describe('getGenericFromDataStore', () => {
@@ -61,7 +62,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.PrimaryCareGiver.fields.Child.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Child',
-      associatedField: 'primaryCareGiverChildId',
+      associatedFields: ['primaryCareGiverChildId'],
     });
 
     expect(genericSchema.models.PrimaryCareGiver.fields.primaryCareGiverChildId.relationship).toStrictEqual({
@@ -88,7 +89,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Lock.fields.Key.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Key',
-      associatedField: 'lockKeyId',
+      associatedFields: ['lockKeyId'],
     });
 
     expect(genericSchema.models.Lock.fields.lockKeyId.relationship).toStrictEqual({
@@ -99,7 +100,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Key.fields.Lock.relationship).toStrictEqual({
       type: 'BELONGS_TO',
       relatedModelName: 'Lock',
-      associatedField: 'keyLockId',
+      associatedFields: ['keyLockId'],
     });
 
     expect(genericSchema.models.Owner.fields.Dog.relationship).toStrictEqual<HasManyRelationshipType>({
@@ -122,7 +123,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.PrimaryCareGiver.fields.Child.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Child',
-      associatedField: 'primaryCareGiverChildId',
+      associatedFields: ['primaryCareGiverChildId'],
     });
 
     expect(genericSchema.models.PrimaryCareGiver.fields.primaryCareGiverChildId.relationship).toStrictEqual({
@@ -149,7 +150,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Lock.fields.Key.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Key',
-      associatedField: 'lockKeyId',
+      associatedFields: ['lockKeyId'],
     });
 
     expect(genericSchema.models.Lock.fields.lockKeyId.relationship).toStrictEqual({
@@ -160,7 +161,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Key.fields.Lock.relationship).toStrictEqual({
       type: 'BELONGS_TO',
       relatedModelName: 'Lock',
-      associatedField: 'keyLockId',
+      associatedFields: ['keyLockId'],
     });
 
     expect(genericSchema.models.Owner.fields.Dog.relationship).toStrictEqual<HasManyRelationshipType>({
@@ -232,5 +233,21 @@ describe('getGenericFromDataStore', () => {
     expect(models.Dog.primaryKeys).toStrictEqual(['id']);
     expect(models.Student.primaryKeys).toStrictEqual(['specialStudentId', 'grade', 'age']);
     expect(models.Teacher.primaryKeys).toStrictEqual(['specialTeacherId']);
+  });
+
+  it('should correctly map model with composite keys', () => {
+    const genericSchema = getGenericFromDataStore(schemaWithCompositeKeys);
+    const { CompositeDog } = genericSchema.models;
+    expect(CompositeDog.primaryKeys).toStrictEqual(['name', 'description']);
+    expect(CompositeDog.fields.CompositeBowl.relationship).toStrictEqual({
+      type: 'HAS_ONE',
+      relatedModelName: 'CompositeBowl',
+      associatedFields: ['compositeDogCompositeBowlShape', 'compositeDogCompositeBowlSize'],
+    });
+    expect(CompositeDog.fields.CompositeOwner.relationship).toStrictEqual({
+      type: 'BELONGS_TO',
+      relatedModelName: 'CompositeOwner',
+      associatedFields: ['compositeDogCompositeOwnerLastName', 'compositeDogCompositeOwnerFirstName'],
+    });
   });
 });

--- a/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
@@ -123,7 +123,7 @@ describe('mapFormMetaData', () => {
     expect(fieldConfigs.Student.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Student',
-      associatedField: 'TeacherStudentId',
+      associatedFields: ['TeacherStudentId'],
     });
   });
 

--- a/packages/codegen-ui/lib/generic-from-datastore.ts
+++ b/packages/codegen-ui/lib/generic-from-datastore.ts
@@ -143,14 +143,24 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
             ('targetName' in field.association || 'targetNames' in field.association) &&
             (field.association.targetName || field.association.targetNames)
           ) {
-            const targetName = field.association.targetName || field.association.targetNames?.[0];
-            if (targetName) {
-              addRelationship(fieldsWithImplicitRelationships, model.name, targetName, {
-                type: relationshipType,
-                relatedModelName,
+            const targetNames = field.association.targetName
+              ? [field.association.targetName]
+              : field.association.targetNames;
+            const associatedFields: string[] = [];
+            if (targetNames) {
+              targetNames.forEach((targetName) => {
+                addRelationship(fieldsWithImplicitRelationships, model.name, targetName, {
+                  type: relationshipType,
+                  relatedModelName,
+                });
+                associatedFields.push(targetName);
               });
-              modelRelationship = { type: relationshipType, relatedModelName, associatedField: targetName };
             }
+            modelRelationship = {
+              type: relationshipType,
+              relatedModelName,
+              associatedFields: associatedFields.length ? associatedFields : undefined,
+            };
           }
 
           genericField.relationship = modelRelationship;

--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -43,12 +43,12 @@ export type HasManyRelationshipType = {
 
 export type HasOneRelationshipType = {
   type: 'HAS_ONE';
-  associatedField?: string;
+  associatedFields?: string[];
 } & CommonRelationshipType;
 
 export type BelongsToRelationshipType = {
   type: 'BELONGS_TO';
-  associatedField?: string;
+  associatedFields?: string[];
 } & CommonRelationshipType;
 
 export type GenericDataRelationshipType = HasManyRelationshipType | HasOneRelationshipType | BelongsToRelationshipType;


### PR DESCRIPTION
…relationship logic

*Issue #, if available:*

*Description of changes:*
- exclude all scalar fields associated with models from auto-mapping, not just the first one
- update unlinking logic for hasOne and belongsTo to include all associated fields, not just the first one


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
