### PR TITLE
fix: enforce bidirectionality between hasOne and belongsTo

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -388,8 +388,32 @@ export default function CreateCompositeDogForm(props) {
               CompositeVets: undefined,
             })
           );
-          await Promise.all(
-            CompositeToys.reduce((promises, original) => {
+          const promises = [];
+          const compositeOwnerToLink = modelFields.CompositeOwner;
+          if (compositeOwnerToLink) {
+            promises.push(
+              DataStore.save(
+                CompositeOwner0.copyOf(compositeOwnerToLink, (updated) => {
+                  updated.CompositeDog = compositeDog;
+                })
+              )
+            );
+            const compositeDogToUnlink =
+              await compositeOwnerToLink.CompositeDog;
+            if (compositeDogToUnlink) {
+              promises.push(
+                DataStore.save(
+                  CompositeDog.copyOf(compositeDogToUnlink, (updated) => {
+                    updated.CompositeOwner = undefined;
+                    updated.compositeDogCompositeOwnerLastName = undefined;
+                    updated.compositeDogCompositeOwnerFirstName = undefined;
+                  })
+                )
+              );
+            }
+          }
+          promises.push(
+            ...CompositeToys.reduce((promises, original) => {
               promises.push(
                 DataStore.save(
                   CompositeToy.copyOf(original, (updated) => {
@@ -402,8 +426,8 @@ export default function CreateCompositeDogForm(props) {
               return promises;
             }, [])
           );
-          await Promise.all(
-            CompositeVets.reduce((promises, compositeVet) => {
+          promises.push(
+            ...CompositeVets.reduce((promises, compositeVet) => {
               promises.push(
                 DataStore.save(
                   new CompositeDogCompositeVet({
@@ -415,6 +439,7 @@ export default function CreateCompositeDogForm(props) {
               return promises;
             }, [])
           );
+          await Promise.all(promises);
           if (onSuccess) {
             onSuccess(modelFields);
           }
@@ -3691,6 +3716,42 @@ export default function UpdateCompositeDogForm(props) {
             }
           });
           const promises = [];
+          const compositeOwnerToUnlink =
+            await compositeDogRecord.CompositeOwner;
+          if (compositeOwnerToUnlink) {
+            promises.push(
+              DataStore.save(
+                CompositeOwner0.copyOf(compositeOwnerToUnlink, (updated) => {
+                  updated.CompositeDog = undefined;
+                  updated.compositeOwnerCompositeDogName = undefined;
+                  updated.compositeOwnerCompositeDogDescription = undefined;
+                })
+              )
+            );
+          }
+          const compositeOwnerToLink = modelFields.CompositeOwner;
+          if (compositeOwnerToLink) {
+            promises.push(
+              DataStore.save(
+                CompositeOwner0.copyOf(compositeOwnerToLink, (updated) => {
+                  updated.CompositeDog = compositeDogRecord;
+                })
+              )
+            );
+            const compositeDogToUnlink =
+              await compositeOwnerToLink.CompositeDog;
+            if (compositeDogToUnlink) {
+              promises.push(
+                DataStore.save(
+                  CompositeDog.copyOf(compositeDogToUnlink, (updated) => {
+                    updated.CompositeOwner = undefined;
+                    updated.compositeDogCompositeOwnerLastName = undefined;
+                    updated.compositeDogCompositeOwnerFirstName = undefined;
+                  })
+                )
+              );
+            }
+          }
           const compositeToysToLink = [];
           const compositeToysToUnLink = [];
           const compositeToysSet = new Set();
@@ -7459,8 +7520,9 @@ export default function TagCreateForm(props) {
               Posts: undefined,
             })
           );
-          await Promise.all(
-            Posts.reduce((promises, post) => {
+          const promises = [];
+          promises.push(
+            ...Posts.reduce((promises, post) => {
               promises.push(
                 DataStore.save(
                   new TagPost({
@@ -7472,6 +7534,7 @@ export default function TagCreateForm(props) {
               return promises;
             }, [])
           );
+          await Promise.all(promises);
           if (onSuccess) {
             onSuccess(modelFields);
           }
@@ -8478,8 +8541,9 @@ export default function SchoolCreateForm(props) {
               Students: undefined,
             })
           );
-          await Promise.all(
-            Students.reduce((promises, original) => {
+          const promises = [];
+          promises.push(
+            ...Students.reduce((promises, original) => {
               promises.push(
                 DataStore.save(
                   Student.copyOf(original, (updated) => {
@@ -8490,6 +8554,7 @@ export default function SchoolCreateForm(props) {
               return promises;
             }, [])
           );
+          await Promise.all(promises);
           if (onSuccess) {
             onSuccess(modelFields);
           }
@@ -9464,8 +9529,9 @@ export default function TagCreateForm(props) {
               Posts: undefined,
             })
           );
-          await Promise.all(
-            Posts.reduce((promises, post) => {
+          const promises = [];
+          promises.push(
+            ...Posts.reduce((promises, post) => {
               promises.push(
                 DataStore.save(
                   new TagPost({
@@ -9477,6 +9543,7 @@ export default function TagCreateForm(props) {
               return promises;
             }, [])
           );
+          await Promise.all(promises);
           if (onSuccess) {
             onSuccess(modelFields);
           }

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -146,6 +146,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                 importedModelName,
                 formMetadata.fieldConfigs,
                 dataSchemaMetadata,
+                this.importCollection,
               ),
               // call onSuccess hook if it exists
               factory.createIfStatement(

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/bidirectional-relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/bidirectional-relationship.ts
@@ -1,0 +1,458 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { GenericDataSchema, GenericDataField } from '@aws-amplify/codegen-ui';
+import { FieldConfigMetadata } from '@aws-amplify/codegen-ui/lib/types';
+import { factory, NodeFlags, SyntaxKind } from 'typescript';
+import { lowerCaseFirst } from '../../helpers';
+import { ImportCollection, ImportSource } from '../../imports';
+import { isModelDataType } from './render-checkers';
+import { getRecordName } from './form-state';
+
+function getFieldBiDirectionalWith({
+  modelName,
+  dataSchema,
+  fieldConfig,
+}: {
+  modelName: string;
+  dataSchema: GenericDataSchema;
+  fieldConfig: [string, FieldConfigMetadata];
+}):
+  | {
+      relatedModelName: string;
+      fieldBiDirectionalWithName: string;
+      fieldBiDirectionalWith: GenericDataField;
+      associatedFieldsBiDirectionalWith: string[];
+    }
+  | undefined {
+  const [, fieldConfigMetaData] = fieldConfig;
+
+  if (
+    isModelDataType(fieldConfigMetaData) &&
+    fieldConfigMetaData.relationship &&
+    (fieldConfigMetaData.relationship.type === 'HAS_ONE' || fieldConfigMetaData.relationship.type === 'BELONGS_TO')
+  ) {
+    const { relatedModelName } = fieldConfigMetaData.relationship;
+    const fieldBiDirectionalWith = Object.entries(dataSchema.models[relatedModelName]?.fields ?? {}).find(
+      ([, fieldInfo]) => {
+        if (
+          typeof fieldInfo.dataType === 'object' &&
+          'model' in fieldInfo.dataType &&
+          fieldInfo.dataType.model === modelName &&
+          fieldConfigMetaData.relationship &&
+          (fieldConfigMetaData.relationship.type === 'HAS_ONE' ||
+            fieldConfigMetaData.relationship.type === 'BELONGS_TO')
+        ) {
+          return true;
+        }
+        return false;
+      },
+    );
+    if (!fieldBiDirectionalWith) {
+      return undefined;
+    }
+    const [name, field] = fieldBiDirectionalWith;
+    if (field.relationship?.type === 'HAS_ONE' || field.relationship?.type === 'BELONGS_TO') {
+      return {
+        relatedModelName,
+        fieldBiDirectionalWithName: name,
+        fieldBiDirectionalWith: field,
+        associatedFieldsBiDirectionalWith: field.relationship.associatedFields
+          ? field.relationship.associatedFields
+          : [],
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export function getBiDirectionalRelationshipStatements({
+  formActionType,
+  dataSchema,
+  importCollection,
+  fieldConfig,
+  modelName,
+  savedRecordName,
+}: {
+  formActionType: 'create' | 'update';
+  dataSchema: GenericDataSchema;
+  importCollection: ImportCollection;
+  fieldConfig: [string, FieldConfigMetadata];
+  modelName: string;
+  savedRecordName: string;
+}) {
+  const getFieldBiDirectionalWithReturnValue = getFieldBiDirectionalWith({
+    modelName,
+    dataSchema,
+    fieldConfig,
+  });
+
+  if (!getFieldBiDirectionalWithReturnValue) {
+    return [];
+  }
+
+  const currentRecord = formActionType === 'update' ? getRecordName(modelName) : savedRecordName;
+
+  const { relatedModelName, fieldBiDirectionalWithName, associatedFieldsBiDirectionalWith } =
+    getFieldBiDirectionalWithReturnValue;
+  const [fieldName, { relationship }] = fieldConfig;
+  const importedRelatedModelName = importCollection.getMappedAlias(ImportSource.LOCAL_MODELS, relatedModelName);
+  const importedThisModelName = importCollection.getMappedAlias(ImportSource.LOCAL_MODELS, modelName);
+  // TODO: setting associated fields to `undefined` is a workaround.
+  // remove after DataStore addresses issue: https://github.com/aws-amplify/amplify-js/issues/10750
+  const associatedFields =
+    (relationship?.type === 'HAS_ONE' || relationship?.type === 'BELONGS_TO') && relationship.associatedFields
+      ? relationship.associatedFields
+      : [];
+
+  const statements: any[] = [];
+  if (formActionType === 'update') {
+    const relatedRecordToUnlink = `${lowerCaseFirst(relatedModelName)}ToUnlink`;
+    /**
+          const compositeOwnerToUnlink = await compositeDogRecord.CompositeOwner;
+          if(compositeOwnerToUnlink) {
+           promises.push( DataStore.save(CompositeOwner0.copyOf(compositeOwnerToUnlink, (updated) => {
+              updated.compositeOwnerCompositeDogName = undefined;
+              updated.compositeOwnerCompositeDogDescription = undefined;
+              updated.CompositeDog = undefined;
+            })))
+          }
+         */
+    statements.push(
+      ...[
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier(relatedRecordToUnlink),
+                undefined,
+                undefined,
+                factory.createAwaitExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier(currentRecord),
+                    factory.createIdentifier(fieldName),
+                  ),
+                ),
+              ),
+            ],
+            NodeFlags.Const,
+          ),
+        ),
+        factory.createIfStatement(
+          factory.createIdentifier(relatedRecordToUnlink),
+          factory.createBlock(
+            [
+              factory.createExpressionStatement(
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('promises'),
+                    factory.createIdentifier('push'),
+                  ),
+                  undefined,
+                  [
+                    factory.createCallExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier('DataStore'),
+                        factory.createIdentifier('save'),
+                      ),
+                      undefined,
+                      [
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier(importedRelatedModelName),
+                            factory.createIdentifier('copyOf'),
+                          ),
+                          undefined,
+                          [
+                            factory.createIdentifier(relatedRecordToUnlink),
+                            factory.createArrowFunction(
+                              undefined,
+                              undefined,
+                              [
+                                factory.createParameterDeclaration(
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  factory.createIdentifier('updated'),
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                ),
+                              ],
+                              undefined,
+                              factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                              factory.createBlock(
+                                [
+                                  factory.createExpressionStatement(
+                                    factory.createBinaryExpression(
+                                      factory.createPropertyAccessExpression(
+                                        factory.createIdentifier('updated'),
+                                        factory.createIdentifier(fieldBiDirectionalWithName),
+                                      ),
+                                      factory.createToken(SyntaxKind.EqualsToken),
+                                      factory.createIdentifier('undefined'),
+                                    ),
+                                  ),
+                                  ...associatedFieldsBiDirectionalWith.map((field) =>
+                                    factory.createExpressionStatement(
+                                      factory.createBinaryExpression(
+                                        factory.createPropertyAccessExpression(
+                                          factory.createIdentifier('updated'),
+                                          factory.createIdentifier(field),
+                                        ),
+                                        factory.createToken(SyntaxKind.EqualsToken),
+                                        factory.createIdentifier('undefined'),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                                true,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            true,
+          ),
+          undefined,
+        ),
+      ],
+    );
+  }
+
+  /** 
+          const compositeOwnerToLink = modelFields.CompositeOwner;
+          if (compositeOwnerToLink) {
+            promises.push(DataStore.save(CompositeOwner0.copyOf(compositeOwnerToLink, (updated) => {
+              updated.CompositeDog = compositeDogRecord;
+            })))
+
+            const compositeDogToUnlink = await compositeOwnerToLink.CompositeDog;
+            if (compositeDogToUnlink) {
+              promises.push(DataStore.save(CompositeDog.copyOf(compositeDogToUnlink, (updated) => {
+                updated.compositeDogCompositeOwnerLastName = undefined;
+                updated.compositeDogCompositeOwnerFirstName = undefined;
+                updated.CompositeOwner = undefined;
+              })))
+            }
+          }
+     */
+  const relatedRecordToLink = `${lowerCaseFirst(relatedModelName)}ToLink`;
+  const thisModelRecordToUnlink = `${lowerCaseFirst(modelName)}ToUnlink`;
+
+  statements.push(
+    ...[
+      factory.createVariableStatement(
+        undefined,
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              factory.createIdentifier(relatedRecordToLink),
+              undefined,
+              undefined,
+              factory.createPropertyAccessExpression(
+                factory.createIdentifier('modelFields'),
+                factory.createIdentifier(fieldName),
+              ),
+            ),
+          ],
+          NodeFlags.Const,
+        ),
+      ),
+      factory.createIfStatement(
+        factory.createIdentifier(relatedRecordToLink),
+        factory.createBlock(
+          [
+            factory.createExpressionStatement(
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('promises'),
+                  factory.createIdentifier('push'),
+                ),
+                undefined,
+                [
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('DataStore'),
+                      factory.createIdentifier('save'),
+                    ),
+                    undefined,
+                    [
+                      factory.createCallExpression(
+                        factory.createPropertyAccessExpression(
+                          factory.createIdentifier(importedRelatedModelName),
+                          factory.createIdentifier('copyOf'),
+                        ),
+                        undefined,
+                        [
+                          factory.createIdentifier(relatedRecordToLink),
+                          factory.createArrowFunction(
+                            undefined,
+                            undefined,
+                            [
+                              factory.createParameterDeclaration(
+                                undefined,
+                                undefined,
+                                undefined,
+                                factory.createIdentifier('updated'),
+                                undefined,
+                                undefined,
+                                undefined,
+                              ),
+                            ],
+                            undefined,
+                            factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                            factory.createBlock(
+                              [
+                                factory.createExpressionStatement(
+                                  factory.createBinaryExpression(
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier('updated'),
+                                      factory.createIdentifier(fieldBiDirectionalWithName),
+                                    ),
+                                    factory.createToken(SyntaxKind.EqualsToken),
+                                    factory.createIdentifier(currentRecord),
+                                  ),
+                                ),
+                              ],
+                              true,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            factory.createVariableStatement(
+              undefined,
+              factory.createVariableDeclarationList(
+                [
+                  factory.createVariableDeclaration(
+                    factory.createIdentifier(thisModelRecordToUnlink),
+                    undefined,
+                    undefined,
+                    factory.createAwaitExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier(relatedRecordToLink),
+                        factory.createIdentifier(fieldBiDirectionalWithName),
+                      ),
+                    ),
+                  ),
+                ],
+                NodeFlags.Const,
+              ),
+            ),
+            factory.createIfStatement(
+              factory.createIdentifier(thisModelRecordToUnlink),
+              factory.createBlock(
+                [
+                  factory.createExpressionStatement(
+                    factory.createCallExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier('promises'),
+                        factory.createIdentifier('push'),
+                      ),
+                      undefined,
+                      [
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('DataStore'),
+                            factory.createIdentifier('save'),
+                          ),
+                          undefined,
+                          [
+                            factory.createCallExpression(
+                              factory.createPropertyAccessExpression(
+                                factory.createIdentifier(importedThisModelName),
+                                factory.createIdentifier('copyOf'),
+                              ),
+                              undefined,
+                              [
+                                factory.createIdentifier(thisModelRecordToUnlink),
+                                factory.createArrowFunction(
+                                  undefined,
+                                  undefined,
+                                  [
+                                    factory.createParameterDeclaration(
+                                      undefined,
+                                      undefined,
+                                      undefined,
+                                      factory.createIdentifier('updated'),
+                                      undefined,
+                                      undefined,
+                                      undefined,
+                                    ),
+                                  ],
+                                  undefined,
+                                  factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                                  factory.createBlock(
+                                    [
+                                      factory.createExpressionStatement(
+                                        factory.createBinaryExpression(
+                                          factory.createPropertyAccessExpression(
+                                            factory.createIdentifier('updated'),
+                                            factory.createIdentifier(fieldName),
+                                          ),
+                                          factory.createToken(SyntaxKind.EqualsToken),
+                                          factory.createIdentifier('undefined'),
+                                        ),
+                                      ),
+                                      ...associatedFields.map((field) =>
+                                        factory.createExpressionStatement(
+                                          factory.createBinaryExpression(
+                                            factory.createPropertyAccessExpression(
+                                              factory.createIdentifier('updated'),
+                                              factory.createIdentifier(field),
+                                            ),
+                                            factory.createToken(SyntaxKind.EqualsToken),
+                                            factory.createIdentifier('undefined'),
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+                true,
+              ),
+              undefined,
+            ),
+          ],
+          true,
+        ),
+        undefined,
+      ),
+    ],
+  );
+
+  return statements;
+}

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
@@ -63,6 +63,8 @@ export const getCurrentDisplayValueName = (fieldName: string) =>
 
 export const getRecordsName = (modelName: string) => `${lowerCaseFirst(modelName)}Records`;
 
+export const getRecordName = (modelName: string) => `${lowerCaseFirst(modelName)}Record`;
+
 export const getLinkedDataName = (modelName: string) => `linked${capitalizeFirstLetter(modelName)}`;
 
 export const getCurrentValueIdentifier = (fieldName: string) =>

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -983,101 +983,108 @@ export const buildManyToManyRelationshipDataStoreStatements = (
       ),
     ];
   }
+
   return [
     factory.createExpressionStatement(
-      factory.createAwaitExpression(
-        factory.createCallExpression(
-          factory.createPropertyAccessExpression(factory.createIdentifier('Promise'), factory.createIdentifier('all')),
-          undefined,
-          [
-            factory.createCallExpression(
-              factory.createPropertyAccessExpression(
-                factory.createIdentifier(fieldName),
-                factory.createIdentifier('reduce'),
-              ),
-              undefined,
-              [
-                factory.createArrowFunction(
-                  undefined,
-                  undefined,
-                  [
-                    factory.createParameterDeclaration(
-                      undefined,
-                      undefined,
-                      undefined,
-                      factory.createIdentifier('promises'),
-                      undefined,
-                      undefined,
-                      undefined,
-                    ),
-                    factory.createParameterDeclaration(
-                      undefined,
-                      undefined,
-                      undefined,
-                      factory.createIdentifier(joinTableRelatedModelName),
-                      undefined,
-                      undefined,
-                      undefined,
-                    ),
-                  ],
-                  undefined,
-                  factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                  factory.createBlock(
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(factory.createIdentifier('promises'), factory.createIdentifier('push')),
+        undefined,
+        [
+          factory.createSpreadElement(
+            factory.createParenthesizedExpression(
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier(fieldName),
+                  factory.createIdentifier('reduce'),
+                ),
+                undefined,
+                [
+                  factory.createArrowFunction(
+                    undefined,
+                    undefined,
                     [
-                      factory.createExpressionStatement(
-                        factory.createCallExpression(
-                          factory.createPropertyAccessExpression(
-                            factory.createIdentifier('promises'),
-                            factory.createIdentifier('push'),
-                          ),
-                          undefined,
-                          [
-                            factory.createCallExpression(
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier('DataStore'),
-                                factory.createIdentifier('save'),
-                              ),
-                              undefined,
-                              [
-                                factory.createNewExpression(factory.createIdentifier(relatedJoinTableName), undefined, [
-                                  // {
-                                  //   cpkTeacher: cPKTeacher,
-                                  //   cpkClass,
-                                  // }
-                                  factory.createObjectLiteralExpression(
+                      factory.createParameterDeclaration(
+                        undefined,
+                        undefined,
+                        undefined,
+                        factory.createIdentifier('promises'),
+                        undefined,
+                        undefined,
+                        undefined,
+                      ),
+                      factory.createParameterDeclaration(
+                        undefined,
+                        undefined,
+                        undefined,
+                        factory.createIdentifier(joinTableRelatedModelName),
+                        undefined,
+                        undefined,
+                        undefined,
+                      ),
+                    ],
+                    undefined,
+                    factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                    factory.createBlock(
+                      [
+                        factory.createExpressionStatement(
+                          factory.createCallExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('promises'),
+                              factory.createIdentifier('push'),
+                            ),
+                            undefined,
+                            [
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('DataStore'),
+                                  factory.createIdentifier('save'),
+                                ),
+                                undefined,
+                                [
+                                  factory.createNewExpression(
+                                    factory.createIdentifier(relatedJoinTableName),
+                                    undefined,
                                     [
-                                      savedModelName === joinTableThisModelName
-                                        ? factory.createShorthandPropertyAssignment(
-                                            factory.createIdentifier(joinTableThisModelName),
+                                      // {
+                                      //   cpkTeacher: cPKTeacher,
+                                      //   cpkClass,
+                                      // }
+                                      factory.createObjectLiteralExpression(
+                                        [
+                                          savedModelName === joinTableThisModelName
+                                            ? factory.createShorthandPropertyAssignment(
+                                                factory.createIdentifier(joinTableThisModelName),
+                                                undefined,
+                                              )
+                                            : factory.createPropertyAssignment(
+                                                factory.createIdentifier(joinTableThisModelName),
+                                                factory.createIdentifier(savedModelName),
+                                              ),
+                                          factory.createShorthandPropertyAssignment(
+                                            factory.createIdentifier(joinTableRelatedModelName),
                                             undefined,
-                                          )
-                                        : factory.createPropertyAssignment(
-                                            factory.createIdentifier(joinTableThisModelName),
-                                            factory.createIdentifier(savedModelName),
                                           ),
-                                      factory.createShorthandPropertyAssignment(
-                                        factory.createIdentifier(joinTableRelatedModelName),
-                                        undefined,
+                                        ],
+                                        true,
                                       ),
                                     ],
-                                    true,
                                   ),
-                                ]),
-                              ],
-                            ),
-                          ],
+                                ],
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                      factory.createReturnStatement(factory.createIdentifier('promises')),
-                    ],
-                    true,
+                        factory.createReturnStatement(factory.createIdentifier('promises')),
+                      ],
+                      true,
+                    ),
                   ),
-                ),
-                factory.createArrayLiteralExpression([], false),
-              ],
+                  factory.createArrayLiteralExpression([], false),
+                ],
+              ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     ),
   ];
@@ -1709,107 +1716,109 @@ export const buildHasManyRelationshipDataStoreStatements = (
   }
   return [
     factory.createExpressionStatement(
-      factory.createAwaitExpression(
-        factory.createCallExpression(
-          factory.createPropertyAccessExpression(factory.createIdentifier('Promise'), factory.createIdentifier('all')),
-          undefined,
-          [
-            factory.createCallExpression(
-              factory.createPropertyAccessExpression(
-                factory.createIdentifier(fieldName),
-                factory.createIdentifier('reduce'),
-              ),
-              undefined,
-              [
-                factory.createArrowFunction(
-                  undefined,
-                  undefined,
-                  [
-                    factory.createParameterDeclaration(
-                      undefined,
-                      undefined,
-                      undefined,
-                      factory.createIdentifier('promises'),
-                      undefined,
-                      undefined,
-                      undefined,
-                    ),
-                    factory.createParameterDeclaration(
-                      undefined,
-                      undefined,
-                      undefined,
-                      factory.createIdentifier('original'),
-                      undefined,
-                      undefined,
-                      undefined,
-                    ),
-                  ],
-                  undefined,
-                  factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                  factory.createBlock(
-                    [
-                      factory.createExpressionStatement(
-                        factory.createCallExpression(
-                          factory.createPropertyAccessExpression(
-                            factory.createIdentifier('promises'),
-                            factory.createIdentifier('push'),
-                          ),
-                          undefined,
-                          [
-                            factory.createCallExpression(
-                              factory.createPropertyAccessExpression(
-                                factory.createIdentifier('DataStore'),
-                                factory.createIdentifier('save'),
-                              ),
-                              undefined,
-                              [
-                                factory.createCallExpression(
-                                  factory.createPropertyAccessExpression(
-                                    factory.createIdentifier(relatedModelName),
-                                    factory.createIdentifier('copyOf'),
-                                  ),
-                                  undefined,
-                                  [
-                                    factory.createIdentifier('original'),
-                                    factory.createArrowFunction(
-                                      undefined,
-                                      undefined,
-                                      [
-                                        factory.createParameterDeclaration(
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                          factory.createIdentifier('updated'),
-                                          undefined,
-                                          undefined,
-                                          undefined,
-                                        ),
-                                      ],
-                                      undefined,
-                                      factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                                      createHasManyUpdateRelatedModelBlock({
-                                        relatedModelFields,
-                                        thisModelPrimaryKeys,
-                                        thisModelRecord: savedModelName,
-                                      }),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                      factory.createReturnStatement(factory.createIdentifier('promises')),
-                    ],
-                    true,
-                  ),
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(factory.createIdentifier('promises'), factory.createIdentifier('push')),
+        undefined,
+        [
+          factory.createSpreadElement(
+            factory.createParenthesizedExpression(
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier(fieldName),
+                  factory.createIdentifier('reduce'),
                 ),
-                factory.createArrayLiteralExpression([], false),
-              ],
+                undefined,
+                [
+                  factory.createArrowFunction(
+                    undefined,
+                    undefined,
+                    [
+                      factory.createParameterDeclaration(
+                        undefined,
+                        undefined,
+                        undefined,
+                        factory.createIdentifier('promises'),
+                        undefined,
+                        undefined,
+                        undefined,
+                      ),
+                      factory.createParameterDeclaration(
+                        undefined,
+                        undefined,
+                        undefined,
+                        factory.createIdentifier('original'),
+                        undefined,
+                        undefined,
+                        undefined,
+                      ),
+                    ],
+                    undefined,
+                    factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                    factory.createBlock(
+                      [
+                        factory.createExpressionStatement(
+                          factory.createCallExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('promises'),
+                              factory.createIdentifier('push'),
+                            ),
+                            undefined,
+                            [
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('DataStore'),
+                                  factory.createIdentifier('save'),
+                                ),
+                                undefined,
+                                [
+                                  factory.createCallExpression(
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier(relatedModelName),
+                                      factory.createIdentifier('copyOf'),
+                                    ),
+                                    undefined,
+                                    [
+                                      factory.createIdentifier('original'),
+                                      factory.createArrowFunction(
+                                        undefined,
+                                        undefined,
+                                        [
+                                          factory.createParameterDeclaration(
+                                            undefined,
+                                            undefined,
+                                            undefined,
+                                            factory.createIdentifier('updated'),
+                                            undefined,
+                                            undefined,
+                                            undefined,
+                                          ),
+                                        ],
+                                        undefined,
+                                        factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                                        createHasManyUpdateRelatedModelBlock({
+                                          relatedModelFields,
+                                          thisModelPrimaryKeys,
+                                          thisModelRecord: savedModelName,
+                                        }),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                        factory.createReturnStatement(factory.createIdentifier('promises')),
+                      ],
+                      true,
+                    ),
+                  ),
+                  factory.createArrayLiteralExpression([], false),
+                ],
+              ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     ),
   ];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Logically, there should be a 1-1 relationship between hasOne and belongsTo.
But DS does not enforce it.
So this is to enforce it during form submission.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
