### PR TITLE
test: change schemas for cpk tests

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3711,8 +3711,10 @@ export default function UpdateCPKTeacherForm(props) {
                 r.and((r) => {
                   const recordKeys = JSON.parse(id);
                   return [
-                    r.cpkClassID.eq(recordKeys.specialClassId),
-                    r.cpkTeacherID.eq(cPKTeacherRecord.specialTeacherId),
+                    r.cPKClassSpecialClassId.eq(recordKeys.specialClassId),
+                    r.cPKTeacherSpecialTeacherId.eq(
+                      cPKTeacherRecord.specialTeacherId
+                    ),
                   ];
                 })
             );
@@ -3779,7 +3781,7 @@ export default function UpdateCPKTeacherForm(props) {
               CPKTeacher.copyOf(cPKTeacherRecord, (updated) => {
                 Object.assign(updated, modelFields);
                 if (!modelFields.CPKStudent) {
-                  updated.cPKTeacherCPKStudentId = undefined;
+                  updated.cPKTeacherCPKStudentSpecialStudentId = undefined;
                 }
               })
             )

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -393,7 +393,7 @@ describe('amplify form renderer tests', () => {
         expect(componentText).toContain('cPKClassesMap.set(getIDValue.CPKClasses?.(r), newCount)');
         expect(componentText).toContain('const count = linkedCPKClassesMap.get(getIDValue.CPKClasses?.(r))');
         expect(componentText).toContain('linkedCPKClassesMap.set(getIDValue.CPKClasses?.(r), newCount)');
-        expect(componentText).toContain('r.cpkTeacherID.eq(cPKTeacherRecord.specialTeacherId)');
+        expect(componentText).toContain('r.cPKTeacherSpecialTeacherId.eq');
         expect(componentText).toContain('cpkTeacher: cPKTeacherRecord');
 
         // hasMany

--- a/packages/codegen-ui/example-schemas/datastore/cpk-relationships.json
+++ b/packages/codegen-ui/example-schemas/datastore/cpk-relationships.json
@@ -1,246 +1,213 @@
 {
-    "models": {
-        "CPKStudent": {
-            "name": "CPKStudent",
-            "fields": {
-              "id": {
-                "name": "id",
-                "isArray": false,
-                "type": "ID",
-                "isRequired": true,
-                "attributes": []
-              },
-              "specialStudentId": {
-                "name": "specialStudentId",
-                "isArray": false,
-                "type": "ID",
-                "isRequired": true,
-                "attributes": []
-              },
-              "createdAt": {
-                "name": "createdAt",
-                "isArray": false,
-                "type": "AWSDateTime",
-                "isRequired": false,
-                "attributes": [],
-                "isReadOnly": true
-              },
-              "updatedAt": {
-                "name": "updatedAt",
-                "isArray": false,
-                "type": "AWSDateTime",
-                "isRequired": false,
-                "attributes": [],
-                "isReadOnly": true
-              }
-            },
-            "syncable": true,
-            "pluralName": "Students",
-            "attributes": [
-              {
-                "type": "model",
-                "properties": {}
-              },
-              {
-                "type": "key",
-                "properties": {
-                  "fields": [
-                    "specialStudentId"
-                  ]
-                }
-              }
-            ]
-          },
-          "CPKTeacherCPKClass": {
-            "name": "CPKTeacherCPKClass",
-            "fields": {
-              "id": {
-                "name": "id",
-                "isArray": false,
-                "type": "ID",
-                "isRequired": true,
-                "attributes": []
-              },
-              "cpkTeacher": {
-                "name": "cpkTeacher",
-                "isArray": false,
-                "type": {
-                  "model": "CPKTeacher"
-                },
-                "isRequired": true,
-                "attributes": [],
-                "association": {
-                  "connectionType": "BELONGS_TO",
-                  "targetName": "cpkTeacherID"
-                }
-              },
-              "cpkClass": {
-                "name": "cpkClass",
-                "isArray": false,
-                "type": {
-                  "model": "CPKClass"
-                },
-                "isRequired": true,
-                "attributes": [],
-                "association": {
-                  "connectionType": "BELONGS_TO",
-                  "targetName": "cpkClassID"
-                }
-              },
-              "createdAt": {
-                "name": "createdAt",
-                "isArray": false,
-                "type": "AWSDateTime",
-                "isRequired": false,
-                "attributes": [],
-                "isReadOnly": true
-              },
-              "updatedAt": {
-                "name": "updatedAt",
-                "isArray": false,
-                "type": "AWSDateTime",
-                "isRequired": false,
-                "attributes": [],
-                "isReadOnly": true
-              }
-            },
-            "syncable": true,
-            "pluralName": "CPKTeacherCPKClasses",
-            "attributes": [
-              {
-                "type": "model",
-                "properties": {}
-              },
-              {
-                "type": "key",
-                "properties": {
-                  "name": "byCPKTeacher",
-                  "fields": [
-                    "cpkTeacherID"
-                  ]
-                }
-              },
-              {
-                "type": "key",
-                "properties": {
-                  "name": "byCPKClass",
-                  "fields": [
-                    "cpkClassID"
-                  ]
-                }
-              }
-            ]
-          },
-          "CPKTeacher": {
-            "name": "CPKTeacher",
-            "fields": {
-                "id": {
-                    "name": "id",
-                    "isArray": false,
-                    "type": "ID",
-                    "isRequired": true,
-                    "attributes": []
-                },
-                "specialTeacherId": {
-                    "name": "specialTeacherId",
-                    "isArray": false,
-                    "type": "ID",
-                    "isRequired": true,
-                    "attributes": []
-                },
-                "CPKStudent": {
-                    "name": "CPKStudent",
-                    "isArray": false,
-                    "type": {
-                        "model": "CPKStudent"
-                    },
-                    "isRequired": false,
-                    "attributes": [],
-                    "association": {
-                        "connectionType": "HAS_ONE",
-                        "associatedWith": "specialStudentId",
-                        "targetName": "cPKTeacherCPKStudentId"
-                    }
-                },
-                "CPKClasses": {
-                    "name": "CPKClasses",
-                    "isArray": true,
-                    "type": {
-                        "model": "CPKTeacherCPKClass"
-                    },
-                    "isRequired": false,
-                    "attributes": [],
-                    "isArrayNullable": true,
-                    "association": {
-                        "connectionType": "HAS_MANY",
-                        "associatedWith": "cpkTeacher"
-                    }
-                },
-                "CPKProjects": {
-                    "name": "CPKProjects",
-                    "isArray": true,
-                    "type": {
-                        "model": "CPKProject"
-                    },
-                    "isRequired": false,
-                    "attributes": [],
-                    "isArrayNullable": true,
-                    "association": {
-                        "connectionType": "HAS_MANY",
-                        "associatedWith": "cPKTeacherID"
-                    }
-                },
-                "createdAt": {
-                    "name": "createdAt",
-                    "isArray": false,
-                    "type": "AWSDateTime",
-                    "isRequired": false,
-                    "attributes": [],
-                    "isReadOnly": true
-                },
-                "updatedAt": {
-                    "name": "updatedAt",
-                    "isArray": false,
-                    "type": "AWSDateTime",
-                    "isRequired": false,
-                    "attributes": [],
-                    "isReadOnly": true
-                },
-                "cPKTeacherCPKStudentId": {
-                    "name": "cPKTeacherCPKStudentId",
-                    "isArray": false,
-                    "type": "ID",
-                    "isRequired": false,
-                    "attributes": []
-                }
-            },
-            "syncable": true,
-            "pluralName": "CPKTeachers",
-            "attributes": [
-                {
-                    "type": "model",
-                    "properties": {}
-                },
-                {
-                    "type": "key",
-                    "properties": {
-                        "fields": [
-                            "specialTeacherId"
-                        ]
-                    }
-                }
-            ]
-        },
-        "CPKProject": {
-          "name": "CPKProject",
+  "models": {
+      "CPKStudent": {
+          "name": "CPKStudent",
           "fields": {
-              "id": {
-                  "name": "id",
+              "specialStudentId": {
+                  "name": "specialStudentId",
                   "isArray": false,
                   "type": "ID",
                   "isRequired": true,
                   "attributes": []
               },
+              "createdAt": {
+                  "name": "createdAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
+              },
+              "updatedAt": {
+                  "name": "updatedAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
+              }
+          },
+          "syncable": true,
+          "pluralName": "CPKStudents",
+          "attributes": [
+              {
+                  "type": "model",
+                  "properties": {}
+              },
+              {
+                  "type": "key",
+                  "properties": {
+                      "fields": [
+                          "specialStudentId"
+                      ]
+                  }
+              }
+          ]
+      },
+      "CPKTeacher": {
+          "name": "CPKTeacher",
+          "fields": {
+              "specialTeacherId": {
+                  "name": "specialTeacherId",
+                  "isArray": false,
+                  "type": "ID",
+                  "isRequired": true,
+                  "attributes": []
+              },
+              "CPKStudent": {
+                  "name": "CPKStudent",
+                  "isArray": false,
+                  "type": {
+                      "model": "CPKStudent"
+                  },
+                  "isRequired": false,
+                  "attributes": [],
+                  "association": {
+                      "connectionType": "HAS_ONE",
+                      "associatedWith": [
+                          "specialStudentId"
+                      ],
+                      "targetNames": [
+                          "cPKTeacherCPKStudentSpecialStudentId"
+                      ]
+                  }
+              },
+              "CPKClasses": {
+                  "name": "CPKClasses",
+                  "isArray": true,
+                  "type": {
+                      "model": "CPKTeacherCPKClass"
+                  },
+                  "isRequired": false,
+                  "attributes": [],
+                  "isArrayNullable": true,
+                  "association": {
+                      "connectionType": "HAS_MANY",
+                      "associatedWith": [
+                          "cpkTeacher"
+                      ]
+                  }
+              },
+              "CPKProjects": {
+                  "name": "CPKProjects",
+                  "isArray": true,
+                  "type": {
+                      "model": "CPKProject"
+                  },
+                  "isRequired": false,
+                  "attributes": [],
+                  "isArrayNullable": true,
+                  "association": {
+                      "connectionType": "HAS_MANY",
+                      "associatedWith": [
+                          "cPKTeacherID"
+                      ]
+                  }
+              },
+              "createdAt": {
+                  "name": "createdAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
+              },
+              "updatedAt": {
+                  "name": "updatedAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
+              },
+              "cPKTeacherCPKStudentSpecialStudentId": {
+                  "name": "cPKTeacherCPKStudentSpecialStudentId",
+                  "isArray": false,
+                  "type": "ID",
+                  "isRequired": false,
+                  "attributes": []
+              }
+          },
+          "syncable": true,
+          "pluralName": "CPKTeachers",
+          "attributes": [
+              {
+                  "type": "model",
+                  "properties": {}
+              },
+              {
+                  "type": "key",
+                  "properties": {
+                      "fields": [
+                          "specialTeacherId"
+                      ]
+                  }
+              }
+          ]
+      },
+      "CPKClass": {
+          "name": "CPKClass",
+          "fields": {
+              "specialClassId": {
+                  "name": "specialClassId",
+                  "isArray": false,
+                  "type": "ID",
+                  "isRequired": true,
+                  "attributes": []
+              },
+              "CPKTeachers": {
+                  "name": "CPKTeachers",
+                  "isArray": true,
+                  "type": {
+                      "model": "CPKTeacherCPKClass"
+                  },
+                  "isRequired": false,
+                  "attributes": [],
+                  "isArrayNullable": true,
+                  "association": {
+                      "connectionType": "HAS_MANY",
+                      "associatedWith": [
+                          "cpkClass"
+                      ]
+                  }
+              },
+              "createdAt": {
+                  "name": "createdAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
+              },
+              "updatedAt": {
+                  "name": "updatedAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
+              }
+          },
+          "syncable": true,
+          "pluralName": "CPKClasses",
+          "attributes": [
+              {
+                  "type": "model",
+                  "properties": {}
+              },
+              {
+                  "type": "key",
+                  "properties": {
+                      "fields": [
+                          "specialClassId"
+                      ]
+                  }
+              }
+          ]
+      },
+      "CPKProject": {
+          "name": "CPKProject",
+          "fields": {
               "specialProjectId": {
                   "name": "specialProjectId",
                   "isArray": false,
@@ -298,74 +265,107 @@
               }
           ]
       },
-          "CPKClass": {
-            "name": "CPKClass",
-            "fields": {
+      "CPKTeacherCPKClass": {
+          "name": "CPKTeacherCPKClass",
+          "fields": {
               "id": {
-                "name": "id",
-                "isArray": false,
-                "type": "ID",
-                "isRequired": true,
-                "attributes": []
+                  "name": "id",
+                  "isArray": false,
+                  "type": "ID",
+                  "isRequired": true,
+                  "attributes": []
               },
-              "specialClassId": {
-                "name": "specialClassId",
-                "isArray": false,
-                "type": "ID",
-                "isRequired": true,
-                "attributes": []
+              "cPKTeacherSpecialTeacherId": {
+                  "name": "cPKTeacherSpecialTeacherId",
+                  "isArray": false,
+                  "type": "ID",
+                  "isRequired": false,
+                  "attributes": []
               },
-              "CPKTeachers": {
-                "name": "CPKTeachers",
-                "isArray": true,
-                "type": {
-                  "model": "CPKTeacherCPKClass"
-                },
-                "isRequired": false,
-                "attributes": [],
-                "isArrayNullable": true,
-                "association": {
-                  "connectionType": "HAS_MANY",
-                  "associatedWith": "cpkClass"
-                }
+              "cPKClassSpecialClassId": {
+                  "name": "cPKClassSpecialClassId",
+                  "isArray": false,
+                  "type": "ID",
+                  "isRequired": false,
+                  "attributes": []
+              },
+              "cpkTeacher": {
+                  "name": "cpkTeacher",
+                  "isArray": false,
+                  "type": {
+                      "model": "CPKTeacher"
+                  },
+                  "isRequired": true,
+                  "attributes": [],
+                  "association": {
+                      "connectionType": "BELONGS_TO",
+                      "targetNames": [
+                          "cPKTeacherSpecialTeacherId"
+                      ]
+                  }
+              },
+              "cpkClass": {
+                  "name": "cpkClass",
+                  "isArray": false,
+                  "type": {
+                      "model": "CPKClass"
+                  },
+                  "isRequired": true,
+                  "attributes": [],
+                  "association": {
+                      "connectionType": "BELONGS_TO",
+                      "targetNames": [
+                          "cPKClassSpecialClassId"
+                      ]
+                  }
               },
               "createdAt": {
-                "name": "createdAt",
-                "isArray": false,
-                "type": "AWSDateTime",
-                "isRequired": false,
-                "attributes": [],
-                "isReadOnly": true
+                  "name": "createdAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
               },
               "updatedAt": {
-                "name": "updatedAt",
-                "isArray": false,
-                "type": "AWSDateTime",
-                "isRequired": false,
-                "attributes": [],
-                "isReadOnly": true
+                  "name": "updatedAt",
+                  "isArray": false,
+                  "type": "AWSDateTime",
+                  "isRequired": false,
+                  "attributes": [],
+                  "isReadOnly": true
               }
-            },
-            "syncable": true,
-            "pluralName": "CPKClasses",
-            "attributes": [
+          },
+          "syncable": true,
+          "pluralName": "CPKTeacherCPKClasses",
+          "attributes": [
               {
-                "type": "model",
-                "properties": {}
+                  "type": "model",
+                  "properties": {}
               },
               {
-                "type": "key",
-                "properties": {
-                  "fields": [
-                    "specialClassId"
-                  ]
-                }
+                  "type": "key",
+                  "properties": {
+                      "name": "byCPKTeacher",
+                      "fields": [
+                          "cPKTeacherSpecialTeacherId"
+                      ]
+                  }
+              },
+              {
+                  "type": "key",
+                  "properties": {
+                      "name": "byCPKClass",
+                      "fields": [
+                          "cPKClassSpecialClassId"
+                      ]
+                  }
               }
-            ]
-          }
-          },
-    "enums": {},
-    "nonModels": {},
-    "version": "38a1a46479c6cd75d21439d7f3122c1d",
-    "codegenVersion": "000000"
+          ]
+      }
+  },
+  "enums": {},
+  "nonModels": {},
+  "codegenVersion": "3.3.2",
+  "version": "6cdebeac40c17b1a27a64848aafdc86a"
 }

--- a/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
@@ -1519,34 +1519,13 @@ export const schemaWithAssumptions: Schema = {
 
 export const schemaWithCPK: Schema = {
   models: {
-    Student: {
-      name: 'Student',
+    CPKStudent: {
+      name: 'CPKStudent',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialStudentId: {
           name: 'specialStudentId',
           isArray: false,
           type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
-        grade: {
-          name: 'grade',
-          isArray: false,
-          type: 'Int',
-          isRequired: true,
-          attributes: [],
-        },
-        age: {
-          name: 'age',
-          isArray: false,
-          type: 'Int',
           isRequired: true,
           attributes: [],
         },
@@ -1568,7 +1547,7 @@ export const schemaWithCPK: Schema = {
         },
       },
       syncable: true,
-      pluralName: 'Students',
+      pluralName: 'CPKStudents',
       attributes: [
         {
           type: 'model',
@@ -1577,21 +1556,14 @@ export const schemaWithCPK: Schema = {
         {
           type: 'key',
           properties: {
-            fields: ['specialStudentId', 'grade', 'age'],
+            fields: ['specialStudentId'],
           },
         },
       ],
     },
-    Teacher: {
-      name: 'Teacher',
+    CPKTeacher: {
+      name: 'CPKTeacher',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialTeacherId: {
           name: 'specialTeacherId',
           isArray: false,
@@ -1599,18 +1571,46 @@ export const schemaWithCPK: Schema = {
           isRequired: true,
           attributes: [],
         },
-        Student: {
-          name: 'Student',
+        CPKStudent: {
+          name: 'CPKStudent',
           isArray: false,
           type: {
-            model: 'Student',
+            model: 'CPKStudent',
           },
           isRequired: false,
           attributes: [],
           association: {
             connectionType: 'HAS_ONE',
-            associatedWith: 'specialStudentId',
-            targetName: 'TeacherStudentId',
+            associatedWith: ['specialStudentId'],
+            targetNames: ['cPKTeacherCPKStudentSpecialStudentId'],
+          },
+        },
+        CPKClasses: {
+          name: 'CPKClasses',
+          isArray: true,
+          type: {
+            model: 'CPKTeacherCPKClass',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['cpkTeacher'],
+          },
+        },
+        CPKProjects: {
+          name: 'CPKProjects',
+          isArray: true,
+          type: {
+            model: 'CPKProject',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['cPKTeacherID'],
           },
         },
         createdAt: {
@@ -1629,8 +1629,8 @@ export const schemaWithCPK: Schema = {
           attributes: [],
           isReadOnly: true,
         },
-        TeacherStudentId: {
-          name: 'TeacherStudentId',
+        cPKTeacherCPKStudentSpecialStudentId: {
+          name: 'cPKTeacherCPKStudentSpecialStudentId',
           isArray: false,
           type: 'ID',
           isRequired: false,
@@ -1638,7 +1638,7 @@ export const schemaWithCPK: Schema = {
         },
       },
       syncable: true,
-      pluralName: 'Teachers',
+      pluralName: 'CPKTeachers',
       attributes: [
         {
           type: 'model',
@@ -1652,20 +1652,76 @@ export const schemaWithCPK: Schema = {
         },
       ],
     },
-    Dog: {
-      name: 'Dog',
+    CPKClass: {
+      name: 'CPKClass',
       fields: {
-        id: {
-          name: 'id',
+        specialClassId: {
+          name: 'specialClassId',
           isArray: false,
           type: 'ID',
           isRequired: true,
           attributes: [],
         },
-        name: {
-          name: 'name',
+        CPKTeachers: {
+          name: 'CPKTeachers',
+          isArray: true,
+          type: {
+            model: 'CPKTeacherCPKClass',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['cpkClass'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
           isArray: false,
-          type: 'String',
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'CPKClasses',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['specialClassId'],
+          },
+        },
+      ],
+    },
+    CPKProject: {
+      name: 'CPKProject',
+      fields: {
+        specialProjectId: {
+          name: 'specialProjectId',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        cPKTeacherID: {
+          name: 'cPKTeacherID',
+          isArray: false,
+          type: 'ID',
           isRequired: false,
           attributes: [],
         },
@@ -1687,19 +1743,122 @@ export const schemaWithCPK: Schema = {
         },
       },
       syncable: true,
-      pluralName: 'Dogs',
+      pluralName: 'CPKProjects',
       attributes: [
         {
           type: 'model',
           properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            fields: ['specialProjectId'],
+          },
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCPKTeacher',
+            fields: ['cPKTeacherID'],
+          },
+        },
+      ],
+    },
+    CPKTeacherCPKClass: {
+      name: 'CPKTeacherCPKClass',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        cPKTeacherSpecialTeacherId: {
+          name: 'cPKTeacherSpecialTeacherId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        cPKClassSpecialClassId: {
+          name: 'cPKClassSpecialClassId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        cpkTeacher: {
+          name: 'cpkTeacher',
+          isArray: false,
+          type: {
+            model: 'CPKTeacher',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['cPKTeacherSpecialTeacherId'],
+          },
+        },
+        cpkClass: {
+          name: 'cpkClass',
+          isArray: false,
+          type: {
+            model: 'CPKClass',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['cPKClassSpecialClassId'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'CPKTeacherCPKClasses',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCPKTeacher',
+            fields: ['cPKTeacherSpecialTeacherId'],
+          },
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCPKClass',
+            fields: ['cPKClassSpecialClassId'],
+          },
         },
       ],
     },
   },
   enums: {},
   nonModels: {},
-  version: '38a1a46479c6cd75d21439d7f3122c1d',
-  codegenVersion: '000000',
+  codegenVersion: '3.3.2',
+  version: '6cdebeac40c17b1a27a64848aafdc86a',
 };
 
 export const schemaWithCompositeKeys: Schema = {

--- a/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
@@ -230,9 +230,8 @@ describe('getGenericFromDataStore', () => {
   it('should correctly identify primary keys', () => {
     const genericSchema = getGenericFromDataStore(schemaWithCPK);
     const { models } = genericSchema;
-    expect(models.Dog.primaryKeys).toStrictEqual(['id']);
-    expect(models.Student.primaryKeys).toStrictEqual(['specialStudentId', 'grade', 'age']);
-    expect(models.Teacher.primaryKeys).toStrictEqual(['specialTeacherId']);
+    expect(models.CPKStudent.primaryKeys).toStrictEqual(['specialStudentId']);
+    expect(models.CPKTeacher.primaryKeys).toStrictEqual(['specialTeacherId']);
   });
 
   it('should correctly map model with composite keys', () => {

--- a/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
@@ -109,7 +109,7 @@ describe('mapFormMetaData', () => {
       formActionType: 'create',
       dataType: {
         dataSourceType: 'DataStore',
-        dataTypeName: 'Teacher',
+        dataTypeName: 'CPKTeacher',
       },
       fields: {},
       sectionalElements: {},
@@ -119,11 +119,11 @@ describe('mapFormMetaData', () => {
 
     const { fieldConfigs } = mapFormMetadata(form, generateFormDefinition({ form, dataSchema }));
 
-    expect('Student' in fieldConfigs).toBe(true);
-    expect(fieldConfigs.Student.relationship).toStrictEqual({
+    expect('CPKStudent' in fieldConfigs).toBe(true);
+    expect(fieldConfigs.CPKStudent.relationship).toStrictEqual({
       type: 'HAS_ONE',
-      relatedModelName: 'Student',
-      associatedFields: ['TeacherStudentId'],
+      relatedModelName: 'CPKStudent',
+      associatedFields: ['cPKTeacherCPKStudentSpecialStudentId'],
     });
   });
 

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -140,7 +140,7 @@ describe('UpdateForms', () => {
         cy.contains(/mySpecialTeacherId/).then((recordElement: JQuery) => {
           const record = JSON.parse(recordElement.text());
 
-          expect(record.cPKTeacherCPKStudentId).to.equal('Hermione');
+          expect(record.cPKTeacherCPKStudentSpecialStudentId).to.equal('Hermione');
           expect(record.CPKStudent.specialStudentId).to.equal('Hermione');
           expect(record.CPKClasses.length).to.equal(1);
           expect(record.CPKClasses[0].specialClassId).to.equal('English');

--- a/packages/test-generator/integration-test-templates/src/models/index.d.ts
+++ b/packages/test-generator/integration-test-templates/src/models/index.d.ts
@@ -14,6 +14,7 @@
   limitations under the License.
  */
 /* eslint-disable max-classes-per-file */
+/* eslint-disable @typescript-eslint/no-redeclare */
 import {
   ModelInit,
   MutableModel,
@@ -21,6 +22,9 @@ import {
   LazyLoadingDisabled,
   AsyncItem,
   AsyncCollection,
+  __modelMeta__,
+  CustomIdentifier,
+  ManagedIdentifier,
 } from '@aws-amplify/datastore';
 
 export enum City {
@@ -73,26 +77,6 @@ type StudentMetaData = {
 };
 
 type AllSupportedFormFieldsMetaData = {
-  readOnlyFields: 'createdAt' | 'updatedAt';
-};
-
-type CPKStudentMetaData = {
-  readOnlyFields: 'createdAt' | 'updatedAt';
-};
-
-type CPKTeacherMetaData = {
-  readOnlyFields: 'createdAt' | 'updatedAt';
-};
-
-type CPKClassMetaData = {
-  readOnlyFields: 'createdAt' | 'updatedAt';
-};
-
-type CPKTeacherCPKClassMetaData = {
-  readOnlyFields: 'createdAt' | 'updatedAt';
-};
-
-type CPKProjectMetaData = {
   readOnlyFields: 'createdAt' | 'updatedAt';
 };
 
@@ -155,7 +139,6 @@ type LazyUser = {
 
 export declare type User = LazyLoading extends LazyLoadingDisabled ? EagerUser : LazyUser;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare const User: (new (init: ModelInit<User, UserMetaData>) => User) & {
   copyOf(
     source: User,
@@ -255,7 +238,6 @@ type LazyTag = {
 
 export declare type Tag = LazyLoading extends LazyLoadingDisabled ? EagerTag : LazyTag;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare const Tag: (new (init: ModelInit<Tag, TagMetaData>) => Tag) & {
   copyOf(source: Tag, mutator: (draft: MutableModel<Tag, TagMetaData>) => MutableModel<Tag, TagMetaData> | void): Tag;
 };
@@ -288,7 +270,6 @@ export declare type AllSupportedFormFieldsTag = LazyLoading extends LazyLoadingD
   ? EagerAllSupportedFormFieldsTag
   : LazyAllSupportedFormFieldsTag;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare const AllSupportedFormFieldsTag: (new (
   init: ModelInit<AllSupportedFormFieldsTag, AllSupportedFormFieldsTagMetaData>,
 ) => AllSupportedFormFieldsTag) & {
@@ -330,7 +311,6 @@ type LazyOwner = {
 
 export declare type Owner = LazyLoading extends LazyLoadingDisabled ? EagerOwner : LazyOwner;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare const Owner: (new (init: ModelInit<Owner, OwnerMetaData>) => Owner) & {
   copyOf(
     source: Owner,
@@ -356,7 +336,6 @@ type LazyStudent = {
 
 export declare type Student = LazyLoading extends LazyLoadingDisabled ? EagerStudent : LazyStudent;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare const Student: (new (init: ModelInit<Student, StudentMetaData>) => Student) & {
   copyOf(
     source: Student,
@@ -468,7 +447,6 @@ export declare type AllSupportedFormFields = LazyLoading extends LazyLoadingDisa
   ? EagerAllSupportedFormFields
   : LazyAllSupportedFormFields;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare const AllSupportedFormFields: (new (
   init: ModelInit<AllSupportedFormFields, AllSupportedFormFieldsMetaData>,
 ) => AllSupportedFormFields) & {
@@ -481,32 +459,70 @@ export declare const AllSupportedFormFields: (new (
 };
 
 type EagerCPKStudent = {
-  readonly id: string;
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKStudent, 'specialStudentId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
   readonly specialStudentId: string;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 };
 
 type LazyCPKStudent = {
-  readonly id: string;
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKStudent, 'specialStudentId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
   readonly specialStudentId: string;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 };
 
 export declare type CPKStudent = LazyLoading extends LazyLoadingDisabled ? EagerCPKStudent : LazyCPKStudent;
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export declare const CPKStudent: (new (init: ModelInit<CPKStudent, CPKStudentMetaData>) => CPKStudent) & {
-  copyOf(
-    source: CPKStudent,
-    mutator: (
-      draft: MutableModel<CPKStudent, CPKStudentMetaData>,
-    ) => MutableModel<CPKStudent, CPKStudentMetaData> | void,
-  ): CPKStudent;
+
+export declare const CPKStudent: (new (init: ModelInit<CPKStudent>) => CPKStudent) & {
+  copyOf(source: CPKStudent, mutator: (draft: MutableModel<CPKStudent>) => MutableModel<CPKStudent> | void): CPKStudent;
+};
+
+type EagerCPKTeacher = {
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKTeacher, 'specialTeacherId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly specialTeacherId: string;
+  readonly CPKStudent?: CPKStudent | null;
+  readonly CPKClasses?: (CPKTeacherCPKClass | null)[] | null;
+  readonly CPKProjects?: (CPKProject | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly cPKTeacherCPKStudentSpecialStudentId?: string | null;
+};
+
+type LazyCPKTeacher = {
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKTeacher, 'specialTeacherId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly specialTeacherId: string;
+  readonly CPKStudent: AsyncItem<CPKStudent | undefined>;
+  readonly CPKClasses: AsyncCollection<CPKTeacherCPKClass>;
+  readonly CPKProjects: AsyncCollection<CPKProject>;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly cPKTeacherCPKStudentSpecialStudentId?: string | null;
+};
+
+export declare type CPKTeacher = LazyLoading extends LazyLoadingDisabled ? EagerCPKTeacher : LazyCPKTeacher;
+
+export declare const CPKTeacher: (new (init: ModelInit<CPKTeacher>) => CPKTeacher) & {
+  copyOf(source: CPKTeacher, mutator: (draft: MutableModel<CPKTeacher>) => MutableModel<CPKTeacher> | void): CPKTeacher;
 };
 
 type EagerCPKClass = {
-  readonly id: string;
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKClass, 'specialClassId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
   readonly specialClassId: string;
   readonly CPKTeachers?: (CPKTeacherCPKClass | null)[] | null;
   readonly createdAt?: string | null;
@@ -514,7 +530,10 @@ type EagerCPKClass = {
 };
 
 type LazyCPKClass = {
-  readonly id: string;
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKClass, 'specialClassId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
   readonly specialClassId: string;
   readonly CPKTeachers: AsyncCollection<CPKTeacherCPKClass>;
   readonly createdAt?: string | null;
@@ -522,49 +541,47 @@ type LazyCPKClass = {
 };
 
 export declare type CPKClass = LazyLoading extends LazyLoadingDisabled ? EagerCPKClass : LazyCPKClass;
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export declare const CPKClass: (new (init: ModelInit<CPKClass, CPKClassMetaData>) => CPKClass) & {
-  copyOf(
-    source: CPKClass,
-    mutator: (draft: MutableModel<CPKClass, CPKClassMetaData>) => MutableModel<CPKClass, CPKClassMetaData> | void,
-  ): CPKClass;
+
+export declare const CPKClass: (new (init: ModelInit<CPKClass>) => CPKClass) & {
+  copyOf(source: CPKClass, mutator: (draft: MutableModel<CPKClass>) => MutableModel<CPKClass> | void): CPKClass;
 };
 
-type EagerCPKTeacher = {
-  readonly id: string;
-  readonly specialTeacherId: string;
-  readonly CPKStudent?: CPKStudent | null;
-  readonly CPKClasses?: (CPKTeacherCPKClass | null)[] | null;
-  readonly CPKProjects?: (CPKProject | null)[] | null;
+type EagerCPKProject = {
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKProject, 'specialProjectId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly specialProjectId: string;
+  readonly cPKTeacherID?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
-  readonly cPKTeacherCPKStudentId?: string | null;
 };
 
-type LazyCPKTeacher = {
-  readonly id: string;
-  readonly specialTeacherId: string;
-  readonly CPKStudent: AsyncItem<CPKStudent | undefined>;
-  readonly CPKClasses: AsyncCollection<CPKTeacherCPKClass>;
-  readonly CPKProjects: AsyncCollection<CPKProject>;
+type LazyCPKProject = {
+  readonly [__modelMeta__]: {
+    identifier: CustomIdentifier<CPKProject, 'specialProjectId'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly specialProjectId: string;
+  readonly cPKTeacherID?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
-  readonly cPKTeacherCPKStudentId?: string | null;
 };
 
-export declare type CPKTeacher = LazyLoading extends LazyLoadingDisabled ? EagerCPKTeacher : LazyCPKTeacher;
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export declare const CPKTeacher: (new (init: ModelInit<CPKTeacher, CPKTeacherMetaData>) => CPKTeacher) & {
-  copyOf(
-    source: CPKTeacher,
-    mutator: (
-      draft: MutableModel<CPKTeacher, CPKTeacherMetaData>,
-    ) => MutableModel<CPKTeacher, CPKTeacherMetaData> | void,
-  ): CPKTeacher;
+export declare type CPKProject = LazyLoading extends LazyLoadingDisabled ? EagerCPKProject : LazyCPKProject;
+
+export declare const CPKProject: (new (init: ModelInit<CPKProject>) => CPKProject) & {
+  copyOf(source: CPKProject, mutator: (draft: MutableModel<CPKProject>) => MutableModel<CPKProject> | void): CPKProject;
 };
 
 type EagerCPKTeacherCPKClass = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<CPKTeacherCPKClass, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
   readonly id: string;
+  readonly cPKTeacherSpecialTeacherId?: string | null;
+  readonly cPKClassSpecialClassId?: string | null;
   readonly cpkTeacher: CPKTeacher;
   readonly cpkClass: CPKClass;
   readonly createdAt?: string | null;
@@ -572,7 +589,13 @@ type EagerCPKTeacherCPKClass = {
 };
 
 type LazyCPKTeacherCPKClass = {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<CPKTeacherCPKClass, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
   readonly id: string;
+  readonly cPKTeacherSpecialTeacherId?: string | null;
+  readonly cPKClassSpecialClassId?: string | null;
   readonly cpkTeacher: AsyncItem<CPKTeacher>;
   readonly cpkClass: AsyncItem<CPKClass>;
   readonly createdAt?: string | null;
@@ -582,41 +605,10 @@ type LazyCPKTeacherCPKClass = {
 export declare type CPKTeacherCPKClass = LazyLoading extends LazyLoadingDisabled
   ? EagerCPKTeacherCPKClass
   : LazyCPKTeacherCPKClass;
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export declare const CPKTeacherCPKClass: (new (
-  init: ModelInit<CPKTeacherCPKClass, CPKTeacherCPKClassMetaData>,
-) => CPKTeacherCPKClass) & {
+
+export declare const CPKTeacherCPKClass: (new (init: ModelInit<CPKTeacherCPKClass>) => CPKTeacherCPKClass) & {
   copyOf(
     source: CPKTeacherCPKClass,
-    mutator: (
-      draft: MutableModel<CPKTeacherCPKClass, CPKTeacherCPKClassMetaData>,
-    ) => MutableModel<CPKTeacherCPKClass, CPKTeacherCPKClassMetaData> | void,
+    mutator: (draft: MutableModel<CPKTeacherCPKClass>) => MutableModel<CPKTeacherCPKClass> | void,
   ): CPKTeacherCPKClass;
-};
-
-type EagerCPKProject = {
-  readonly id: string;
-  readonly specialProjectId: string;
-  readonly cPKTeacherID?: string;
-  readonly createdAt?: string | null;
-  readonly updatedAt?: string | null;
-};
-
-type LazyCPKProject = {
-  readonly id: string;
-  readonly specialProjectId: string;
-  readonly cPKTeacherID?: string;
-  readonly createdAt?: string | null;
-  readonly updatedAt?: string | null;
-};
-
-export declare type CPKProject = LazyLoading extends LazyLoadingDisabled ? EagerCPKProject : LazyCPKProject;
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export declare const CPKProject: (new (init: ModelInit<CPKProject, CPKProjectMetaData>) => CPKProject) & {
-  copyOf(
-    source: CPKProject,
-    mutator: (
-      draft: MutableModel<CPKProject, CPKProjectMetaData>,
-    ) => MutableModel<CPKProject, CPKProjectMetaData> | void,
-  ): CPKProject;
 };

--- a/packages/test-generator/integration-test-templates/src/models/schema.js
+++ b/packages/test-generator/integration-test-templates/src/models/schema.js
@@ -843,13 +843,6 @@ export const schema = {
     CPKStudent: {
       name: 'CPKStudent',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialStudentId: {
           name: 'specialStudentId',
           isArray: false,
@@ -875,7 +868,7 @@ export const schema = {
         },
       },
       syncable: true,
-      pluralName: 'Students',
+      pluralName: 'CPKStudents',
       attributes: [
         {
           type: 'model',
@@ -889,92 +882,9 @@ export const schema = {
         },
       ],
     },
-    CPKTeacherCPKClass: {
-      name: 'CPKTeacherCPKClass',
-      fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
-        cpkTeacher: {
-          name: 'cpkTeacher',
-          isArray: false,
-          type: {
-            model: 'CPKTeacher',
-          },
-          isRequired: true,
-          attributes: [],
-          association: {
-            connectionType: 'BELONGS_TO',
-            targetName: 'cpkTeacherID',
-          },
-        },
-        cpkClass: {
-          name: 'cpkClass',
-          isArray: false,
-          type: {
-            model: 'CPKClass',
-          },
-          isRequired: true,
-          attributes: [],
-          association: {
-            connectionType: 'BELONGS_TO',
-            targetName: 'cpkClassID',
-          },
-        },
-        createdAt: {
-          name: 'createdAt',
-          isArray: false,
-          type: 'AWSDateTime',
-          isRequired: false,
-          attributes: [],
-          isReadOnly: true,
-        },
-        updatedAt: {
-          name: 'updatedAt',
-          isArray: false,
-          type: 'AWSDateTime',
-          isRequired: false,
-          attributes: [],
-          isReadOnly: true,
-        },
-      },
-      syncable: true,
-      pluralName: 'CPKTeacherCPKClasses',
-      attributes: [
-        {
-          type: 'model',
-          properties: {},
-        },
-        {
-          type: 'key',
-          properties: {
-            name: 'byCPKTeacher',
-            fields: ['cpkTeacherID'],
-          },
-        },
-        {
-          type: 'key',
-          properties: {
-            name: 'byCPKClass',
-            fields: ['cpkClassID'],
-          },
-        },
-      ],
-    },
     CPKTeacher: {
       name: 'CPKTeacher',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialTeacherId: {
           name: 'specialTeacherId',
           isArray: false,
@@ -992,8 +902,8 @@ export const schema = {
           attributes: [],
           association: {
             connectionType: 'HAS_ONE',
-            associatedWith: 'specialStudentId',
-            targetName: 'cPKTeacherCPKStudentId',
+            associatedWith: ['specialStudentId'],
+            targetNames: ['cPKTeacherCPKStudentSpecialStudentId'],
           },
         },
         CPKClasses: {
@@ -1007,7 +917,7 @@ export const schema = {
           isArrayNullable: true,
           association: {
             connectionType: 'HAS_MANY',
-            associatedWith: 'cpkTeacher',
+            associatedWith: ['cpkTeacher'],
           },
         },
         CPKProjects: {
@@ -1021,7 +931,7 @@ export const schema = {
           isArrayNullable: true,
           association: {
             connectionType: 'HAS_MANY',
-            associatedWith: 'cPKTeacherID',
+            associatedWith: ['cPKTeacherID'],
           },
         },
         createdAt: {
@@ -1040,8 +950,8 @@ export const schema = {
           attributes: [],
           isReadOnly: true,
         },
-        cPKTeacherCPKStudentId: {
-          name: 'cPKTeacherCPKStudentId',
+        cPKTeacherCPKStudentSpecialStudentId: {
+          name: 'cPKTeacherCPKStudentSpecialStudentId',
           isArray: false,
           type: 'ID',
           isRequired: false,
@@ -1066,13 +976,6 @@ export const schema = {
     CPKClass: {
       name: 'CPKClass',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialClassId: {
           name: 'specialClassId',
           isArray: false,
@@ -1091,7 +994,7 @@ export const schema = {
           isArrayNullable: true,
           association: {
             connectionType: 'HAS_MANY',
-            associatedWith: 'cpkClass',
+            associatedWith: ['cpkClass'],
           },
         },
         createdAt: {
@@ -1129,13 +1032,6 @@ export const schema = {
     CPKProject: {
       name: 'CPKProject',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialProjectId: {
           name: 'specialProjectId',
           isArray: false,
@@ -1185,6 +1081,96 @@ export const schema = {
           properties: {
             name: 'byCPKTeacher',
             fields: ['cPKTeacherID'],
+          },
+        },
+      ],
+    },
+    CPKTeacherCPKClass: {
+      name: 'CPKTeacherCPKClass',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        cPKTeacherSpecialTeacherId: {
+          name: 'cPKTeacherSpecialTeacherId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        cPKClassSpecialClassId: {
+          name: 'cPKClassSpecialClassId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        cpkTeacher: {
+          name: 'cpkTeacher',
+          isArray: false,
+          type: {
+            model: 'CPKTeacher',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['cPKTeacherSpecialTeacherId'],
+          },
+        },
+        cpkClass: {
+          name: 'cpkClass',
+          isArray: false,
+          type: {
+            model: 'CPKClass',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['cPKClassSpecialClassId'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'CPKTeacherCPKClasses',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCPKTeacher',
+            fields: ['cPKTeacherSpecialTeacherId'],
+          },
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCPKClass',
+            fields: ['cPKClassSpecialClassId'],
           },
         },
       ],

--- a/packages/test-generator/lib/models/schema.ts
+++ b/packages/test-generator/lib/models/schema.ts
@@ -845,13 +845,6 @@ export default {
     CPKStudent: {
       name: 'CPKStudent',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialStudentId: {
           name: 'specialStudentId',
           isArray: false,
@@ -877,7 +870,7 @@ export default {
         },
       },
       syncable: true,
-      pluralName: 'Students',
+      pluralName: 'CPKStudents',
       attributes: [
         {
           type: 'model',
@@ -891,92 +884,9 @@ export default {
         },
       ],
     },
-    CPKTeacherCPKClass: {
-      name: 'CPKTeacherCPKClass',
-      fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
-        cpkTeacher: {
-          name: 'cpkTeacher',
-          isArray: false,
-          type: {
-            model: 'CPKTeacher',
-          },
-          isRequired: true,
-          attributes: [],
-          association: {
-            connectionType: 'BELONGS_TO',
-            targetName: 'cpkTeacherID',
-          },
-        },
-        cpkClass: {
-          name: 'cpkClass',
-          isArray: false,
-          type: {
-            model: 'CPKClass',
-          },
-          isRequired: true,
-          attributes: [],
-          association: {
-            connectionType: 'BELONGS_TO',
-            targetName: 'cpkClassID',
-          },
-        },
-        createdAt: {
-          name: 'createdAt',
-          isArray: false,
-          type: 'AWSDateTime',
-          isRequired: false,
-          attributes: [],
-          isReadOnly: true,
-        },
-        updatedAt: {
-          name: 'updatedAt',
-          isArray: false,
-          type: 'AWSDateTime',
-          isRequired: false,
-          attributes: [],
-          isReadOnly: true,
-        },
-      },
-      syncable: true,
-      pluralName: 'CPKTeacherCPKClasses',
-      attributes: [
-        {
-          type: 'model',
-          properties: {},
-        },
-        {
-          type: 'key',
-          properties: {
-            name: 'byCPKTeacher',
-            fields: ['cpkTeacherID'],
-          },
-        },
-        {
-          type: 'key',
-          properties: {
-            name: 'byCPKClass',
-            fields: ['cpkClassID'],
-          },
-        },
-      ],
-    },
     CPKTeacher: {
       name: 'CPKTeacher',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialTeacherId: {
           name: 'specialTeacherId',
           isArray: false,
@@ -994,8 +904,8 @@ export default {
           attributes: [],
           association: {
             connectionType: 'HAS_ONE',
-            associatedWith: 'specialStudentId',
-            targetName: 'cPKTeacherCPKStudentId',
+            associatedWith: ['specialStudentId'],
+            targetNames: ['cPKTeacherCPKStudentSpecialStudentId'],
           },
         },
         CPKClasses: {
@@ -1009,7 +919,7 @@ export default {
           isArrayNullable: true,
           association: {
             connectionType: 'HAS_MANY',
-            associatedWith: 'cpkTeacher',
+            associatedWith: ['cpkTeacher'],
           },
         },
         CPKProjects: {
@@ -1023,7 +933,7 @@ export default {
           isArrayNullable: true,
           association: {
             connectionType: 'HAS_MANY',
-            associatedWith: 'cPKTeacherID',
+            associatedWith: ['cPKTeacherID'],
           },
         },
         createdAt: {
@@ -1042,8 +952,8 @@ export default {
           attributes: [],
           isReadOnly: true,
         },
-        cPKTeacherCPKStudentId: {
-          name: 'cPKTeacherCPKStudentId',
+        cPKTeacherCPKStudentSpecialStudentId: {
+          name: 'cPKTeacherCPKStudentSpecialStudentId',
           isArray: false,
           type: 'ID',
           isRequired: false,
@@ -1068,13 +978,6 @@ export default {
     CPKClass: {
       name: 'CPKClass',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialClassId: {
           name: 'specialClassId',
           isArray: false,
@@ -1093,7 +996,7 @@ export default {
           isArrayNullable: true,
           association: {
             connectionType: 'HAS_MANY',
-            associatedWith: 'cpkClass',
+            associatedWith: ['cpkClass'],
           },
         },
         createdAt: {
@@ -1131,13 +1034,6 @@ export default {
     CPKProject: {
       name: 'CPKProject',
       fields: {
-        id: {
-          name: 'id',
-          isArray: false,
-          type: 'ID',
-          isRequired: true,
-          attributes: [],
-        },
         specialProjectId: {
           name: 'specialProjectId',
           isArray: false,
@@ -1187,6 +1083,96 @@ export default {
           properties: {
             name: 'byCPKTeacher',
             fields: ['cPKTeacherID'],
+          },
+        },
+      ],
+    },
+    CPKTeacherCPKClass: {
+      name: 'CPKTeacherCPKClass',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        cPKTeacherSpecialTeacherId: {
+          name: 'cPKTeacherSpecialTeacherId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        cPKClassSpecialClassId: {
+          name: 'cPKClassSpecialClassId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        cpkTeacher: {
+          name: 'cpkTeacher',
+          isArray: false,
+          type: {
+            model: 'CPKTeacher',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['cPKTeacherSpecialTeacherId'],
+          },
+        },
+        cpkClass: {
+          name: 'cpkClass',
+          isArray: false,
+          type: {
+            model: 'CPKClass',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['cPKClassSpecialClassId'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'CPKTeacherCPKClasses',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCPKTeacher',
+            fields: ['cPKTeacherSpecialTeacherId'],
+          },
+        },
+        {
+          type: 'key',
+          properties: {
+            name: 'byCPKClass',
+            fields: ['cPKClassSpecialClassId'],
           },
         },
       ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The schemas testing CPK were generated without `features.respectprimarykeyattributesonconnectionfield` set to `true` in the `cli.json`. This updates the schemas to those generated with the flag set to `true`, so that they are a more accurate representation of customer input.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
