### PR TITLE
fix: hasMany update form should throw better error message for invali…

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3616,14 +3616,27 @@ export default function UpdateCompositeDogForm(props) {
             }
           });
           compositeToysToUnLink.forEach((original) => {
-            promises.push(
-              DataStore.save(
-                CompositeToy.copyOf(original, (updated) => {
-                  updated.compositeDogCompositeToysName = null;
-                  updated.compositeDogCompositeToysDescription = null;
-                })
-              )
-            );
+            try {
+              promises.push(
+                DataStore.save(
+                  CompositeToy.copyOf(original, (updated) => {
+                    updated.compositeDogCompositeToysName = null;
+                    updated.compositeDogCompositeToysDescription = null;
+                  })
+                )
+              );
+            } catch (err) {
+              if (
+                err.message ===
+                \\"Field compositeDogCompositeToysName is required\\"
+              ) {
+                throw Error(
+                  \`\${original.id} cannot be unlinked from CompositeDog because compositeDogCompositeToysName is a required field.\`
+                );
+              } else {
+                throw err;
+              }
+            }
           });
           compositeToysToLink.forEach((original) => {
             promises.push(
@@ -4666,13 +4679,23 @@ export default function UpdateCPKTeacherForm(props) {
             }
           });
           cPKProjectsToUnLink.forEach((original) => {
-            promises.push(
-              DataStore.save(
-                CPKProject.copyOf(original, (updated) => {
-                  updated.cPKTeacherID = null;
-                })
-              )
-            );
+            try {
+              promises.push(
+                DataStore.save(
+                  CPKProject.copyOf(original, (updated) => {
+                    updated.cPKTeacherID = null;
+                  })
+                )
+              );
+            } catch (err) {
+              if (err.message === \\"Field cPKTeacherID is required\\") {
+                throw Error(
+                  \`\${original.id} cannot be unlinked from CPKTeacher because cPKTeacherID is a required field.\`
+                );
+              } else {
+                throw err;
+              }
+            }
           });
           cPKProjectsToLink.forEach((original) => {
             promises.push(
@@ -10774,13 +10797,23 @@ export default function SchoolUpdateForm(props) {
             }
           });
           studentsToUnLink.forEach((original) => {
-            promises.push(
-              DataStore.save(
-                Student.copyOf(original, (updated) => {
-                  updated.schoolID = null;
-                })
-              )
-            );
+            try {
+              promises.push(
+                DataStore.save(
+                  Student.copyOf(original, (updated) => {
+                    updated.schoolID = null;
+                  })
+                )
+              );
+            } catch (err) {
+              if (err.message === \\"Field schoolID is required\\") {
+                throw Error(
+                  \`\${original.id} cannot be unlinked from School because schoolID is a required field.\`
+                );
+              } else {
+                throw err;
+              }
+            }
           });
           studentsToLink.forEach((original) => {
             promises.push(

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -1551,67 +1551,120 @@ export const buildHasManyRelationshipDataStoreStatements = (
               factory.createToken(SyntaxKind.EqualsGreaterThanToken),
               factory.createBlock(
                 [
-                  factory.createExpressionStatement(
-                    factory.createCallExpression(
-                      factory.createPropertyAccessExpression(
-                        factory.createIdentifier('promises'),
-                        factory.createIdentifier('push'),
-                      ),
-                      undefined,
+                  factory.createTryStatement(
+                    factory.createBlock(
                       [
-                        factory.createCallExpression(
-                          factory.createPropertyAccessExpression(
-                            factory.createIdentifier('DataStore'),
-                            factory.createIdentifier('save'),
-                          ),
-                          undefined,
-                          [
-                            factory.createCallExpression(
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier(relatedModelName),
-                                factory.createIdentifier('copyOf'),
-                              ),
-                              undefined,
-                              [
-                                factory.createIdentifier('original'),
-                                factory.createArrowFunction(
-                                  undefined,
-                                  undefined,
-                                  [
-                                    factory.createParameterDeclaration(
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      factory.createIdentifier('updated'),
-                                      undefined,
-                                      undefined,
-                                      undefined,
+                        factory.createExpressionStatement(
+                          factory.createCallExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('promises'),
+                              factory.createIdentifier('push'),
+                            ),
+                            undefined,
+                            [
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('DataStore'),
+                                  factory.createIdentifier('save'),
+                                ),
+                                undefined,
+                                [
+                                  factory.createCallExpression(
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier(relatedModelName),
+                                      factory.createIdentifier('copyOf'),
                                     ),
-                                  ],
-                                  undefined,
-                                  factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                                  factory.createBlock(
-                                    relatedModelFields.map((relatedModelField) =>
-                                      factory.createExpressionStatement(
-                                        factory.createBinaryExpression(
-                                          factory.createPropertyAccessExpression(
+                                    undefined,
+                                    [
+                                      factory.createIdentifier('original'),
+                                      factory.createArrowFunction(
+                                        undefined,
+                                        undefined,
+                                        [
+                                          factory.createParameterDeclaration(
+                                            undefined,
+                                            undefined,
+                                            undefined,
                                             factory.createIdentifier('updated'),
-                                            factory.createIdentifier(relatedModelField),
+                                            undefined,
+                                            undefined,
+                                            undefined,
                                           ),
-                                          factory.createToken(SyntaxKind.EqualsToken),
-                                          factory.createNull(),
+                                        ],
+                                        undefined,
+                                        factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                                        factory.createBlock(
+                                          relatedModelFields.map((relatedModelField) =>
+                                            factory.createExpressionStatement(
+                                              factory.createBinaryExpression(
+                                                factory.createPropertyAccessExpression(
+                                                  factory.createIdentifier('updated'),
+                                                  factory.createIdentifier(relatedModelField),
+                                                ),
+                                                factory.createToken(SyntaxKind.EqualsToken),
+                                                factory.createNull(),
+                                              ),
+                                            ),
+                                          ),
+                                          true,
                                         ),
                                       ),
-                                    ),
-                                    true,
+                                    ],
                                   ),
-                                ),
-                              ],
-                            ),
-                          ],
+                                ],
+                              ),
+                            ],
+                          ),
                         ),
                       ],
+                      true,
                     ),
+                    factory.createCatchClause(
+                      factory.createVariableDeclaration(
+                        factory.createIdentifier('err'),
+                        undefined,
+                        undefined,
+                        undefined,
+                      ),
+                      factory.createBlock(
+                        [
+                          factory.createIfStatement(
+                            factory.createBinaryExpression(
+                              factory.createPropertyAccessExpression(
+                                factory.createIdentifier('err'),
+                                factory.createIdentifier('message'),
+                              ),
+                              factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                              factory.createStringLiteral(`Field ${relatedModelFields[0]} is required`),
+                            ),
+                            factory.createBlock(
+                              [
+                                factory.createThrowStatement(
+                                  factory.createCallExpression(factory.createIdentifier('Error'), undefined, [
+                                    factory.createTemplateExpression(factory.createTemplateHead('', ''), [
+                                      factory.createTemplateSpan(
+                                        factory.createPropertyAccessExpression(
+                                          factory.createIdentifier('original'),
+                                          factory.createIdentifier('id'),
+                                        ),
+                                        factory.createTemplateTail(
+                                          // eslint-disable-next-line max-len
+                                          ` cannot be unlinked from ${modelName} because ${relatedModelFields[0]} is a required field.`,
+                                        ),
+                                      ),
+                                    ]),
+                                  ]),
+                                ),
+                              ],
+                              true,
+                            ),
+                            factory.createBlock([factory.createThrowStatement(factory.createIdentifier('err'))], true),
+                          ),
+                        ],
+                        true,
+                      ),
+                    ),
+                    undefined,
                   ),
                 ],
                 true,

--- a/packages/codegen-ui/example-schemas/datastore/school-student.json
+++ b/packages/codegen-ui/example-schemas/datastore/school-student.json
@@ -61,7 +61,12 @@
             "rules": [
               {
                 "allow": "public",
-                "operations": ["create", "update", "delete", "read"]
+                "operations": [
+                  "create",
+                  "update",
+                  "delete",
+                  "read"
+                ]
               }
             ]
           }
@@ -89,7 +94,7 @@
           "name": "schoolID",
           "isArray": false,
           "type": "ID",
-          "isRequired": false,
+          "isRequired": true,
           "attributes": []
         },
         "createdAt": {
@@ -120,7 +125,9 @@
           "type": "key",
           "properties": {
             "name": "bySchool",
-            "fields": ["schoolID"]
+            "fields": [
+              "schoolID"
+            ]
           }
         },
         {
@@ -129,7 +136,12 @@
             "rules": [
               {
                 "allow": "public",
-                "operations": ["create", "update", "delete", "read"]
+                "operations": [
+                  "create",
+                  "update",
+                  "delete",
+                  "read"
+                ]
               }
             ]
           }

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -54,6 +54,17 @@ describe('UpdateForms', () => {
         typeInAutocomplete(`George{downArrow}{enter}`);
         clickAddToArray();
 
+        // HasMany
+        removeArrayItem('Jessica');
+
+        getArrayFieldButtonByLabel('Has many students').click();
+        typeInAutocomplete(`{downArrow}{enter}`);
+        clickAddToArray();
+
+        getArrayFieldButtonByLabel('Has many students').click();
+        typeInAutocomplete(`Sar{downArrow}{enter}`);
+        clickAddToArray();
+
         // Many to many update
         removeArrayItem('Red');
         removeArrayItem('Blue');
@@ -66,18 +77,6 @@ describe('UpdateForms', () => {
         typeInAutocomplete(`Gr{downArrow}{enter}`);
         clickAddToArray();
 
-        // Has many update
-        removeArrayItem('David');
-        removeArrayItem('Jessica');
-
-        getArrayFieldButtonByLabel('Has many students').click();
-        typeInAutocomplete(`{downArrow}{enter}`);
-        clickAddToArray();
-
-        getArrayFieldButtonByLabel('Has many students').click();
-        typeInAutocomplete(`Sar{downArrow}{enter}`);
-        clickAddToArray();
-
         cy.contains('Submit').click();
 
         cy.contains(/My string/).then((recordElement: JQuery) => {
@@ -87,11 +86,13 @@ describe('UpdateForms', () => {
           expect(record.ManyToManyTags[0].label).to.equal('Green');
           expect(record.ManyToManyTags[1].label).to.equal('Orange');
           expect(record.BelongsToOwner.name).to.equal('George');
-          expect(record.HasManyStudents.length).to.equal(2);
-          expect(record.HasManyStudents[0].name).to.equal('Matthew');
+          expect(record.HasManyStudents.length).to.equal(3);
+          expect(record.HasManyStudents[0].name).to.equal('David');
           expect(record.HasManyStudents[0].allSupportedFormFieldsID).to.equal(record.id);
-          expect(record.HasManyStudents[1].name).to.equal('Sarah');
+          expect(record.HasManyStudents[1].name).to.equal('Matthew');
           expect(record.HasManyStudents[1].allSupportedFormFieldsID).to.equal(record.id);
+          expect(record.HasManyStudents[2].name).to.equal('Sarah');
+          expect(record.HasManyStudents[2].allSupportedFormFieldsID).to.equal(record.id);
         });
       });
     });

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -87,11 +87,11 @@ describe('UpdateForms', () => {
           expect(record.ManyToManyTags[1].label).to.equal('Orange');
           expect(record.BelongsToOwner.name).to.equal('George');
           expect(record.HasManyStudents.length).to.equal(3);
-          expect(record.HasManyStudents[0].name).to.equal('David');
+          expect(record.HasManyStudents[0].name).to.equal('Matthew');
           expect(record.HasManyStudents[0].allSupportedFormFieldsID).to.equal(record.id);
-          expect(record.HasManyStudents[1].name).to.equal('Matthew');
+          expect(record.HasManyStudents[1].name).to.equal('Sarah');
           expect(record.HasManyStudents[1].allSupportedFormFieldsID).to.equal(record.id);
-          expect(record.HasManyStudents[2].name).to.equal('Sarah');
+          expect(record.HasManyStudents[2].name).to.equal('David');
           expect(record.HasManyStudents[2].allSupportedFormFieldsID).to.equal(record.id);
         });
       });


### PR DESCRIPTION
*Description of changes:*
When the linking field of a child data is set up to be required by the user for has many relationship, a confusing error message is shown to the user.

![Screen Shot 2022-12-01 at 5 15 12 PM (1)](https://user-images.githubusercontent.com/9378323/209215809-fba96f26-1c42-452e-9074-0a0baaecd1a0.png)

This change catches the error message returns from the update request, and throws an new error with more descriptive message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
