### PR TITLE
test: update cpk and composite schemas

### DIFF
--- a/packages/codegen-ui/example-schemas/datastore/composite-relationships.json
+++ b/packages/codegen-ui/example-schemas/datastore/composite-relationships.json
@@ -1,4 +1,4 @@
-{
+ {
     "models": {
         "CompositeDog": {
             "name": "CompositeDog",
@@ -229,7 +229,8 @@
                     "association": {
                         "connectionType": "HAS_ONE",
                         "associatedWith": [
-                            "CompositeOwner"
+                            "name",
+                            "description"
                         ],
                         "targetNames": [
                             "compositeOwnerCompositeDogName",
@@ -549,6 +550,6 @@
     },
     "enums": {},
     "nonModels": {},
-    "codegenVersion": "3.3.2",
+    "codegenVersion": "3.3.5",
     "version": "8f8e59ee8fb2e3ca4efda3aa25b0211f"
 }

--- a/packages/codegen-ui/example-schemas/datastore/cpk-relationships.json
+++ b/packages/codegen-ui/example-schemas/datastore/cpk-relationships.json
@@ -1,371 +1,371 @@
 {
-  "models": {
-      "CPKStudent": {
-          "name": "CPKStudent",
-          "fields": {
-              "specialStudentId": {
-                  "name": "specialStudentId",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": true,
-                  "attributes": []
-              },
-              "createdAt": {
-                  "name": "createdAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              },
-              "updatedAt": {
-                  "name": "updatedAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              }
-          },
-          "syncable": true,
-          "pluralName": "CPKStudents",
-          "attributes": [
-              {
-                  "type": "model",
-                  "properties": {}
-              },
-              {
-                  "type": "key",
-                  "properties": {
-                      "fields": [
-                          "specialStudentId"
-                      ]
-                  }
-              }
-          ]
-      },
-      "CPKTeacher": {
-          "name": "CPKTeacher",
-          "fields": {
-              "specialTeacherId": {
-                  "name": "specialTeacherId",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": true,
-                  "attributes": []
-              },
-              "CPKStudent": {
-                  "name": "CPKStudent",
-                  "isArray": false,
-                  "type": {
-                      "model": "CPKStudent"
-                  },
-                  "isRequired": false,
-                  "attributes": [],
-                  "association": {
-                      "connectionType": "HAS_ONE",
-                      "associatedWith": [
-                          "specialStudentId"
-                      ],
-                      "targetNames": [
-                          "cPKTeacherCPKStudentSpecialStudentId"
-                      ]
-                  }
-              },
-              "CPKClasses": {
-                  "name": "CPKClasses",
-                  "isArray": true,
-                  "type": {
-                      "model": "CPKTeacherCPKClass"
-                  },
-                  "isRequired": false,
-                  "attributes": [],
-                  "isArrayNullable": true,
-                  "association": {
-                      "connectionType": "HAS_MANY",
-                      "associatedWith": [
-                          "cpkTeacher"
-                      ]
-                  }
-              },
-              "CPKProjects": {
-                  "name": "CPKProjects",
-                  "isArray": true,
-                  "type": {
-                      "model": "CPKProject"
-                  },
-                  "isRequired": false,
-                  "attributes": [],
-                  "isArrayNullable": true,
-                  "association": {
-                      "connectionType": "HAS_MANY",
-                      "associatedWith": [
-                          "cPKTeacherID"
-                      ]
-                  }
-              },
-              "createdAt": {
-                  "name": "createdAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              },
-              "updatedAt": {
-                  "name": "updatedAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              },
-              "cPKTeacherCPKStudentSpecialStudentId": {
-                  "name": "cPKTeacherCPKStudentSpecialStudentId",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": false,
-                  "attributes": []
-              }
-          },
-          "syncable": true,
-          "pluralName": "CPKTeachers",
-          "attributes": [
-              {
-                  "type": "model",
-                  "properties": {}
-              },
-              {
-                  "type": "key",
-                  "properties": {
-                      "fields": [
-                          "specialTeacherId"
-                      ]
-                  }
-              }
-          ]
-      },
-      "CPKClass": {
-          "name": "CPKClass",
-          "fields": {
-              "specialClassId": {
-                  "name": "specialClassId",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": true,
-                  "attributes": []
-              },
-              "CPKTeachers": {
-                  "name": "CPKTeachers",
-                  "isArray": true,
-                  "type": {
-                      "model": "CPKTeacherCPKClass"
-                  },
-                  "isRequired": false,
-                  "attributes": [],
-                  "isArrayNullable": true,
-                  "association": {
-                      "connectionType": "HAS_MANY",
-                      "associatedWith": [
-                          "cpkClass"
-                      ]
-                  }
-              },
-              "createdAt": {
-                  "name": "createdAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              },
-              "updatedAt": {
-                  "name": "updatedAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              }
-          },
-          "syncable": true,
-          "pluralName": "CPKClasses",
-          "attributes": [
-              {
-                  "type": "model",
-                  "properties": {}
-              },
-              {
-                  "type": "key",
-                  "properties": {
-                      "fields": [
-                          "specialClassId"
-                      ]
-                  }
-              }
-          ]
-      },
-      "CPKProject": {
-          "name": "CPKProject",
-          "fields": {
-              "specialProjectId": {
-                  "name": "specialProjectId",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": true,
-                  "attributes": []
-              },
-              "cPKTeacherID": {
-                  "name": "cPKTeacherID",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": false,
-                  "attributes": []
-              },
-              "createdAt": {
-                  "name": "createdAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              },
-              "updatedAt": {
-                  "name": "updatedAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              }
-          },
-          "syncable": true,
-          "pluralName": "CPKProjects",
-          "attributes": [
-              {
-                  "type": "model",
-                  "properties": {}
-              },
-              {
-                  "type": "key",
-                  "properties": {
-                      "fields": [
-                          "specialProjectId"
-                      ]
-                  }
-              },
-              {
-                  "type": "key",
-                  "properties": {
-                      "name": "byCPKTeacher",
-                      "fields": [
-                          "cPKTeacherID"
-                      ]
-                  }
-              }
-          ]
-      },
-      "CPKTeacherCPKClass": {
-          "name": "CPKTeacherCPKClass",
-          "fields": {
-              "id": {
-                  "name": "id",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": true,
-                  "attributes": []
-              },
-              "cPKTeacherSpecialTeacherId": {
-                  "name": "cPKTeacherSpecialTeacherId",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": false,
-                  "attributes": []
-              },
-              "cPKClassSpecialClassId": {
-                  "name": "cPKClassSpecialClassId",
-                  "isArray": false,
-                  "type": "ID",
-                  "isRequired": false,
-                  "attributes": []
-              },
-              "cpkTeacher": {
-                  "name": "cpkTeacher",
-                  "isArray": false,
-                  "type": {
-                      "model": "CPKTeacher"
-                  },
-                  "isRequired": true,
-                  "attributes": [],
-                  "association": {
-                      "connectionType": "BELONGS_TO",
-                      "targetNames": [
-                          "cPKTeacherSpecialTeacherId"
-                      ]
-                  }
-              },
-              "cpkClass": {
-                  "name": "cpkClass",
-                  "isArray": false,
-                  "type": {
-                      "model": "CPKClass"
-                  },
-                  "isRequired": true,
-                  "attributes": [],
-                  "association": {
-                      "connectionType": "BELONGS_TO",
-                      "targetNames": [
-                          "cPKClassSpecialClassId"
-                      ]
-                  }
-              },
-              "createdAt": {
-                  "name": "createdAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              },
-              "updatedAt": {
-                  "name": "updatedAt",
-                  "isArray": false,
-                  "type": "AWSDateTime",
-                  "isRequired": false,
-                  "attributes": [],
-                  "isReadOnly": true
-              }
-          },
-          "syncable": true,
-          "pluralName": "CPKTeacherCPKClasses",
-          "attributes": [
-              {
-                  "type": "model",
-                  "properties": {}
-              },
-              {
-                  "type": "key",
-                  "properties": {
-                      "name": "byCPKTeacher",
-                      "fields": [
-                          "cPKTeacherSpecialTeacherId"
-                      ]
-                  }
-              },
-              {
-                  "type": "key",
-                  "properties": {
-                      "name": "byCPKClass",
-                      "fields": [
-                          "cPKClassSpecialClassId"
-                      ]
-                  }
-              }
-          ]
-      }
-  },
-  "enums": {},
-  "nonModels": {},
-  "codegenVersion": "3.3.2",
-  "version": "6cdebeac40c17b1a27a64848aafdc86a"
+    "models": {
+        "CPKStudent": {
+            "name": "CPKStudent",
+            "fields": {
+                "specialStudentId": {
+                    "name": "specialStudentId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "CPKStudents",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "fields": [
+                            "specialStudentId"
+                        ]
+                    }
+                }
+            ]
+        },
+        "CPKTeacher": {
+            "name": "CPKTeacher",
+            "fields": {
+                "specialTeacherId": {
+                    "name": "specialTeacherId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "CPKStudent": {
+                    "name": "CPKStudent",
+                    "isArray": false,
+                    "type": {
+                        "model": "CPKStudent"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "HAS_ONE",
+                        "associatedWith": [
+                            "specialStudentId"
+                        ],
+                        "targetNames": [
+                            "cPKTeacherCPKStudentSpecialStudentId"
+                        ]
+                    }
+                },
+                "CPKClasses": {
+                    "name": "CPKClasses",
+                    "isArray": true,
+                    "type": {
+                        "model": "CPKTeacherCPKClass"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": [
+                            "cpkTeacher"
+                        ]
+                    }
+                },
+                "CPKProjects": {
+                    "name": "CPKProjects",
+                    "isArray": true,
+                    "type": {
+                        "model": "CPKProject"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": [
+                            "cPKTeacherID"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "cPKTeacherCPKStudentSpecialStudentId": {
+                    "name": "cPKTeacherCPKStudentSpecialStudentId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                }
+            },
+            "syncable": true,
+            "pluralName": "CPKTeachers",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "fields": [
+                            "specialTeacherId"
+                        ]
+                    }
+                }
+            ]
+        },
+        "CPKClass": {
+            "name": "CPKClass",
+            "fields": {
+                "specialClassId": {
+                    "name": "specialClassId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "CPKTeachers": {
+                    "name": "CPKTeachers",
+                    "isArray": true,
+                    "type": {
+                        "model": "CPKTeacherCPKClass"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": [
+                            "cpkClass"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "CPKClasses",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "fields": [
+                            "specialClassId"
+                        ]
+                    }
+                }
+            ]
+        },
+        "CPKProject": {
+            "name": "CPKProject",
+            "fields": {
+                "specialProjectId": {
+                    "name": "specialProjectId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "cPKTeacherID": {
+                    "name": "cPKTeacherID",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "CPKProjects",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "fields": [
+                            "specialProjectId"
+                        ]
+                    }
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "name": "byCPKTeacher",
+                        "fields": [
+                            "cPKTeacherID"
+                        ]
+                    }
+                }
+            ]
+        },
+        "CPKTeacherCPKClass": {
+            "name": "CPKTeacherCPKClass",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "cPKTeacherSpecialTeacherId": {
+                    "name": "cPKTeacherSpecialTeacherId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "cPKClassSpecialClassId": {
+                    "name": "cPKClassSpecialClassId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "cpkTeacher": {
+                    "name": "cpkTeacher",
+                    "isArray": false,
+                    "type": {
+                        "model": "CPKTeacher"
+                    },
+                    "isRequired": true,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "BELONGS_TO",
+                        "targetNames": [
+                            "cPKTeacherSpecialTeacherId"
+                        ]
+                    }
+                },
+                "cpkClass": {
+                    "name": "cpkClass",
+                    "isArray": false,
+                    "type": {
+                        "model": "CPKClass"
+                    },
+                    "isRequired": true,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "BELONGS_TO",
+                        "targetNames": [
+                            "cPKClassSpecialClassId"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "CPKTeacherCPKClasses",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "name": "byCPKTeacher",
+                        "fields": [
+                            "cPKTeacherSpecialTeacherId"
+                        ]
+                    }
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "name": "byCPKClass",
+                        "fields": [
+                            "cPKClassSpecialClassId"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "enums": {},
+    "nonModels": {},
+    "codegenVersion": "3.3.5",
+    "version": "19f0d1f134e00e6d1829446b37439661"
 }

--- a/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
@@ -1577,7 +1577,7 @@ export const schemaWithCPK: Schema = {
           type: {
             model: 'CPKStudent',
           },
-          isRequired: false,
+          isRequired: true,
           attributes: [],
           association: {
             connectionType: 'HAS_ONE',
@@ -1633,7 +1633,7 @@ export const schemaWithCPK: Schema = {
           name: 'cPKTeacherCPKStudentSpecialStudentId',
           isArray: false,
           type: 'ID',
-          isRequired: false,
+          isRequired: true,
           attributes: [],
         },
       },
@@ -1857,8 +1857,8 @@ export const schemaWithCPK: Schema = {
   },
   enums: {},
   nonModels: {},
-  codegenVersion: '3.3.2',
-  version: '6cdebeac40c17b1a27a64848aafdc86a',
+  codegenVersion: '3.3.5',
+  version: '19f0d1f134e00e6d1829446b37439661',
 };
 
 export const schemaWithCompositeKeys: Schema = {
@@ -2071,7 +2071,7 @@ export const schemaWithCompositeKeys: Schema = {
           attributes: [],
           association: {
             connectionType: 'HAS_ONE',
-            associatedWith: ['CompositeOwner'],
+            associatedWith: ['name', 'description'],
             targetNames: ['compositeOwnerCompositeDogName', 'compositeOwnerCompositeDogDescription'],
           },
         },
@@ -2361,6 +2361,6 @@ export const schemaWithCompositeKeys: Schema = {
   },
   enums: {},
   nonModels: {},
-  codegenVersion: '3.3.2',
+  codegenVersion: '3.3.5',
   version: '8f8e59ee8fb2e3ca4efda3aa25b0211f',
 };

--- a/packages/test-generator/integration-test-templates/src/models/schema.js
+++ b/packages/test-generator/integration-test-templates/src/models/schema.js
@@ -1393,7 +1393,7 @@ export const schema = {
           attributes: [],
           association: {
             connectionType: 'HAS_ONE',
-            associatedWith: ['CompositeOwner'],
+            associatedWith: ['name', 'description'],
             targetNames: ['compositeOwnerCompositeDogName', 'compositeOwnerCompositeDogDescription'],
           },
         },

--- a/packages/test-generator/lib/models/schema.ts
+++ b/packages/test-generator/lib/models/schema.ts
@@ -1394,7 +1394,7 @@ export default {
           attributes: [],
           association: {
             connectionType: 'HAS_ONE',
-            associatedWith: ['CompositeOwner'],
+            associatedWith: ['name', 'description'],
             targetNames: ['compositeOwnerCompositeDogName', 'compositeOwnerCompositeDogDescription'],
           },
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a hotfix for an issue effecting hasOne-belongsTo relationships in the CLI (https://github.com/aws-amplify/amplify-cli/pull/11736) 
This PR updates the schemas used in tests to the one generated by the latest CLI.
We have an outstanding task to generate the schemas dynamically in the tests using the introspection API.
When we have that in place, we will not need to do manual updates like this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
