### PR TITLE
fix: allow empty non-required fields to save

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -379,6 +379,11 @@ export default function CreateCompositeDogForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const compositeDog = await DataStore.save(
             new CompositeDog({
               ...modelFields,
@@ -2817,6 +2822,11 @@ export default function MyPostForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Post(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -3594,6 +3604,11 @@ export default function UpdateCompositeDogForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const promises = [];
           const compositeToysToLink = [];
           const compositeToysToUnLink = [];
@@ -4574,6 +4589,11 @@ export default function UpdateCPKTeacherForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const promises = [];
           const cPKClassesToLinkMap = new Map();
           const cPKClassesToUnLinkMap = new Map();
@@ -6536,6 +6556,11 @@ export default function MyPostForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Post(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -7110,6 +7135,11 @@ export default function TagCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const tag = await DataStore.save(
             new Tag({
               ...modelFields,
@@ -7658,6 +7688,11 @@ export default function MyMemberForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Member(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -8125,6 +8160,11 @@ export default function SchoolCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const school = await DataStore.save(
             new School({
               ...modelFields,
@@ -8612,6 +8652,11 @@ export default function BookCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Book(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -9100,6 +9145,11 @@ export default function TagCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const tag = await DataStore.save(
             new Tag({
               ...modelFields,
@@ -9678,6 +9728,11 @@ export default function BookCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Book(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -10095,6 +10150,11 @@ export default function MyPostForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(
             Post.copyOf(postRecord, (updated) => {
               Object.assign(updated, modelFields);
@@ -10754,6 +10814,11 @@ export default function SchoolUpdateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const promises = [];
           const studentsToLink = [];
           const studentsToUnLink = [];
@@ -11280,6 +11345,11 @@ export default function MyMemberForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(
             Member.copyOf(memberRecord, (updated) => {
               Object.assign(updated, modelFields);
@@ -11798,6 +11868,11 @@ export default function TagUpdateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           const promises = [];
           const postsToLinkMap = new Map();
           const postsToUnLinkMap = new Map();
@@ -12397,6 +12472,11 @@ export default function MyFlexCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Flex0(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -12971,6 +13051,11 @@ export default function BlogCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Blog(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -13567,6 +13652,11 @@ export default function InputGalleryCreateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new InputGallery(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -14489,6 +14579,11 @@ export default function InputGalleryUpdateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(
             InputGallery.copyOf(inputGalleryRecord, (updated) => {
               Object.assign(updated, modelFields);
@@ -15357,6 +15452,11 @@ export default function MyFlexUpdateForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(
             Flex0.copyOf(flexRecord, (updated) => {
               Object.assign(updated, modelFields);
@@ -15785,6 +15885,11 @@ export default function PostCreateFormRow(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Post(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);
@@ -16391,6 +16496,11 @@ export default function MyMemberForm(props) {
           modelFields = onSubmit(modelFields);
         }
         try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
           await DataStore.save(new Member(modelFields));
           if (onSuccess) {
             onSuccess(modelFields);

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -31,6 +31,7 @@ import { onSubmitValidationRun, buildModelFieldObject } from '../forms/form-rend
 import { hasTokenReference } from '../utils/forms/layout-helpers';
 import { resetFunctionCheck } from '../forms/form-renderer-helper/value-props';
 import { isModelDataType } from '../forms/form-renderer-helper/render-checkers';
+import { replaceEmptyStringStatement } from '../forms/form-renderer-helper/cta-props';
 
 export default class FormRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -138,6 +139,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
         factory.createTryStatement(
           factory.createBlock(
             [
+              replaceEmptyStringStatement,
               ...buildDataStoreExpression(
                 formActionType,
                 dataTypeName,

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
@@ -102,6 +102,92 @@ const getRecordUpdateDataStoreCallExpression = ({
   );
 };
 
+/**
+  Object.entries(modelFields).forEach(([key, value]) => {
+    if (typeof value === 'string' && value.trim() === "") {
+      modelFields[key] = undefined;
+    }
+  });
+ */
+export const replaceEmptyStringStatement = factory.createExpressionStatement(
+  factory.createCallExpression(
+    factory.createPropertyAccessExpression(
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(factory.createIdentifier('Object'), factory.createIdentifier('entries')),
+        undefined,
+        [factory.createIdentifier('modelFields')],
+      ),
+      factory.createIdentifier('forEach'),
+    ),
+    undefined,
+    [
+      factory.createArrowFunction(
+        undefined,
+        undefined,
+        [
+          factory.createParameterDeclaration(
+            undefined,
+            undefined,
+            undefined,
+            factory.createArrayBindingPattern([
+              factory.createBindingElement(undefined, undefined, factory.createIdentifier('key'), undefined),
+              factory.createBindingElement(undefined, undefined, factory.createIdentifier('value'), undefined),
+            ]),
+            undefined,
+            undefined,
+            undefined,
+          ),
+        ],
+        undefined,
+        factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+        factory.createBlock(
+          [
+            factory.createIfStatement(
+              factory.createBinaryExpression(
+                factory.createBinaryExpression(
+                  factory.createTypeOfExpression(factory.createIdentifier('value')),
+                  factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                  factory.createStringLiteral('string'),
+                ),
+                factory.createToken(SyntaxKind.AmpersandAmpersandToken),
+                factory.createBinaryExpression(
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('value'),
+                      factory.createIdentifier('trim'),
+                    ),
+                    undefined,
+                    [],
+                  ),
+                  factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                  factory.createStringLiteral(''),
+                ),
+              ),
+              factory.createBlock(
+                [
+                  factory.createExpressionStatement(
+                    factory.createBinaryExpression(
+                      factory.createElementAccessExpression(
+                        factory.createIdentifier('modelFields'),
+                        factory.createIdentifier('key'),
+                      ),
+                      factory.createToken(SyntaxKind.EqualsToken),
+                      factory.createIdentifier('undefined'),
+                    ),
+                  ),
+                ],
+                true,
+              ),
+              undefined,
+            ),
+          ],
+          true,
+        ),
+      ),
+    ],
+  ),
+);
+
 export const buildDataStoreExpression = (
   dataStoreActionType: 'update' | 'create',
   modelName: string,

--- a/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
@@ -92,6 +92,23 @@ describe('CreateForms', () => {
   });
 
   describe('DataStoreFormCreateAllSupportedFormFields', () => {
+    beforeEach(() => {
+      cy.reload();
+    });
+    it('should save to DataStore with blank values in non-required fields', () => {
+      cy.get('#dataStoreFormCreateAllSupportedFormFields').within(() => {
+        getInputByLabel('String').type('MyString');
+
+        cy.contains('Submit').click();
+
+        cy.contains(/MyString/).then((recordElement: JQuery) => {
+          const record = JSON.parse(recordElement.text());
+
+          expect(record.string).to.equal('MyString');
+        });
+      });
+    });
+
     it('should save to DataStore', () => {
       cy.get('#dataStoreFormCreateAllSupportedFormFields').within(() => {
         getInputByLabel('String').type('MyString');

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -28,6 +28,9 @@ describe('UpdateForms', () => {
   });
 
   describe('DataStoreFormUpdateAllSupportedFormFields', () => {
+    beforeEach(() => {
+      cy.reload();
+    });
     it('should display current values and save to DataStore', () => {
       cy.get('#dataStoreFormUpdateAllSupportedFormFields').within(() => {
         // TODO: check current values on all fields and change
@@ -97,9 +100,6 @@ describe('UpdateForms', () => {
     });
 
     it('should remove hasOne and belongsTo relationships', () => {
-      // reset state
-      cy.reload();
-
       cy.get('#dataStoreFormUpdateAllSupportedFormFields').within(() => {
         // hasOne
         removeArrayItem('John Lennon');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If a non-required field is empty, DataStore.save would fail because we would try to save `""` for `AWSEmail`, etc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
