### PR TITLE
fix: parse and stringify nonmodel fields

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -2872,6 +2872,9 @@ export default function MyPostForm(props) {
               nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
                 JSON.parse(s)
               ),
+              nonModelField: modelFields.nonModelField
+                ? JSON.parse(modelFields.nonModelField)
+                : modelFields.nonModelField,
             })
           );
           if (onSuccess) {
@@ -6876,6 +6879,9 @@ export default function MyPostForm(props) {
               nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
                 JSON.parse(s)
               ),
+              nonModelField: modelFields.nonModelField
+                ? JSON.parse(modelFields.nonModelField)
+                : modelFields.nonModelField,
             })
           );
           if (onSuccess) {
@@ -10603,7 +10609,11 @@ export default function MyPostForm(props) {
         ? cleanValues.nonModelField
         : JSON.stringify(cleanValues.nonModelField)
     );
-    setNonModelFieldArray(cleanValues.nonModelFieldArray ?? []);
+    setNonModelFieldArray(
+      cleanValues.nonModelFieldArray?.map((item) =>
+        typeof item === \\"string\\" ? item : JSON.stringify(item)
+      ) ?? []
+    );
     setCurrentNonModelFieldArrayValue(\\"\\");
     setErrors({});
   };
@@ -10693,7 +10703,15 @@ export default function MyPostForm(props) {
           });
           await DataStore.save(
             Post.copyOf(postRecord, (updated) => {
-              Object.assign(updated, modelFields);
+              Object.assign(updated, {
+                ...modelFields,
+                nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
+                  JSON.parse(s)
+                ),
+                nonModelField: modelFields.nonModelField
+                  ? JSON.parse(modelFields.nonModelField)
+                  : modelFields.nonModelField,
+              });
             })
           );
           if (onSuccess) {
@@ -16580,6 +16598,9 @@ export default function PostCreateFormRow(props) {
               nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
                 JSON.parse(s)
               ),
+              nonModelField: modelFields.nonModelField
+                ? JSON.parse(modelFields.nonModelField)
+                : modelFields.nonModelField,
             })
           );
           if (onSuccess) {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/parse-fields.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/parse-fields.ts
@@ -1,0 +1,134 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { isNonModelDataType, FieldConfigMetadata } from '@aws-amplify/codegen-ui';
+import {
+  PropertyAccessExpression,
+  Identifier,
+  factory,
+  SyntaxKind,
+  Expression,
+  ObjectLiteralExpression,
+} from 'typescript';
+/**
+ * JSON.parse(s)
+ */
+export const parseValue = (expression: Expression) =>
+  factory.createCallExpression(
+    factory.createPropertyAccessExpression(factory.createIdentifier('JSON'), factory.createIdentifier('parse')),
+    undefined,
+    [expression],
+  );
+
+/**
+ * modelFields.nonModelFieldArray.map(s => JSON.parse(item))
+ */
+export const parseArrayValues = (accessName: PropertyAccessExpression | Identifier) => {
+  return factory.createCallExpression(
+    factory.createPropertyAccessExpression(accessName, factory.createIdentifier('map')),
+    undefined,
+    [
+      factory.createArrowFunction(
+        undefined,
+        undefined,
+        [
+          factory.createParameterDeclaration(
+            undefined,
+            undefined,
+            undefined,
+            factory.createIdentifier('s'),
+            undefined,
+            undefined,
+          ),
+        ],
+        undefined,
+        factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+        parseValue(factory.createIdentifier('s')),
+      ),
+    ],
+  );
+};
+
+/**
+ * arrayFields = nonModelFieldArray: modelFields.nonModelFieldArray.map(s => JSON.parse(item))
+ * singleFields =
+ *  nonModelField: modelFields.nonModelField ? JSON.parse(modelFields.nonModelField) : modelFields.nonModelField
+ */
+export const generateParsePropertyAssignments = (arrayFields: string[], nonArrayFields: string[]) => {
+  const parseArrayFields = arrayFields.map((field) =>
+    factory.createPropertyAssignment(
+      factory.createIdentifier(field),
+      parseArrayValues(
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('modelFields'),
+          factory.createIdentifier(field),
+        ),
+      ),
+    ),
+  );
+  const parseFields = nonArrayFields.map((field) =>
+    factory.createPropertyAssignment(
+      factory.createIdentifier(field),
+      factory.createConditionalExpression(
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('modelFields'),
+          factory.createIdentifier(field),
+        ),
+        factory.createToken(SyntaxKind.QuestionToken),
+        parseValue(
+          factory.createPropertyAccessExpression(
+            factory.createIdentifier('modelFields'),
+            factory.createIdentifier(field),
+          ),
+        ),
+        factory.createToken(SyntaxKind.ColonToken),
+        factory.createPropertyAccessExpression(
+          factory.createIdentifier('modelFields'),
+          factory.createIdentifier(field),
+        ),
+      ),
+    ),
+  );
+  return [...parseArrayFields, ...parseFields];
+};
+
+//
+export const generateUpdateModelObject = (
+  fieldConfigs: Record<string, FieldConfigMetadata>,
+  modelFieldsObjectName: string,
+) => {
+  const nonModelFields: string[] = [];
+  const nonModelArrayFields: string[] = [];
+
+  Object.entries(fieldConfigs).forEach(([name, { dataType, sanitizedFieldName, isArray }]) => {
+    if (isNonModelDataType(dataType)) {
+      const renderedFieldName = sanitizedFieldName || name;
+      if (!isArray) {
+        nonModelFields.push(renderedFieldName);
+      } else {
+        nonModelArrayFields.push(renderedFieldName);
+      }
+    }
+  });
+  const parsePropertyAssignments = generateParsePropertyAssignments(nonModelArrayFields, nonModelFields);
+  let updateModelObject: ObjectLiteralExpression | Identifier = factory.createIdentifier(modelFieldsObjectName);
+  if (parsePropertyAssignments.length) {
+    updateModelObject = factory.createObjectLiteralExpression(
+      [factory.createSpreadAssignment(factory.createIdentifier(modelFieldsObjectName)), ...parsePropertyAssignments],
+      true,
+    );
+  }
+  return updateModelObject;
+};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- parse nonmodel fields on submit
- stringify nonmodel fields on update form load

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
