### PR TITLE
feat: add getAliasMap method to importCollection

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -292,6 +292,10 @@ describe('amplify form renderer tests', () => {
         'datastore/project-team-model',
       );
 
+      const aliasMap = importCollection.getAliasMap();
+      expect(aliasMap.model.Team).toBe('Team0');
+      expect(aliasMap.model.Member).toBe('Member');
+
       const teamAlias = importCollection.getMappedAlias(ImportSource.LOCAL_MODELS, 'Team');
 
       const includesTeam = requiredDataModels.includes('Team');

--- a/packages/codegen-ui-react/lib/imports/import-collection.ts
+++ b/packages/codegen-ui-react/lib/imports/import-collection.ts
@@ -109,6 +109,19 @@ export class ImportCollection {
     ];
   }
 
+  getAliasMap(): { model: { [modelName: string]: string } } {
+    const modelMap: { [modelName: string]: string } = {};
+    const modelSet = this.#collection.get(ImportSource.LOCAL_MODELS);
+    const modelAliases = this.importAlias.get(ImportSource.LOCAL_MODELS);
+    if (modelSet) {
+      [...modelSet].forEach((item) => {
+        const alias = modelAliases?.get(item);
+        if (alias) modelMap[item] = alias;
+      });
+    }
+    return { model: modelMap };
+  }
+
   buildImportStatements(skipReactImport?: boolean): ImportDeclaration[] {
     const importDeclarations = ([] as ImportDeclaration[])
       .concat(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CMSv2 team is asking for an interface that would allow them to use just `importCollection` and get rid of dependency on `requiredDataModels`. This adds a method to `importCollection` that would let them do this easily.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
