### PR TITLE
test: update tests with placeholders

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -385,6 +385,7 @@ export default function CreateCompositeToyForm(props) {
           label=\\"Composite dog composite toys name\\"
           isRequired={false}
           isReadOnly={false}
+          placeholder=\\"Search CompositeDog\\"
           value={currentCompositeDogCompositeToysNameValue}
           options={compositeDogRecords.map((r) => ({
             id: r?.name,
@@ -449,6 +450,7 @@ export default function CreateCompositeToyForm(props) {
           label=\\"Composite dog composite toys description\\"
           isRequired={false}
           isReadOnly={false}
+          placeholder=\\"Search CompositeDog\\"
           value={currentCompositeDogCompositeToysDescriptionValue}
           options={compositeDogRecords.map((r) => ({
             id: r?.description,
@@ -8759,6 +8761,7 @@ export default function MyMemberForm(props) {
           label=\\"Team id\\"
           isRequired={true}
           isReadOnly={false}
+          placeholder=\\"Search Team\\"
           value={currentTeamIDValue}
           options={teamRecords.map((r) => ({
             id: r?.id,
@@ -12740,6 +12743,7 @@ export default function MyMemberForm(props) {
           label=\\"Team id\\"
           isRequired={true}
           isReadOnly={false}
+          placeholder=\\"Search Team\\"
           value={currentTeamIDValue}
           options={teamRecords.map((r) => ({
             id: r?.id,
@@ -18113,6 +18117,7 @@ export default function MyMemberForm(props) {
           label=\\"Team id\\"
           isRequired={true}
           isReadOnly={false}
+          placeholder=\\"Search Team\\"
           value={currentTeamIDValue}
           options={teamRecords.map((r) => ({
             id: r?.id,

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -463,6 +463,7 @@ describe('mapModelFieldsConfigs', () => {
               readOnly: false,
               isArray: true,
               relationship: {
+                canUnlinkAssociatedModel: true,
                 type: 'HAS_MANY',
                 relatedModelName: 'CompositeToy',
                 relatedModelFields: ['compositeDogCompositeToysName', 'compositeDogCompositeToysDescription'],
@@ -529,6 +530,7 @@ describe('mapModelFieldsConfigs', () => {
       label: 'Composite dog composite toys name',
       dataType: 'ID',
       inputType: {
+        placeholder: 'Search CompositeDog',
         type: 'Autocomplete',
         required: false,
         readOnly: false,
@@ -547,6 +549,7 @@ describe('mapModelFieldsConfigs', () => {
       dataType: 'String',
       inputType: {
         type: 'Autocomplete',
+        placeholder: 'Search CompositeDog',
         required: false,
         readOnly: false,
         name: 'compositeDogCompositeToysDescription',


### PR DESCRIPTION
*What happened:*
1. PRs that added more unit tests passed checks
2. PR for adding placeholder was merged
3. PRs that added more unit tests were merged
4. Unit tests are now failing because they do not contain placeholders.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
