### PR TITLE
fix: add default value support for controlled textfield components

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -936,12 +936,12 @@ export default function CustomDataForm(props) {
   const { onSubmit, onCancel, onValidate, onChange, overrides, ...rest } =
     props;
   const initialValues = {
-    name: \\"\\",
-    email: \\"\\",
+    name: \\"John Doe\\",
+    email: \\"johndoe@amplify.com\\",
     city: undefined,
     category: undefined,
     pages: 0,
-    phone: \\"\\",
+    phone: \\"+1-401-152-6995\\",
   };
   const [name, setName] = React.useState(initialValues.name);
   const [email, setEmail] = React.useState(initialValues.email);
@@ -1026,7 +1026,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"name\\"
         isRequired={true}
-        defaultValue=\\"John Doe\\"
         value={name}
         onChange={(e) => {
           let { value } = e.target;
@@ -1055,7 +1054,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"E-mail\\"
         isRequired={true}
-        defaultValue=\\"johndoe@amplify.com\\"
         value={email}
         onChange={(e) => {
           let { value } = e.target;
@@ -1200,7 +1198,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"Phone Number\\"
         isRequired={true}
-        defaultValue=\\"+1-401-152-6995\\"
         type=\\"tel\\"
         value={phone}
         onChange={(e) => {
@@ -1335,12 +1332,12 @@ export default function CustomDataForm(props) {
     props;
   const { tokens } = useTheme();
   const initialValues = {
-    name: \\"\\",
-    email: \\"\\",
+    name: \\"John Doe\\",
+    email: \\"johndoe@amplify.com\\",
     city: undefined,
     category: undefined,
     pages: 0,
-    phone: \\"\\",
+    phone: \\"+1-401-152-6995\\",
   };
   const [name, setName] = React.useState(initialValues.name);
   const [email, setEmail] = React.useState(initialValues.email);
@@ -1425,7 +1422,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"name\\"
         isRequired={true}
-        defaultValue=\\"John Doe\\"
         value={name}
         onChange={(e) => {
           let { value } = e.target;
@@ -1454,7 +1450,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"E-mail\\"
         isRequired={true}
-        defaultValue=\\"johndoe@amplify.com\\"
         value={email}
         onChange={(e) => {
           let { value } = e.target;
@@ -1599,7 +1594,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"Phone Number\\"
         isRequired={true}
-        defaultValue=\\"+1-401-152-6995\\"
         type=\\"tel\\"
         value={phone}
         onChange={(e) => {
@@ -1878,9 +1872,9 @@ export default function CustomDataForm(props) {
   const { onSubmit, onCancel, onValidate, onChange, overrides, ...rest } =
     props;
   const initialValues = {
-    name: \\"\\",
-    email: [],
-    phone: [],
+    name: \\"John Doe\\",
+    email: [\\"johndoe@amplify.com\\"],
+    phone: [\\"+1-401-152-6995\\"],
   };
   const [name, setName] = React.useState(initialValues.name);
   const [email, setEmail] = React.useState(initialValues.email);
@@ -1959,7 +1953,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"name\\"
         isRequired={true}
-        defaultValue=\\"John Doe\\"
         value={name}
         onChange={(e) => {
           let { value } = e.target;
@@ -2008,7 +2001,6 @@ export default function CustomDataForm(props) {
         <TextField
           label=\\"E-mail\\"
           isRequired={true}
-          defaultValue=\\"johndoe@amplify.com\\"
           value={currentEmailValue}
           onChange={(e) => {
             let { value } = e.target;
@@ -2051,7 +2043,6 @@ export default function CustomDataForm(props) {
         <TextField
           label=\\"phone\\"
           isRequired={true}
-          defaultValue=\\"+1-401-152-6995\\"
           type=\\"tel\\"
           value={currentPhoneValue}
           onChange={(e) => {
@@ -2174,8 +2165,8 @@ export default function CustomDataForm(props) {
     ...rest
   } = props;
   const initialValues = {
-    name: \\"\\",
-    email: \\"\\",
+    name: \\"John Doe\\",
+    email: \\"johndoe@amplify.com\\",
     \\"metadata-field\\": \\"\\",
     city: undefined,
     category: undefined,
@@ -2280,7 +2271,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"name\\"
         isRequired={true}
-        defaultValue=\\"John Doe\\"
         value={name}
         onChange={(e) => {
           let { value } = e.target;
@@ -2309,7 +2299,6 @@ export default function CustomDataForm(props) {
       <TextField
         label=\\"E-mail\\"
         isRequired={true}
-        defaultValue=\\"johndoe@amplify.com\\"
         value={email}
         onChange={(e) => {
           let { value } = e.target;

--- a/packages/codegen-ui-react/lib/__tests__/forms/form-state.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/forms/form-state.test.ts
@@ -63,7 +63,7 @@ describe('set field state', () => {
 });
 
 describe('get default values', () => {
-  it('should generate the proper default value for a TextField', () => {
+  it('should generate the proper default value for an empty TextField', () => {
     const expression = getDefaultValueExpression('name', 'TextField');
     expect(expression).toMatchObject({ text: '' });
   });
@@ -71,5 +71,19 @@ describe('get default values', () => {
   it('should generate the proper default value for a SliderField', () => {
     const expression = getDefaultValueExpression('name', 'SliderField');
     expect(expression).toMatchObject({ text: '0' });
+  });
+
+  it('should generate the proper default value for non-empty TextField', () => {
+    const expression = getDefaultValueExpression('name', 'TextField', undefined, false, false, 'Don Corleone');
+    expect(expression).toMatchObject({ text: 'Don Corleone' });
+  });
+
+  it('should generate the proper default value for non-empty TextField array', () => {
+    const expression = getDefaultValueExpression('name', 'TextField', undefined, true, false, 'mobster');
+    expect(expression).toEqual(
+      expect.objectContaining({
+        elements: expect.arrayContaining([expect.objectContaining({ text: 'mobster' })]),
+      }),
+    );
   });
 });

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -452,7 +452,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
       );
     }
 
-    statements.push(getInitialValues(formMetadata.fieldConfigs));
+    statements.push(getInitialValues(formMetadata.fieldConfigs, this.component));
 
     statements.push(...getUseStateHooks(formMetadata.fieldConfigs));
 

--- a/packages/codegen-ui-react/lib/helpers/index.ts
+++ b/packages/codegen-ui-react/lib/helpers/index.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { GenericDataField, GenericDataSchema } from '@aws-amplify/codegen-ui/lib/types';
+import { GenericDataField, GenericDataSchema, StudioFormFields } from '@aws-amplify/codegen-ui/lib/types';
 import { factory, Statement, Expression, NodeFlags, Identifier } from 'typescript';
 import { isPrimitive } from '../primitive';
 
@@ -112,4 +112,18 @@ export function isAliased(componentType: string): boolean {
 
 export function removeAlias(aliasString: string): string {
   return aliasString.replace(/(Custom$)/g, '');
+}
+
+export function getControlledComponentDefaultValue(
+  fields: StudioFormFields,
+  componentType: string,
+  name: string,
+): string | null {
+  let defaultValue = null;
+  Object.entries(fields).forEach(([key, value]) => {
+    if (key === name && 'inputType' in value && value.inputType?.defaultValue && componentType === 'TextField') {
+      defaultValue = value.inputType.defaultValue;
+    }
+  });
+  return defaultValue;
 }

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -206,7 +206,6 @@ export function getFormDefinitionInputElement(
           isRequired: isRequiredValue,
           isReadOnly: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
           placeholder: config.inputType?.placeholder || baseConfig?.inputType?.placeholder,
-          defaultValue: defaultStringValue,
           type: getTextFieldType(componentType),
         },
         studioFormComponentType: componentType,

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -33,7 +33,6 @@ export type FormDefinitionTextFieldElement = {
     isRequired?: boolean;
     isReadOnly?: boolean;
     placeholder?: string;
-    defaultValue?: string;
     type?: string;
   };
   studioFormComponentType:


### PR DESCRIPTION
*Description of changes:*
This is a follow up to moving TextField to a controlled component.  Since it's controlled, we can no longer use the defaultValue param, we have to pass in the default value to the initialValue object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
