### PR TITLE
feat: add feature flags for relationship and non-model form fields su…

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
+++ b/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
@@ -20,6 +20,7 @@ import {
   getGenericFromDataStore,
   StudioForm,
   StudioView,
+  FormFeatureFlags,
 } from '@aws-amplify/codegen-ui';
 import { Schema } from '@aws-amplify/datastore';
 import { createPrinter, createSourceFile, EmitHint, NewLineKind, Node } from 'typescript';
@@ -56,6 +57,7 @@ export const generateWithAmplifyFormRenderer = (
   formJsonFile: string,
   dataSchemaJsonFile: string | undefined,
   renderConfig: ReactRenderConfig = defaultCLIRenderConfig,
+  featureFlags?: FormFeatureFlags,
 ): { componentText: string; declaration?: string } => {
   let dataSchema: GenericDataSchema | undefined;
   if (dataSchemaJsonFile) {
@@ -63,7 +65,7 @@ export const generateWithAmplifyFormRenderer = (
     dataSchema = getGenericFromDataStore(dataStoreSchema);
   }
   const rendererFactory = new StudioTemplateRendererFactory(
-    (component: StudioForm) => new AmplifyFormRenderer(component, dataSchema, renderConfig),
+    (component: StudioForm) => new AmplifyFormRenderer(component, dataSchema, renderConfig, featureFlags),
   );
 
   const renderer = rendererFactory.buildRenderer(loadSchemaFromJSONFile<StudioForm>(formJsonFile));

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -22,6 +22,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/post-datastore-create',
         'datastore/post',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toContain('resetStateValues();');
@@ -33,6 +35,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/book-datastore-relationship',
         'datastore/relationship',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { Book, Author } from "../models";');
@@ -48,6 +52,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/book-datastore-relationship-multiple',
         'datastore/relationship-multiple',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { Book, Author, Title } from "../models";');
@@ -64,6 +70,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/member-datastore-create',
         'datastore/project-team-model',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { Member, Team as Team0 } from "../models";');
@@ -79,6 +87,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/member-datastore-update-belongs-to',
         'datastore/project-team-model',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { Member, Team as Team0 } from "../models";');
@@ -94,6 +104,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/member-datastore-create',
         'datastore/project-team-model',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // Check that custom field label is working as expected
       expect(componentText).toContain('Team Label');
@@ -108,6 +120,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/tag-datastore-create',
         'datastore/tag-post',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { Tag, Post, TagPost } from "../models";');
@@ -126,6 +140,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/tag-datastore-update',
         'datastore/tag-post',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { Tag, Post, TagPost } from "../models";');
@@ -153,6 +169,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/tag-datastore-create',
         'datastore/tag-post',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // get displayValue function
       expect(componentText).toContain('statuses: (r) => {');
@@ -171,6 +189,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/school-datastore-create',
         'datastore/school-student',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { School, Student } from "../models";');
@@ -189,6 +209,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/school-datastore-update',
         'datastore/school-student',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       // check nested model is imported
       expect(componentText).toContain('import { School, Student } from "../models";');
@@ -216,6 +238,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/post-datastore-create-row',
         'datastore/post',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toMatchSnapshot();
@@ -226,6 +250,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/post-datastore-update',
         'datastore/post',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toMatchSnapshot();
@@ -236,6 +262,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/blog-datastore-create',
         'datastore/blog',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toMatchSnapshot();
@@ -246,6 +274,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/input-gallery-create',
         'datastore/input-gallery',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toContain('const convertToLocal');
@@ -257,6 +287,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/input-gallery-update',
         'datastore/input-gallery',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toContain('const convertToLocal');
@@ -272,6 +304,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/flex-datastore-create',
         'datastore/flex',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toContain('Flex0');
@@ -282,6 +316,8 @@ describe('amplify form renderer tests', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/flex-datastore-update',
         'datastore/flex',
+        undefined,
+        { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
       expect(componentText).toContain('Flex0');
@@ -368,15 +404,29 @@ describe('amplify form renderer tests', () => {
         const { componentText, declaration } = generateWithAmplifyFormRenderer(
           'forms/post-datastore-create-with-custom-array',
           'datastore/post',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
         );
         expect(componentText).toMatchSnapshot();
         expect(declaration).toMatchSnapshot();
+      });
+
+      it('should not render non-model fields if non-model support off', () => {
+        const { componentText } = generateWithAmplifyFormRenderer(
+          'forms/post-datastore-create-with-custom-array',
+          'datastore/post',
+          undefined,
+        );
+
+        expect(componentText).not.toContain('nonModelField');
       });
 
       it('should use matching case for ref when array field is capitalized', () => {
         const { componentText } = generateWithAmplifyFormRenderer(
           'forms/post-datastore-create-with-custom-array',
           'datastore/post',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
         );
 
         expect(componentText).toContain('const CustomtagsRef');
@@ -388,6 +438,8 @@ describe('amplify form renderer tests', () => {
         const { componentText, declaration } = generateWithAmplifyFormRenderer(
           'forms/cpk-teacher-datastore-update',
           'datastore/cpk-relationships',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
         );
         // hasOne
         expect(componentText).toContain('specialTeacherId: specialTeacherIdProp');
@@ -416,6 +468,8 @@ describe('amplify form renderer tests', () => {
         const { componentText, declaration } = generateWithAmplifyFormRenderer(
           'forms/composite-dog-datastore-update',
           'datastore/composite-relationships',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
         );
 
         expect(componentText).toMatchSnapshot();
@@ -426,10 +480,24 @@ describe('amplify form renderer tests', () => {
         const { componentText, declaration } = generateWithAmplifyFormRenderer(
           'forms/composite-dog-datastore-create',
           'datastore/composite-relationships',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
         );
 
         expect(componentText).toMatchSnapshot();
         expect(declaration).toMatchSnapshot();
+      });
+
+      it('should not render relationships if relationship support off', () => {
+        const { componentText } = generateWithAmplifyFormRenderer(
+          'forms/composite-dog-datastore-create',
+          'datastore/composite-relationships',
+          undefined,
+        );
+        expect(componentText).not.toContain('CompositeBowl');
+        expect(componentText).not.toContain('CompositeOwner');
+        expect(componentText).not.toContain('CompositeToys');
+        expect(componentText).not.toContain('CompositeVets');
       });
     });
   });

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -29,6 +29,7 @@ import {
   StudioNode,
   StudioTemplateRenderer,
   validateFormSchema,
+  FormFeatureFlags,
 } from '@aws-amplify/codegen-ui';
 import { EOL } from 'os';
 import {
@@ -131,7 +132,12 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
   protected primaryKeys: string[] | undefined;
 
-  constructor(component: StudioForm, dataSchema: GenericDataSchema | undefined, renderConfig: ReactRenderConfig) {
+  constructor(
+    component: StudioForm,
+    dataSchema: GenericDataSchema | undefined,
+    renderConfig: ReactRenderConfig,
+    featureFlags?: FormFeatureFlags,
+  ) {
     super(component, new ReactOutputManager(), renderConfig);
     this.renderConfig = {
       ...defaultRenderConfig,
@@ -140,7 +146,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     // the super class creates a component aka form which is what we pass in this extended implmentation
     this.fileName = `${this.component.name}.${scriptKindToFileExtension(this.renderConfig.script)}`;
 
-    this.formDefinition = generateFormDefinition({ form: component, dataSchema });
+    this.formDefinition = generateFormDefinition({ form: component, dataSchema, featureFlags });
 
     // create a studio component which will represent the structure of the form
     this.formComponent = mapFormDefinitionToComponent(this.component.name, this.formDefinition);

--- a/packages/codegen-ui/lib/__tests__/check-support.test.ts
+++ b/packages/codegen-ui/lib/__tests__/check-support.test.ts
@@ -61,7 +61,7 @@ describe('checkIsSupportedAsForm', () => {
     expect(checkIsSupportedAsForm(model)).toBe(false);
   });
 
-  it('should support relationships', () => {
+  it('should support relationships if relationship is enabled', () => {
     const model: GenericDataModel = {
       primaryKeys: ['id'],
       fields: {
@@ -75,6 +75,23 @@ describe('checkIsSupportedAsForm', () => {
       },
     };
 
-    expect(checkIsSupportedAsForm(model)).toBe(true);
+    expect(checkIsSupportedAsForm(model, { isRelationshipSupported: true })).toBe(true);
+  });
+
+  it('should not support relationships if relationship is not enabled', () => {
+    const model: GenericDataModel = {
+      primaryKeys: ['id'],
+      fields: {
+        relationship: {
+          dataType: 'ID',
+          required: true,
+          readOnly: false,
+          isArray: false,
+          relationship: { type: 'HAS_ONE', relatedModelName: 'RelatedModel' },
+        },
+      },
+    };
+
+    expect(checkIsSupportedAsForm(model)).toBe(false);
   });
 });

--- a/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
@@ -95,7 +95,10 @@ describe('mapFormMetaData', () => {
       cta: {},
     };
 
-    const { fieldConfigs } = mapFormMetadata(form, generateFormDefinition({ form, dataSchema }));
+    const { fieldConfigs } = mapFormMetadata(
+      form,
+      generateFormDefinition({ form, dataSchema, featureFlags: { isRelationshipSupported: true } }),
+    );
 
     expect('Teachers' in fieldConfigs).toBe(true);
     expect(fieldConfigs.Teachers.isArray).toBe(true);
@@ -117,7 +120,10 @@ describe('mapFormMetaData', () => {
       cta: {},
     };
 
-    const { fieldConfigs } = mapFormMetadata(form, generateFormDefinition({ form, dataSchema }));
+    const { fieldConfigs } = mapFormMetadata(
+      form,
+      generateFormDefinition({ form, dataSchema, featureFlags: { isRelationshipSupported: true } }),
+    );
 
     expect('CPKStudent' in fieldConfigs).toBe(true);
     expect(fieldConfigs.CPKStudent.relationship).toStrictEqual({

--- a/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
@@ -15,7 +15,14 @@
  */
 
 import { mapModelFieldsConfigs, mapElementMatrix, mapStyles, mapElements, mapButtons } from './helpers';
-import { StudioForm, FormDefinition, ModelFieldsConfigs, StudioFieldPosition, GenericDataSchema } from '../types';
+import {
+  StudioForm,
+  FormDefinition,
+  ModelFieldsConfigs,
+  StudioFieldPosition,
+  GenericDataSchema,
+  FormFeatureFlags,
+} from '../types';
 import { InvalidInputError } from '../errors';
 
 /**
@@ -28,9 +35,11 @@ import { InvalidInputError } from '../errors';
 export function generateFormDefinition({
   form,
   dataSchema,
+  featureFlags,
 }: {
   form: StudioForm;
   dataSchema?: GenericDataSchema;
+  featureFlags?: FormFeatureFlags;
 }): FormDefinition {
   const formDefinition: FormDefinition = {
     form: { layoutStyle: mapStyles(form.style) },
@@ -56,6 +65,7 @@ export function generateFormDefinition({
       formDefinition,
       dataTypeName: form.dataType.dataTypeName,
       formActionType: form.formActionType,
+      featureFlags,
     });
   }
 

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -15,11 +15,13 @@
  */
 
 import { sentenceCase } from 'change-case';
+import { checkIsSupportedAsFormField } from '../../check-support';
 
 import { InvalidInputError } from '../../errors';
 import {
   FieldTypeMapKeys,
   FormDefinition,
+  FormFeatureFlags,
   GenericDataField,
   GenericDataModel,
   GenericDataSchema,
@@ -159,11 +161,13 @@ export function mapModelFieldsConfigs({
   formDefinition,
   dataSchema,
   formActionType,
+  featureFlags,
 }: {
   dataTypeName: string;
   dataSchema: GenericDataSchema;
   formDefinition: FormDefinition;
   formActionType?: StudioForm['formActionType'];
+  featureFlags?: FormFeatureFlags;
 }) {
   const modelFieldsConfigs: ModelFieldsConfigs = {};
   const model = dataSchema.models[dataTypeName];
@@ -176,6 +180,7 @@ export function mapModelFieldsConfigs({
     const isAutoExcludedField =
       field.readOnly ||
       (fieldName === 'id' && field.dataType === 'ID' && field.required) ||
+      !checkIsSupportedAsFormField(field, featureFlags) ||
       (field.relationship && !(typeof field.dataType === 'object' && 'model' in field.dataType));
 
     if (!isAutoExcludedField) {

--- a/packages/codegen-ui/lib/types/featureFlags.ts
+++ b/packages/codegen-ui/lib/types/featureFlags.ts
@@ -1,0 +1,19 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+export type FormFeatureFlags = {
+  isRelationshipSupported?: boolean;
+  isNonModelSupported?: boolean;
+};

--- a/packages/codegen-ui/lib/types/index.ts
+++ b/packages/codegen-ui/lib/types/index.ts
@@ -31,5 +31,6 @@ export * from './form';
 export * from './view';
 export * from './data';
 export * from './string-format';
+export * from './featureFlags';
 
 export type StudioSchema = StudioComponent | StudioForm | StudioView | StudioTheme;

--- a/packages/test-generator/lib/generators/NodeTestGenerator.ts
+++ b/packages/test-generator/lib/generators/NodeTestGenerator.ts
@@ -74,7 +74,11 @@ export class NodeTestGenerator extends TestGenerator {
     );
 
     this.formRendererFactory = new StudioTemplateRendererFactory(
-      (form: StudioForm) => new AmplifyFormRenderer(form, getGenericFromDataStore(schema), this.renderConfig),
+      (form: StudioForm) =>
+        new AmplifyFormRenderer(form, getGenericFromDataStore(schema), this.renderConfig, {
+          isNonModelSupported: true,
+          isRelationshipSupported: true,
+        }),
     );
     this.viewRendererFactory = new StudioTemplateRendererFactory(
       (view: StudioView) => new AmplifyViewRenderer(view, getGenericFromDataStore(schema), this.renderConfig),


### PR DESCRIPTION
…pport

*Issue #, if available:*

*Description of changes:*
Have relationship and non-model support enabled only through feature flagging.
When we GA these features, the default behavior (when no feature flags passed, etc.) will be changed to have relationship and non-model enabled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
