### PR TITLE
chore: render indices on children of hasMany

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1,5 +1,565 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`amplify form renderer tests datastore form tests custom form tests should render a create form for child of 1:m relationship 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+} from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { CompositeToy, CompositeDog } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { DataStore } from \\"aws-amplify\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button
+            size=\\"small\\"
+            variation=\\"link\\"
+            isDisabled={hasError}
+            onClick={addItem}
+          >
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function CreateCompositeToyForm(props) {
+  const {
+    clearOnSuccess = true,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    kind: \\"\\",
+    color: \\"\\",
+    compositeDogCompositeToysName: undefined,
+    compositeDogCompositeToysDescription: undefined,
+  };
+  const [kind, setKind] = React.useState(initialValues.kind);
+  const [color, setColor] = React.useState(initialValues.color);
+  const [compositeDogCompositeToysName, setCompositeDogCompositeToysName] =
+    React.useState(initialValues.compositeDogCompositeToysName);
+  const [
+    compositeDogCompositeToysDescription,
+    setCompositeDogCompositeToysDescription,
+  ] = React.useState(initialValues.compositeDogCompositeToysDescription);
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setKind(initialValues.kind);
+    setColor(initialValues.color);
+    setCompositeDogCompositeToysName(
+      initialValues.compositeDogCompositeToysName
+    );
+    setCurrentCompositeDogCompositeToysNameValue(undefined);
+    setCompositeDogCompositeToysDescription(
+      initialValues.compositeDogCompositeToysDescription
+    );
+    setCurrentCompositeDogCompositeToysDescriptionValue(undefined);
+    setErrors({});
+  };
+  const [
+    currentCompositeDogCompositeToysNameValue,
+    setCurrentCompositeDogCompositeToysNameValue,
+  ] = React.useState(undefined);
+  const compositeDogCompositeToysNameRef = React.createRef();
+  const [
+    currentCompositeDogCompositeToysDescriptionValue,
+    setCurrentCompositeDogCompositeToysDescriptionValue,
+  ] = React.useState(undefined);
+  const compositeDogCompositeToysDescriptionRef = React.createRef();
+  const compositeDogRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: CompositeDog,
+  }).items;
+  const validations = {
+    kind: [{ type: \\"Required\\" }],
+    color: [{ type: \\"Required\\" }],
+    compositeDogCompositeToysName: [],
+    compositeDogCompositeToysDescription: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          kind,
+          color,
+          compositeDogCompositeToysName,
+          compositeDogCompositeToysDescription,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(fieldName, item)
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(fieldName, modelFields[fieldName])
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
+          await DataStore.save(new CompositeToy(modelFields));
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+          if (clearOnSuccess) {
+            resetStateValues();
+          }
+        } catch (err) {
+          if (onError) {
+            onError(modelFields, err.message);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"CreateCompositeToyForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Kind\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={kind}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              kind: value,
+              color,
+              compositeDogCompositeToysName,
+              compositeDogCompositeToysDescription,
+            };
+            const result = onChange(modelFields);
+            value = result?.kind ?? value;
+          }
+          if (errors.kind?.hasError) {
+            runValidationTasks(\\"kind\\", value);
+          }
+          setKind(value);
+        }}
+        onBlur={() => runValidationTasks(\\"kind\\", kind)}
+        errorMessage={errors.kind?.errorMessage}
+        hasError={errors.kind?.hasError}
+        {...getOverrideProps(overrides, \\"kind\\")}
+      ></TextField>
+      <TextField
+        label=\\"Color\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={color}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              kind,
+              color: value,
+              compositeDogCompositeToysName,
+              compositeDogCompositeToysDescription,
+            };
+            const result = onChange(modelFields);
+            value = result?.color ?? value;
+          }
+          if (errors.color?.hasError) {
+            runValidationTasks(\\"color\\", value);
+          }
+          setColor(value);
+        }}
+        onBlur={() => runValidationTasks(\\"color\\", color)}
+        errorMessage={errors.color?.errorMessage}
+        hasError={errors.color?.hasError}
+        {...getOverrideProps(overrides, \\"color\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              kind,
+              color,
+              compositeDogCompositeToysName: value,
+              compositeDogCompositeToysDescription,
+            };
+            const result = onChange(modelFields);
+            value = result?.compositeDogCompositeToysName ?? value;
+          }
+          setCompositeDogCompositeToysName(value);
+          setCurrentCompositeDogCompositeToysNameValue(undefined);
+        }}
+        currentFieldValue={currentCompositeDogCompositeToysNameValue}
+        label={\\"Composite dog composite toys name\\"}
+        items={
+          compositeDogCompositeToysName ? [compositeDogCompositeToysName] : []
+        }
+        hasError={errors.compositeDogCompositeToysName?.hasError}
+        setFieldValue={setCurrentCompositeDogCompositeToysNameValue}
+        inputFieldRef={compositeDogCompositeToysNameRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Composite dog composite toys name\\"
+          isRequired={false}
+          isReadOnly={false}
+          value={currentCompositeDogCompositeToysNameValue}
+          options={compositeDogRecords.map((r) => ({
+            id: r?.name,
+            label: r?.name,
+          }))}
+          onSelect={({ id }) => {
+            setCurrentCompositeDogCompositeToysNameValue(id);
+          }}
+          onClear={() => {
+            setCurrentCompositeDogCompositeToysNameDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.compositeDogCompositeToysName?.hasError) {
+              runValidationTasks(\\"compositeDogCompositeToysName\\", value);
+            }
+            setCurrentCompositeDogCompositeToysNameValue(value);
+          }}
+          onBlur={() =>
+            runValidationTasks(
+              \\"compositeDogCompositeToysName\\",
+              currentCompositeDogCompositeToysNameValue
+            )
+          }
+          errorMessage={errors.compositeDogCompositeToysName?.errorMessage}
+          hasError={errors.compositeDogCompositeToysName?.hasError}
+          ref={compositeDogCompositeToysNameRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"compositeDogCompositeToysName\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              kind,
+              color,
+              compositeDogCompositeToysName,
+              compositeDogCompositeToysDescription: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.compositeDogCompositeToysDescription ?? value;
+          }
+          setCompositeDogCompositeToysDescription(value);
+          setCurrentCompositeDogCompositeToysDescriptionValue(undefined);
+        }}
+        currentFieldValue={currentCompositeDogCompositeToysDescriptionValue}
+        label={\\"Composite dog composite toys description\\"}
+        items={
+          compositeDogCompositeToysDescription
+            ? [compositeDogCompositeToysDescription]
+            : []
+        }
+        hasError={errors.compositeDogCompositeToysDescription?.hasError}
+        setFieldValue={setCurrentCompositeDogCompositeToysDescriptionValue}
+        inputFieldRef={compositeDogCompositeToysDescriptionRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Composite dog composite toys description\\"
+          isRequired={false}
+          isReadOnly={false}
+          value={currentCompositeDogCompositeToysDescriptionValue}
+          options={compositeDogRecords.map((r) => ({
+            id: r?.description,
+            label: r?.description,
+          }))}
+          onSelect={({ id }) => {
+            setCurrentCompositeDogCompositeToysDescriptionValue(id);
+          }}
+          onClear={() => {
+            setCurrentCompositeDogCompositeToysDescriptionDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.compositeDogCompositeToysDescription?.hasError) {
+              runValidationTasks(\\"compositeDogCompositeToysDescription\\", value);
+            }
+            setCurrentCompositeDogCompositeToysDescriptionValue(value);
+          }}
+          onBlur={() =>
+            runValidationTasks(
+              \\"compositeDogCompositeToysDescription\\",
+              currentCompositeDogCompositeToysDescriptionValue
+            )
+          }
+          errorMessage={
+            errors.compositeDogCompositeToysDescription?.errorMessage
+          }
+          hasError={errors.compositeDogCompositeToysDescription?.hasError}
+          ref={compositeDogCompositeToysDescriptionRef}
+          labelHidden={true}
+          {...getOverrideProps(
+            overrides,
+            \\"compositeDogCompositeToysDescription\\"
+          )}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Clear\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          {...getOverrideProps(overrides, \\"ClearButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e?.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests datastore form tests custom form tests should render a create form for child of 1:m relationship 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type CreateCompositeToyFormInputValues = {
+    kind?: string;
+    color?: string;
+    compositeDogCompositeToysName?: string;
+    compositeDogCompositeToysDescription?: string;
+};
+export declare type CreateCompositeToyFormValidationValues = {
+    kind?: ValidationFunction<string>;
+    color?: ValidationFunction<string>;
+    compositeDogCompositeToysName?: ValidationFunction<string>;
+    compositeDogCompositeToysDescription?: ValidationFunction<string>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type CreateCompositeToyFormOverridesProps = {
+    CreateCompositeToyFormGrid?: PrimitiveOverrideProps<GridProps>;
+    kind?: PrimitiveOverrideProps<TextFieldProps>;
+    color?: PrimitiveOverrideProps<TextFieldProps>;
+    compositeDogCompositeToysName?: PrimitiveOverrideProps<AutocompleteProps>;
+    compositeDogCompositeToysDescription?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type CreateCompositeToyFormProps = React.PropsWithChildren<{
+    overrides?: CreateCompositeToyFormOverridesProps | undefined | null;
+} & {
+    clearOnSuccess?: boolean;
+    onSubmit?: (fields: CreateCompositeToyFormInputValues) => CreateCompositeToyFormInputValues;
+    onSuccess?: (fields: CreateCompositeToyFormInputValues) => void;
+    onError?: (fields: CreateCompositeToyFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: CreateCompositeToyFormInputValues) => CreateCompositeToyFormInputValues;
+    onValidate?: CreateCompositeToyFormValidationValues;
+} & React.CSSProperties>;
+export default function CreateCompositeToyForm(props: CreateCompositeToyFormProps): React.ReactElement;
+"
+`;
+
 exports[`amplify form renderer tests datastore form tests custom form tests should render a create form for model with composite keys 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
@@ -7985,18 +8545,24 @@ export default function MyMemberForm(props) {
   } = props;
   const initialValues = {
     name: \\"\\",
+    teamID: undefined,
     Team: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
+  const [teamID, setTeamID] = React.useState(initialValues.teamID);
   const [Team, setTeam] = React.useState(initialValues.Team);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     setName(initialValues.name);
+    setTeamID(initialValues.teamID);
+    setCurrentTeamIDValue(undefined);
     setTeam(initialValues.Team);
     setCurrentTeamValue(undefined);
     setCurrentTeamDisplayValue(\\"\\");
     setErrors({});
   };
+  const [currentTeamIDValue, setCurrentTeamIDValue] = React.useState(undefined);
+  const teamIDRef = React.createRef();
   const [currentTeamDisplayValue, setCurrentTeamDisplayValue] =
     React.useState(\\"\\");
   const [currentTeamValue, setCurrentTeamValue] = React.useState(undefined);
@@ -8018,6 +8584,7 @@ export default function MyMemberForm(props) {
   };
   const validations = {
     name: [],
+    teamID: [{ type: \\"Required\\" }],
     Team: [],
   };
   const runValidationTasks = async (
@@ -8046,6 +8613,7 @@ export default function MyMemberForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
+          teamID,
           Team,
         };
         const validationResponses = await Promise.all(
@@ -8144,6 +8712,7 @@ export default function MyMemberForm(props) {
           if (onChange) {
             const modelFields = {
               name: value,
+              teamID,
               Team,
             };
             const result = onChange(modelFields);
@@ -8166,6 +8735,61 @@ export default function MyMemberForm(props) {
           if (onChange) {
             const modelFields = {
               name,
+              teamID: value,
+              Team,
+            };
+            const result = onChange(modelFields);
+            value = result?.teamID ?? value;
+          }
+          setTeamID(value);
+          setCurrentTeamIDValue(undefined);
+        }}
+        currentFieldValue={currentTeamIDValue}
+        label={\\"Team id\\"}
+        items={teamID ? [teamID] : []}
+        hasError={errors.teamID?.hasError}
+        setFieldValue={setCurrentTeamIDValue}
+        inputFieldRef={teamIDRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Team id\\"
+          isRequired={true}
+          isReadOnly={false}
+          value={currentTeamIDValue}
+          options={teamRecords.map((r) => ({
+            id: r?.id,
+            label: r?.id,
+          }))}
+          onSelect={({ id }) => {
+            setCurrentTeamIDValue(id);
+          }}
+          onClear={() => {
+            setCurrentTeamIDDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.teamID?.hasError) {
+              runValidationTasks(\\"teamID\\", value);
+            }
+            setCurrentTeamIDValue(value);
+          }}
+          onBlur={() => runValidationTasks(\\"teamID\\", currentTeamIDValue)}
+          errorMessage={errors.teamID?.errorMessage}
+          hasError={errors.teamID?.hasError}
+          ref={teamIDRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"teamID\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              teamID,
               Team: value,
             };
             const result = onChange(modelFields);
@@ -8245,16 +8869,19 @@ export declare type ValidationResponse = {
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type MyMemberFormInputValues = {
     name?: string;
+    teamID?: string;
     Team?: Team0;
 };
 export declare type MyMemberFormValidationValues = {
     name?: ValidationFunction<string>;
+    teamID?: ValidationFunction<string>;
     Team?: ValidationFunction<Team0>;
 };
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type MyMemberFormOverridesProps = {
     MyMemberFormGrid?: PrimitiveOverrideProps<GridProps>;
     name?: PrimitiveOverrideProps<TextFieldProps>;
+    teamID?: PrimitiveOverrideProps<AutocompleteProps>;
     Team?: PrimitiveOverrideProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type MyMemberFormProps = React.PropsWithChildren<{
@@ -11872,16 +12499,20 @@ export default function MyMemberForm(props) {
   } = props;
   const initialValues = {
     name: \\"\\",
+    teamID: undefined,
     Team: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
+  const [teamID, setTeamID] = React.useState(initialValues.teamID);
   const [Team, setTeam] = React.useState(initialValues.Team);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     const cleanValues = memberRecord
-      ? { ...initialValues, ...memberRecord, Team }
+      ? { ...initialValues, ...memberRecord, teamID, Team }
       : initialValues;
     setName(cleanValues.name);
+    setTeamID(cleanValues.teamID);
+    setCurrentTeamIDValue(undefined);
     setTeam(cleanValues.Team);
     setCurrentTeamValue(undefined);
     setCurrentTeamDisplayValue(\\"\\");
@@ -11892,12 +12523,16 @@ export default function MyMemberForm(props) {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Member, idProp) : member;
       setMemberRecord(record);
+      const teamIDRecord = record ? await record.teamID : undefined;
+      setTeamID(teamIDRecord);
       const TeamRecord = record ? await record.Team : undefined;
       setTeam(TeamRecord);
     };
     queryData();
   }, [idProp, member]);
-  React.useEffect(resetStateValues, [memberRecord, Team]);
+  React.useEffect(resetStateValues, [memberRecord, teamID, Team]);
+  const [currentTeamIDValue, setCurrentTeamIDValue] = React.useState(undefined);
+  const teamIDRef = React.createRef();
   const [currentTeamDisplayValue, setCurrentTeamDisplayValue] =
     React.useState(\\"\\");
   const [currentTeamValue, setCurrentTeamValue] = React.useState(undefined);
@@ -11919,6 +12554,7 @@ export default function MyMemberForm(props) {
   };
   const validations = {
     name: [],
+    teamID: [{ type: \\"Required\\" }],
     Team: [],
   };
   const runValidationTasks = async (
@@ -11947,6 +12583,7 @@ export default function MyMemberForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
+          teamID,
           Team,
         };
         const validationResponses = await Promise.all(
@@ -12053,6 +12690,7 @@ export default function MyMemberForm(props) {
           if (onChange) {
             const modelFields = {
               name: value,
+              teamID,
               Team,
             };
             const result = onChange(modelFields);
@@ -12075,6 +12713,62 @@ export default function MyMemberForm(props) {
           if (onChange) {
             const modelFields = {
               name,
+              teamID: value,
+              Team,
+            };
+            const result = onChange(modelFields);
+            value = result?.teamID ?? value;
+          }
+          setTeamID(value);
+          setCurrentTeamIDValue(undefined);
+        }}
+        currentFieldValue={currentTeamIDValue}
+        label={\\"Team id\\"}
+        items={teamID ? [teamID] : []}
+        hasError={errors.teamID?.hasError}
+        setFieldValue={setCurrentTeamIDValue}
+        inputFieldRef={teamIDRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Team id\\"
+          isRequired={true}
+          isReadOnly={false}
+          value={currentTeamIDValue}
+          options={teamRecords.map((r) => ({
+            id: r?.id,
+            label: r?.id,
+          }))}
+          onSelect={({ id }) => {
+            setCurrentTeamIDValue(id);
+          }}
+          onClear={() => {
+            setCurrentTeamIDDisplayValue(\\"\\");
+          }}
+          defaultValue={teamID}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.teamID?.hasError) {
+              runValidationTasks(\\"teamID\\", value);
+            }
+            setCurrentTeamIDValue(value);
+          }}
+          onBlur={() => runValidationTasks(\\"teamID\\", currentTeamIDValue)}
+          errorMessage={errors.teamID?.errorMessage}
+          hasError={errors.teamID?.hasError}
+          ref={teamIDRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"teamID\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              teamID,
               Team: value,
             };
             const result = onChange(modelFields);
@@ -12155,16 +12849,19 @@ export declare type ValidationResponse = {
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type MyMemberFormInputValues = {
     name?: string;
+    teamID?: string;
     Team?: Team0;
 };
 export declare type MyMemberFormValidationValues = {
     name?: ValidationFunction<string>;
+    teamID?: ValidationFunction<string>;
     Team?: ValidationFunction<Team0>;
 };
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type MyMemberFormOverridesProps = {
     MyMemberFormGrid?: PrimitiveOverrideProps<GridProps>;
     name?: PrimitiveOverrideProps<TextFieldProps>;
+    teamID?: PrimitiveOverrideProps<AutocompleteProps>;
     Team?: PrimitiveOverrideProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type MyMemberFormProps = React.PropsWithChildren<{
@@ -17196,18 +17893,24 @@ export default function MyMemberForm(props) {
   } = props;
   const initialValues = {
     name: \\"\\",
+    teamID: undefined,
     Team: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
+  const [teamID, setTeamID] = React.useState(initialValues.teamID);
   const [Team, setTeam] = React.useState(initialValues.Team);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     setName(initialValues.name);
+    setTeamID(initialValues.teamID);
+    setCurrentTeamIDValue(undefined);
     setTeam(initialValues.Team);
     setCurrentTeamValue(undefined);
     setCurrentTeamDisplayValue(\\"\\");
     setErrors({});
   };
+  const [currentTeamIDValue, setCurrentTeamIDValue] = React.useState(undefined);
+  const teamIDRef = React.createRef();
   const [currentTeamDisplayValue, setCurrentTeamDisplayValue] =
     React.useState(\\"\\");
   const [currentTeamValue, setCurrentTeamValue] = React.useState(undefined);
@@ -17229,6 +17932,7 @@ export default function MyMemberForm(props) {
   };
   const validations = {
     name: [],
+    teamID: [{ type: \\"Required\\" }],
     Team: [],
   };
   const runValidationTasks = async (
@@ -17257,6 +17961,7 @@ export default function MyMemberForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
+          teamID,
           Team,
         };
         const validationResponses = await Promise.all(
@@ -17355,6 +18060,7 @@ export default function MyMemberForm(props) {
           if (onChange) {
             const modelFields = {
               name: value,
+              teamID,
               Team,
             };
             const result = onChange(modelFields);
@@ -17377,6 +18083,61 @@ export default function MyMemberForm(props) {
           if (onChange) {
             const modelFields = {
               name,
+              teamID: value,
+              Team,
+            };
+            const result = onChange(modelFields);
+            value = result?.teamID ?? value;
+          }
+          setTeamID(value);
+          setCurrentTeamIDValue(undefined);
+        }}
+        currentFieldValue={currentTeamIDValue}
+        label={\\"Team id\\"}
+        items={teamID ? [teamID] : []}
+        hasError={errors.teamID?.hasError}
+        setFieldValue={setCurrentTeamIDValue}
+        inputFieldRef={teamIDRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Team id\\"
+          isRequired={true}
+          isReadOnly={false}
+          value={currentTeamIDValue}
+          options={teamRecords.map((r) => ({
+            id: r?.id,
+            label: r?.id,
+          }))}
+          onSelect={({ id }) => {
+            setCurrentTeamIDValue(id);
+          }}
+          onClear={() => {
+            setCurrentTeamIDDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.teamID?.hasError) {
+              runValidationTasks(\\"teamID\\", value);
+            }
+            setCurrentTeamIDValue(value);
+          }}
+          onBlur={() => runValidationTasks(\\"teamID\\", currentTeamIDValue)}
+          errorMessage={errors.teamID?.errorMessage}
+          hasError={errors.teamID?.hasError}
+          ref={teamIDRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"teamID\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              teamID,
               Team: value,
             };
             const result = onChange(modelFields);
@@ -17456,16 +18217,19 @@ export declare type ValidationResponse = {
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type MyMemberFormInputValues = {
     name?: string;
+    teamID?: string;
     Team?: Team0;
 };
 export declare type MyMemberFormValidationValues = {
     name?: ValidationFunction<string>;
+    teamID?: ValidationFunction<string>;
     Team?: ValidationFunction<Team0>;
 };
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type MyMemberFormOverridesProps = {
     MyMemberFormGrid?: PrimitiveOverrideProps<GridProps>;
     name?: PrimitiveOverrideProps<TextFieldProps>;
+    teamID?: PrimitiveOverrideProps<AutocompleteProps>;
     Team?: PrimitiveOverrideProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type MyMemberFormProps = React.PropsWithChildren<{

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -499,6 +499,18 @@ describe('amplify form renderer tests', () => {
         expect(componentText).not.toContain('CompositeToys');
         expect(componentText).not.toContain('CompositeVets');
       });
+
+      it('should render a create form for child of 1:m relationship', () => {
+        const { componentText, declaration } = generateWithAmplifyFormRenderer(
+          'forms/composite-toy-datastore-create',
+          'datastore/composite-relationships',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
+        );
+
+        expect(componentText).toMatchSnapshot();
+        expect(declaration).toMatchSnapshot();
+      });
     });
   });
 });

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -16,7 +16,6 @@
 import { CallExpression, factory, IfStatement, NodeFlags, SyntaxKind } from 'typescript';
 import {
   FieldConfigMetadata,
-  GenericDataRelationshipType,
   HasManyRelationshipType,
   InternalError,
   GenericDataModel,
@@ -30,11 +29,7 @@ import { isManyToManyRelationship } from './map-from-fieldConfigs';
 import { extractModelAndKeys, getIDValueCallChain, getMatchEveryModelFieldCallExpression } from './model-values';
 import { isModelDataType } from './render-checkers';
 
-export const buildRelationshipQuery = (
-  relationship: GenericDataRelationshipType,
-  importCollection: ImportCollection,
-) => {
-  const { relatedModelName } = relationship;
+export const buildRelationshipQuery = (relatedModelName: string, importCollection: ImportCollection) => {
   const itemsName = getRecordsName(relatedModelName);
   const objectProperties = [
     factory.createPropertyAssignment(factory.createIdentifier('type'), factory.createStringLiteral('collection')),

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -20,7 +20,6 @@ import {
   FormDefinition,
   generateFormDefinition,
   GenericDataSchema,
-  GenericDataRelationshipType,
   handleCodegenErrors,
   mapFormDefinitionToComponent,
   mapFormMetadata,
@@ -518,7 +517,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     // Add value state and ref array type fields in ArrayField wrapper
 
-    const relationshipCollection: GenericDataRelationshipType[] = [];
+    const relatedModelNames: Set<string> = new Set();
 
     Object.entries(formMetadata.fieldConfigs).forEach(([field, fieldConfig]) => {
       const { sanitizedFieldName, componentType, dataType, relationship } = fieldConfig;
@@ -562,8 +561,8 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
         );
       }
 
-      if (relationship) {
-        relationshipCollection.push(relationship);
+      if (relationship && !relatedModelNames.has(relationship.relatedModelName)) {
+        relatedModelNames.add(relationship.relatedModelName);
       }
     });
 
@@ -590,10 +589,12 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
             model: Author,
           }).items;
         */
-    if (relationshipCollection.length) {
+    if (relatedModelNames.size) {
       this.importCollection.addMappedImport(ImportValue.USE_DATA_STORE_BINDING);
       statements.push(
-        ...relationshipCollection.map((relationship) => buildRelationshipQuery(relationship, this.importCollection)),
+        ...[...relatedModelNames].map((relatedModelName) =>
+          buildRelationshipQuery(relatedModelName, this.importCollection),
+        ),
       );
     }
 

--- a/packages/codegen-ui/example-schemas/forms/composite-toy-datastore-create.json
+++ b/packages/codegen-ui/example-schemas/forms/composite-toy-datastore-create.json
@@ -1,0 +1,12 @@
+{
+    "name": "CreateCompositeToyForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "CompositeToy"
+    },
+    "formActionType": "create",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+}

--- a/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
@@ -114,6 +114,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Dog.fields.ownerID.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Owner',
+      isHasManyIndex: true,
     });
   });
 
@@ -175,6 +176,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Dog.fields.ownerID.relationship).toStrictEqual({
       type: 'HAS_ONE',
       relatedModelName: 'Owner',
+      isHasManyIndex: true,
     });
   });
 

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -34,6 +34,41 @@ import { ExtendedStudioGenericFieldConfig } from '../../types/form/form-definiti
 import { StudioFormInputFieldProperty } from '../../types/form/input-config';
 import { FIELD_TYPE_MAP } from './field-type-map';
 
+function extractCorrespondingKey({
+  thisModel,
+  relatedModel,
+  relationshipFieldName,
+}: {
+  thisModel: GenericDataModel;
+  relatedModel: GenericDataModel;
+  relationshipFieldName: string;
+}): string {
+  const relationshipField = thisModel.fields[relationshipFieldName];
+  if (
+    relationshipField.relationship &&
+    'isHasManyIndex' in relationshipField.relationship &&
+    relationshipField.relationship.isHasManyIndex
+  ) {
+    const correspondingFieldTuple = Object.entries(relatedModel.fields).find(
+      ([, field]) =>
+        field.relationship?.type === 'HAS_MANY' &&
+        field.relationship?.relatedModelFields.includes(relationshipFieldName),
+    );
+    if (correspondingFieldTuple) {
+      const correspondingField = correspondingFieldTuple[1].relationship;
+      if (correspondingField?.type === 'HAS_MANY') {
+        const indexOfKey = correspondingField.relatedModelFields.indexOf(relationshipFieldName);
+        if (indexOfKey !== -1) {
+          return relatedModel.primaryKeys[indexOfKey];
+        }
+      }
+    }
+  }
+
+  // TODO: support other types
+  return relationshipFieldName;
+}
+
 export function getFieldTypeMapKey(field: GenericDataField): FieldTypeMapKeys {
   if (typeof field.dataType === 'object' && 'enum' in field.dataType) {
     return 'Enum';
@@ -96,11 +131,13 @@ function getModelDisplayValue({
 }
 
 function getValueMappings({
+  dataTypeName,
   fieldName,
   field,
   enums,
   allModels,
 }: {
+  dataTypeName: string;
   fieldName: string;
   field: GenericDataField;
   enums: GenericDataSchema['enums'];
@@ -126,8 +163,16 @@ function getValueMappings({
     const modelName = field.relationship.relatedModelName;
     const relatedModel = allModels[modelName];
     const isModelType = typeof field.dataType === 'object' && 'model' in field.dataType;
-    // if model, store all keys; else, store field as key
-    const keys = isModelType ? relatedModel.primaryKeys : [fieldName];
+    // if model, store all keys; else, store corresponding primary key
+    const keys = isModelType
+      ? relatedModel.primaryKeys
+      : [
+          extractCorrespondingKey({
+            thisModel: allModels[dataTypeName],
+            relatedModel,
+            relationshipFieldName: fieldName,
+          }),
+        ];
     const values: StudioFormValueMappings['values'] = keys.map((key) => ({
       value: { bindingProperties: { property: modelName, field: key } },
     }));
@@ -145,11 +190,13 @@ function getValueMappings({
 }
 
 export function getFieldConfigFromModelField({
+  dataTypeName,
   fieldName,
   field,
   dataSchema,
   setReadOnly,
 }: {
+  dataTypeName: string;
   fieldName: string;
   field: GenericDataField;
   dataSchema: GenericDataSchema;
@@ -196,7 +243,13 @@ export function getFieldConfigFromModelField({
     config.relationship = field.relationship;
   }
 
-  const valueMappings = getValueMappings({ fieldName, field, enums: dataSchema.enums, allModels: dataSchema.models });
+  const valueMappings = getValueMappings({
+    dataTypeName,
+    fieldName,
+    field,
+    enums: dataSchema.enums,
+    allModels: dataSchema.models,
+  });
   if (valueMappings) {
     config.inputType.valueMappings = valueMappings;
   }
@@ -233,7 +286,9 @@ export function mapModelFieldsConfigs({
       field.readOnly ||
       (fieldName === 'id' && field.dataType === 'ID' && field.required) ||
       !checkIsSupportedAsFormField(field, featureFlags) ||
-      (field.relationship && !(typeof field.dataType === 'object' && 'model' in field.dataType));
+      (field.relationship &&
+        !(typeof field.dataType === 'object' && 'model' in field.dataType) &&
+        !('isHasManyIndex' in field.relationship && field.relationship.isHasManyIndex));
 
     if (!isAutoExcludedField) {
       formDefinition.elementMatrix.push([fieldName]);
@@ -242,6 +297,7 @@ export function mapModelFieldsConfigs({
     const isPrimaryKey = model.primaryKeys.includes(fieldName);
 
     modelFieldsConfigs[fieldName] = getFieldConfigFromModelField({
+      dataTypeName,
       fieldName,
       field,
       dataSchema,

--- a/packages/codegen-ui/lib/generic-from-datastore.ts
+++ b/packages/codegen-ui/lib/generic-from-datastore.ts
@@ -128,6 +128,7 @@ export function getGenericFromDataStore(dataStoreSchema: DataStoreSchema): Gener
                 addRelationship(fieldsWithImplicitRelationships, relatedModelName, associatedFieldName, {
                   type: 'HAS_ONE',
                   relatedModelName: model.name,
+                  isHasManyIndex: true,
                 });
               }
             });

--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -44,6 +44,7 @@ export type HasManyRelationshipType = {
 export type HasOneRelationshipType = {
   type: 'HAS_ONE';
   associatedFields?: string[];
+  isHasManyIndex?: boolean;
 } & CommonRelationshipType;
 
 export type BelongsToRelationshipType = {

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
@@ -37,6 +37,7 @@ const EXPECTED_SUCCESSFUL_CASES = new Set([
   'DataStoreFormCreateCPKTeacher',
   'DataStoreFormUpdateCompositeDog',
   'DataStoreFormCreateCompositeDog',
+  'DataStoreFormUpdateCompositeToy',
   'ComponentWithDataBindingWithPredicate',
   'ComponentWithDataBindingWithoutPredicate',
   'ComponentWithSimplePropertyBinding',

--- a/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/update-form-spec.cy.ts
@@ -205,4 +205,31 @@ describe('UpdateForms', () => {
       });
     });
   });
+
+  // this model is m in 1:m
+  describe('DataStoreFormUpdateCompositeToy', () => {
+    beforeEach(() => {
+      cy.reload();
+    });
+    it('should update indices used for 1:m relationships', () => {
+      cy.get('#dataStoreFormUpdateCompositeToy').within(() => {
+        getArrayFieldButtonByLabel('Composite dog composite toys name').click();
+        typeInAutocomplete('Yundoo{downArrow}{enter}');
+        clickAddToArray();
+
+        getArrayFieldButtonByLabel('Composite dog composite toys description').click();
+        typeInAutocomplete('tiny but mighty{downArrow}{enter}');
+        clickAddToArray();
+
+        cy.contains('Submit').click();
+
+        cy.contains(/chew/).then((recordElement: JQuery) => {
+          const record = JSON.parse(recordElement.text());
+
+          expect(record.compositeDogCompositeToysName).to.equal('Yundoo');
+          expect(record.compositeDogCompositeToysDescription).to.equal('tiny but mighty');
+        });
+      });
+    });
+  });
 });

--- a/packages/test-generator/integration-test-templates/src/UpdateFormTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/UpdateFormTests.tsx
@@ -21,6 +21,7 @@ import {
   DataStoreFormUpdateAllSupportedFormFields,
   DataStoreFormUpdateCompositeDog,
   DataStoreFormUpdateCPKTeacher,
+  DataStoreFormUpdateCompositeToy,
 } from './ui-components'; // eslint-disable-line import/extensions, max-len
 import {
   Owner,
@@ -266,6 +267,8 @@ export default function UpdateFormTests() {
   const [compositeDogRecordString, setCompositeDogRecordString] = useState<string>('');
   const initializeStarted = useRef(false);
 
+  const [compositeToyRecord, setCompositeToyRecord] = useState<CompositeToy | undefined>();
+  const [compositeToyRecordString, setCompositeToyRecordString] = useState<string>('');
   useEffect(() => {
     const initializeTestState = async () => {
       if (initializeStarted.current) {
@@ -279,6 +282,7 @@ export default function UpdateFormTests() {
         initializeCPKTeacherTestData({ setCPKTeacherId }),
         initializeCompositeDogTestData({ setCompositeDogRecord }),
       ]);
+      setCompositeToyRecord(await DataStore.query(CompositeToy, { kind: 'chew', color: 'red' }));
       setInitialized(true);
     };
 
@@ -374,6 +378,18 @@ export default function UpdateFormTests() {
           }}
         />
         <Text>{compositeDogRecordString}</Text>
+      </View>
+      <Heading>DataStore Form - UpdateCompositeToy</Heading>
+      <View id="dataStoreFormUpdateCompositeToy">
+        <DataStoreFormUpdateCompositeToy
+          compositeToy={compositeToyRecord}
+          onSuccess={async () => {
+            const record = await DataStore.query(CompositeToy, { kind: 'chew', color: 'red' });
+
+            setCompositeToyRecordString(JSON.stringify(record));
+          }}
+        />
+        <Text>{compositeToyRecordString}</Text>
       </View>
     </AmplifyProvider>
   );

--- a/packages/test-generator/lib/forms/datastore-form-update-composite-toy.json
+++ b/packages/test-generator/lib/forms/datastore-form-update-composite-toy.json
@@ -1,0 +1,13 @@
+{
+    "id": "kdjfskdfddj",
+    "name": "DataStoreFormUpdateCompositeToy",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "CompositeToy"
+    },
+    "formActionType": "update",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+}

--- a/packages/test-generator/lib/forms/index.ts
+++ b/packages/test-generator/lib/forms/index.ts
@@ -24,3 +24,4 @@ export { default as DataStoreFormUpdateCPKTeacher } from './datastore-form-updat
 export { default as DataStoreFormUpdateCompositeDog } from './datastore-form-update-composite-dog.json';
 export { default as DataStoreFormCreateCPKTeacher } from './datastore-form-create-cpk-teacher.json';
 export { default as DataStoreFormCreateCompositeDog } from './datastore-form-create-composite-dog.json';
+export { default as DataStoreFormUpdateCompositeToy } from './datastore-form-update-composite-toy.json';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For 1:m relationship (Post:Comment), there is a secondary index on Comment that allows it to be queried by Post's primary key(s) - https://docs.amplify.aws/cli/graphql/data-modeling/#has-many-relationship.
We want to render the field for this index/indices so that the customer can configure relationships from the child.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
