### PR TITLE
fix: remove functions imported from devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18460,7 +18460,7 @@
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
-        "parse-url": ">=6.0.1"
+        "parse-url": "^6.0.0"
       }
     },
     "git-url-parse": {
@@ -21457,8 +21457,7 @@
       }
     },
     "parse-url": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
+      "version": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
       "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
       "dev": true,
       "requires": {

--- a/packages/codegen-ui-golden-files/package-lock.json
+++ b/packages/codegen-ui-golden-files/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-golden-files",
-			"version": "2.7.0",
+			"version": "2.7.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-amplify/datastore": "^3.12.12",

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
@@ -23,7 +23,6 @@ import {
   ConcatenatedStudioComponentProperty,
 } from '@aws-amplify/codegen-ui';
 import { StudioFormInputFieldProperty } from '@aws-amplify/codegen-ui/lib/types/form/input-config';
-import { isEnumFieldType } from '@aws-amplify/datastore';
 import {
   Expression,
   factory,
@@ -45,7 +44,7 @@ import {
 } from '../../react-component-render-helper';
 import { buildAccessChain, getRecordsName } from './form-state';
 import { getElementAccessExpression, getValidProperty } from './invalid-variable-helpers';
-import { isModelDataType } from './render-checkers';
+import { isEnumDataType, isModelDataType } from './render-checkers';
 
 export const getDisplayValueObjectName = 'getDisplayValue';
 
@@ -412,7 +411,7 @@ export function buildDisplayValueFunction(fieldName: string, fieldConfig: FieldC
     }
   }
 
-  if (isEnumFieldType(fieldConfig.dataType) && fieldConfig.valueMappings && fieldConfig.isArray) {
+  if (isEnumDataType(fieldConfig) && fieldConfig.valueMappings && fieldConfig.isArray) {
     const displayValueMapName = `enumDisplayValueMap`;
     additionalStatements = [
       factory.createVariableStatement(

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-checkers.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-checkers.ts
@@ -14,7 +14,6 @@
   limitations under the License.
  */
 import { FieldConfigMetadata } from '@aws-amplify/codegen-ui';
-import { isEnumFieldType } from '@aws-amplify/datastore';
 
 export const shouldWrapInArrayField = (config: FieldConfigMetadata): boolean => config.isArray || !!config.relationship;
 
@@ -23,8 +22,13 @@ export const isModelDataType = (
 ): config is FieldConfigMetadata & { dataType: { model: string } } =>
   !!(config.dataType && typeof config.dataType === 'object' && 'model' in config.dataType);
 
+export const isEnumDataType = (
+  config: FieldConfigMetadata,
+): config is FieldConfigMetadata & { dataType: { enum: string } } =>
+  !!(config.dataType && typeof config.dataType === 'object' && 'enum' in config.dataType);
+
 export const shouldImplementDisplayValueFunction = (config: FieldConfigMetadata): boolean => {
-  return isModelDataType(config) || (isEnumFieldType(config.dataType) && shouldWrapInArrayField(config));
+  return isModelDataType(config) || (isEnumDataType(config) && shouldWrapInArrayField(config));
 };
 
 export const shouldImplementIDValueFunction = (config: FieldConfigMetadata): boolean => {

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-react",
-			"version": "2.7.0",
+			"version": "2.7.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript/vfs": "~1.3.5",

--- a/packages/codegen-ui/lib/utils/form-component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/form-component-metadata.ts
@@ -13,7 +13,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { isEnumFieldType } from '@aws-amplify/datastore';
 import { camelCase } from 'change-case';
 
 import {
@@ -93,7 +92,11 @@ export const mapFormMetadata = (form: StudioForm, formDefinition: FormDefinition
           });
         }
 
-        if ((element.relationship || isEnumFieldType(element.dataType)) && 'valueMappings' in element) {
+        if (
+          (element.relationship ||
+            (element.dataType && typeof element.dataType === 'object' && 'enum' in element.dataType)) &&
+          'valueMappings' in element
+        ) {
           metadata.valueMappings = element.valueMappings;
         }
 

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui",
-			"version": "2.7.0",
+			"version": "2.7.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"change-case": "^4.1.2",

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@aws-amplify/codegen-ui-test-generator",
-			"version": "2.7.0",
+			"version": "2.7.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "^15.12.1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Using functions imported from devDep `@aws-amplify/datastore` is causing CLI e2e tests to fail. 
This removes their usage and replaces w/ our own helper.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
