### PR TITLE
feat: support bidirectional hasMany

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -562,6 +562,738 @@ export default function CreateCompositeToyForm(props: CreateCompositeToyFormProp
 "
 `;
 
+exports[`amplify form renderer tests datastore form tests custom form tests should render a create form for child of 1:m-belongsTo relationship 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+} from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Comment, Post, User as User0, Org as Org0 } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { DataStore } from \\"aws-amplify\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button
+            size=\\"small\\"
+            variation=\\"link\\"
+            isDisabled={hasError}
+            onClick={addItem}
+          >
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function CreateCommentForm(props) {
+  const {
+    clearOnSuccess = true,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    name: \\"\\",
+    post: undefined,
+    User: undefined,
+    Org: undefined,
+    postCommentsId: undefined,
+  };
+  const [name, setName] = React.useState(initialValues.name);
+  const [post, setPost] = React.useState(initialValues.post);
+  const [User, setUser] = React.useState(initialValues.User);
+  const [Org, setOrg] = React.useState(initialValues.Org);
+  const [postCommentsId, setPostCommentsId] = React.useState(
+    initialValues.postCommentsId
+  );
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setName(initialValues.name);
+    setPost(initialValues.post);
+    setCurrentPostValue(undefined);
+    setCurrentPostDisplayValue(\\"\\");
+    setUser(initialValues.User);
+    setCurrentUserValue(undefined);
+    setCurrentUserDisplayValue(\\"\\");
+    setOrg(initialValues.Org);
+    setCurrentOrgValue(undefined);
+    setCurrentOrgDisplayValue(\\"\\");
+    setPostCommentsId(initialValues.postCommentsId);
+    setCurrentPostCommentsIdValue(undefined);
+    setErrors({});
+  };
+  const [currentPostDisplayValue, setCurrentPostDisplayValue] =
+    React.useState(\\"\\");
+  const [currentPostValue, setCurrentPostValue] = React.useState(undefined);
+  const postRef = React.createRef();
+  const [currentUserDisplayValue, setCurrentUserDisplayValue] =
+    React.useState(\\"\\");
+  const [currentUserValue, setCurrentUserValue] = React.useState(undefined);
+  const UserRef = React.createRef();
+  const [currentOrgDisplayValue, setCurrentOrgDisplayValue] =
+    React.useState(\\"\\");
+  const [currentOrgValue, setCurrentOrgValue] = React.useState(undefined);
+  const OrgRef = React.createRef();
+  const [currentPostCommentsIdValue, setCurrentPostCommentsIdValue] =
+    React.useState(undefined);
+  const postCommentsIdRef = React.createRef();
+  const getIDValue = {
+    post: (r) => JSON.stringify({ id: r?.id }),
+    User: (r) => JSON.stringify({ id: r?.id }),
+    Org: (r) => JSON.stringify({ id: r?.id }),
+  };
+  const postIdSet = new Set(
+    Array.isArray(post)
+      ? post.map((r) => getIDValue.post?.(r))
+      : getIDValue.post?.(post)
+  );
+  const UserIdSet = new Set(
+    Array.isArray(User)
+      ? User.map((r) => getIDValue.User?.(r))
+      : getIDValue.User?.(User)
+  );
+  const OrgIdSet = new Set(
+    Array.isArray(Org)
+      ? Org.map((r) => getIDValue.Org?.(r))
+      : getIDValue.Org?.(Org)
+  );
+  const postRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: Post,
+  }).items;
+  const userRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: User0,
+  }).items;
+  const orgRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: Org0,
+  }).items;
+  const getDisplayValue = {
+    post: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+    User: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+    Org: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+  };
+  const validations = {
+    name: [{ type: \\"Required\\" }],
+    post: [],
+    User: [],
+    Org: [{ type: \\"Required\\", validationMessage: \\"Org is required.\\" }],
+    postCommentsId: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          name,
+          post,
+          User,
+          Org,
+          postCommentsId,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
+          await DataStore.save(new Comment(modelFields));
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+          if (clearOnSuccess) {
+            resetStateValues();
+          }
+        } catch (err) {
+          if (onError) {
+            onError(modelFields, err.message);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"CreateCommentForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Name\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={name}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              name: value,
+              post,
+              User,
+              Org,
+              postCommentsId,
+            };
+            const result = onChange(modelFields);
+            value = result?.name ?? value;
+          }
+          if (errors.name?.hasError) {
+            runValidationTasks(\\"name\\", value);
+          }
+          setName(value);
+        }}
+        onBlur={() => runValidationTasks(\\"name\\", name)}
+        errorMessage={errors.name?.errorMessage}
+        hasError={errors.name?.hasError}
+        {...getOverrideProps(overrides, \\"name\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              post: value,
+              User,
+              Org,
+              postCommentsId,
+            };
+            const result = onChange(modelFields);
+            value = result?.post ?? value;
+          }
+          setPost(value);
+          setCurrentPostValue(undefined);
+          setCurrentPostDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentPostValue}
+        label={\\"Post\\"}
+        items={post ? [post] : []}
+        hasError={errors.post?.hasError}
+        getBadgeText={getDisplayValue.post}
+        setFieldValue={(model) => {
+          setCurrentPostDisplayValue(getDisplayValue.post(model));
+          setCurrentPostValue(model);
+        }}
+        inputFieldRef={postRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Post\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Post\\"
+          value={currentPostDisplayValue}
+          options={postRecords
+            .filter((r) => !postIdSet.has(getIDValue.post?.(r)))
+            .map((r) => ({
+              id: getIDValue.post?.(r),
+              label: getDisplayValue.post?.(r),
+            }))}
+          onSelect={({ id, label }) => {
+            setCurrentPostValue(
+              postRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentPostDisplayValue(label);
+          }}
+          onClear={() => {
+            setCurrentPostDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.post?.hasError) {
+              runValidationTasks(\\"post\\", value);
+            }
+            setCurrentPostDisplayValue(value);
+            setCurrentPostValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"post\\", currentPostDisplayValue)}
+          errorMessage={errors.post?.errorMessage}
+          hasError={errors.post?.hasError}
+          ref={postRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"post\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              post,
+              User: value,
+              Org,
+              postCommentsId,
+            };
+            const result = onChange(modelFields);
+            value = result?.User ?? value;
+          }
+          setUser(value);
+          setCurrentUserValue(undefined);
+          setCurrentUserDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentUserValue}
+        label={\\"User\\"}
+        items={User ? [User] : []}
+        hasError={errors.User?.hasError}
+        getBadgeText={getDisplayValue.User}
+        setFieldValue={(model) => {
+          setCurrentUserDisplayValue(getDisplayValue.User(model));
+          setCurrentUserValue(model);
+        }}
+        inputFieldRef={UserRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"User\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search User\\"
+          value={currentUserDisplayValue}
+          options={userRecords
+            .filter((r) => !UserIdSet.has(getIDValue.User?.(r)))
+            .map((r) => ({
+              id: getIDValue.User?.(r),
+              label: getDisplayValue.User?.(r),
+            }))}
+          onSelect={({ id, label }) => {
+            setCurrentUserValue(
+              userRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentUserDisplayValue(label);
+          }}
+          onClear={() => {
+            setCurrentUserDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.User?.hasError) {
+              runValidationTasks(\\"User\\", value);
+            }
+            setCurrentUserDisplayValue(value);
+            setCurrentUserValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"User\\", currentUserDisplayValue)}
+          errorMessage={errors.User?.errorMessage}
+          hasError={errors.User?.hasError}
+          ref={UserRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"User\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              post,
+              User,
+              Org: value,
+              postCommentsId,
+            };
+            const result = onChange(modelFields);
+            value = result?.Org ?? value;
+          }
+          setOrg(value);
+          setCurrentOrgValue(undefined);
+          setCurrentOrgDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentOrgValue}
+        label={\\"Org\\"}
+        items={Org ? [Org] : []}
+        hasError={errors.Org?.hasError}
+        getBadgeText={getDisplayValue.Org}
+        setFieldValue={(model) => {
+          setCurrentOrgDisplayValue(getDisplayValue.Org(model));
+          setCurrentOrgValue(model);
+        }}
+        inputFieldRef={OrgRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Org\\"
+          isRequired={true}
+          isReadOnly={false}
+          placeholder=\\"Search Org\\"
+          value={currentOrgDisplayValue}
+          options={orgRecords
+            .filter((r) => !OrgIdSet.has(getIDValue.Org?.(r)))
+            .map((r) => ({
+              id: getIDValue.Org?.(r),
+              label: getDisplayValue.Org?.(r),
+            }))}
+          onSelect={({ id, label }) => {
+            setCurrentOrgValue(
+              orgRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentOrgDisplayValue(label);
+          }}
+          onClear={() => {
+            setCurrentOrgDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.Org?.hasError) {
+              runValidationTasks(\\"Org\\", value);
+            }
+            setCurrentOrgDisplayValue(value);
+            setCurrentOrgValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"Org\\", currentOrgDisplayValue)}
+          errorMessage={errors.Org?.errorMessage}
+          hasError={errors.Org?.hasError}
+          ref={OrgRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"Org\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              post,
+              User,
+              Org,
+              postCommentsId: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.postCommentsId ?? value;
+          }
+          setPostCommentsId(value);
+          setCurrentPostCommentsIdValue(undefined);
+        }}
+        currentFieldValue={currentPostCommentsIdValue}
+        label={\\"Post comments id\\"}
+        items={postCommentsId ? [postCommentsId] : []}
+        hasError={errors.postCommentsId?.hasError}
+        setFieldValue={setCurrentPostCommentsIdValue}
+        inputFieldRef={postCommentsIdRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Post comments id\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Post\\"
+          value={currentPostCommentsIdValue}
+          options={postRecords.map((r) => ({
+            id: r?.id,
+            label: r?.id,
+          }))}
+          onSelect={({ id }) => {
+            setCurrentPostCommentsIdValue(id);
+          }}
+          onClear={() => {
+            setCurrentPostCommentsIdDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.postCommentsId?.hasError) {
+              runValidationTasks(\\"postCommentsId\\", value);
+            }
+            setCurrentPostCommentsIdValue(value);
+          }}
+          onBlur={() =>
+            runValidationTasks(\\"postCommentsId\\", currentPostCommentsIdValue)
+          }
+          errorMessage={errors.postCommentsId?.errorMessage}
+          hasError={errors.postCommentsId?.hasError}
+          ref={postCommentsIdRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"postCommentsId\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Clear\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          {...getOverrideProps(overrides, \\"ClearButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e?.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests datastore form tests custom form tests should render a create form for child of 1:m-belongsTo relationship 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post, User as User0, Org as Org0 } from \\"../models\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type CreateCommentFormInputValues = {
+    name?: string;
+    post?: Post;
+    User?: User0;
+    Org?: Org0;
+    postCommentsId?: string;
+};
+export declare type CreateCommentFormValidationValues = {
+    name?: ValidationFunction<string>;
+    post?: ValidationFunction<Post>;
+    User?: ValidationFunction<User0>;
+    Org?: ValidationFunction<Org0>;
+    postCommentsId?: ValidationFunction<string>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type CreateCommentFormOverridesProps = {
+    CreateCommentFormGrid?: PrimitiveOverrideProps<GridProps>;
+    name?: PrimitiveOverrideProps<TextFieldProps>;
+    post?: PrimitiveOverrideProps<AutocompleteProps>;
+    User?: PrimitiveOverrideProps<AutocompleteProps>;
+    Org?: PrimitiveOverrideProps<AutocompleteProps>;
+    postCommentsId?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type CreateCommentFormProps = React.PropsWithChildren<{
+    overrides?: CreateCommentFormOverridesProps | undefined | null;
+} & {
+    clearOnSuccess?: boolean;
+    onSubmit?: (fields: CreateCommentFormInputValues) => CreateCommentFormInputValues;
+    onSuccess?: (fields: CreateCommentFormInputValues) => void;
+    onError?: (fields: CreateCommentFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: CreateCommentFormInputValues) => CreateCommentFormInputValues;
+    onValidate?: CreateCommentFormValidationValues;
+} & React.CSSProperties>;
+export default function CreateCommentForm(props: CreateCommentFormProps): React.ReactElement;
+"
+`;
+
 exports[`amplify form renderer tests datastore form tests custom form tests should render a create form for model with composite keys 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
@@ -3836,6 +4568,536 @@ export declare type MyPostFormProps = React.PropsWithChildren<{
     onValidate?: MyPostFormValidationValues;
 } & React.CSSProperties>;
 export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests datastore form tests custom form tests should render a update form for parent of 1:m-belongsTo relationship 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+} from \\"@aws-amplify/ui-react\\";
+import {
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Org, Comment } from \\"../models\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { DataStore } from \\"aws-amplify\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button
+            size=\\"small\\"
+            variation=\\"link\\"
+            isDisabled={hasError}
+            onClick={addItem}
+          >
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function UpdateOrgForm(props) {
+  const {
+    id: idProp,
+    org,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    name: \\"\\",
+    comments: [],
+  };
+  const [name, setName] = React.useState(initialValues.name);
+  const [comments, setComments] = React.useState(initialValues.comments);
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    const cleanValues = orgRecord
+      ? { ...initialValues, ...orgRecord, comments: linkedComments }
+      : initialValues;
+    setName(cleanValues.name);
+    setComments(cleanValues.comments ?? []);
+    setCurrentCommentsValue(undefined);
+    setCurrentCommentsDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [orgRecord, setOrgRecord] = React.useState(org);
+  const [linkedComments, setLinkedComments] = React.useState([]);
+  const canUnlinkComments = false;
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = idProp ? await DataStore.query(Org, idProp) : org;
+      setOrgRecord(record);
+      const linkedComments = record ? await record.comments.toArray() : [];
+      setLinkedComments(linkedComments);
+    };
+    queryData();
+  }, [idProp, org]);
+  React.useEffect(resetStateValues, [orgRecord, linkedComments]);
+  const [currentCommentsDisplayValue, setCurrentCommentsDisplayValue] =
+    React.useState(\\"\\");
+  const [currentCommentsValue, setCurrentCommentsValue] =
+    React.useState(undefined);
+  const commentsRef = React.createRef();
+  const getIDValue = {
+    comments: (r) => JSON.stringify({ id: r?.id }),
+  };
+  const commentsIdSet = new Set(
+    Array.isArray(comments)
+      ? comments.map((r) => getIDValue.comments?.(r))
+      : getIDValue.comments?.(comments)
+  );
+  const commentRecords = useDataStoreBinding({
+    type: \\"collection\\",
+    model: Comment,
+  }).items;
+  const getDisplayValue = {
+    comments: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+  };
+  const validations = {
+    name: [],
+    comments: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value = getDisplayValue
+      ? getDisplayValue(currentValue)
+      : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          name,
+          comments,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
+          const promises = [];
+          const commentsToLink = [];
+          const commentsToUnLink = [];
+          const commentsSet = new Set();
+          const linkedCommentsSet = new Set();
+          comments.forEach((r) => commentsSet.add(getIDValue.comments?.(r)));
+          linkedComments.forEach((r) =>
+            linkedCommentsSet.add(getIDValue.comments?.(r))
+          );
+          linkedComments.forEach((r) => {
+            if (!commentsSet.has(getIDValue.comments?.(r))) {
+              commentsToUnLink.push(r);
+            }
+          });
+          comments.forEach((r) => {
+            if (!linkedCommentsSet.has(getIDValue.comments?.(r))) {
+              commentsToLink.push(r);
+            }
+          });
+          commentsToUnLink.forEach((original) => {
+            if (!canUnlinkComments) {
+              throw Error(
+                \`Comment \${original.id} cannot be unlinked from Org because orgCommentsId is a required field.\`
+              );
+            }
+            promises.push(
+              DataStore.save(
+                Comment.copyOf(original, (updated) => {
+                  updated.orgCommentsId = null;
+                  updated.Org = null;
+                })
+              )
+            );
+          });
+          commentsToLink.forEach((original) => {
+            promises.push(
+              DataStore.save(
+                Comment.copyOf(original, (updated) => {
+                  updated.orgCommentsId = orgRecord.id;
+                  updated.Org = orgRecord;
+                })
+              )
+            );
+          });
+          promises.push(
+            DataStore.save(
+              Org.copyOf(orgRecord, (updated) => {
+                Object.assign(updated, modelFields);
+              })
+            )
+          );
+          await Promise.all(promises);
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+        } catch (err) {
+          if (onError) {
+            onError(modelFields, err.message);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"UpdateOrgForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Name\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={name}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              name: value,
+              comments,
+            };
+            const result = onChange(modelFields);
+            value = result?.name ?? value;
+          }
+          if (errors.name?.hasError) {
+            runValidationTasks(\\"name\\", value);
+          }
+          setName(value);
+        }}
+        onBlur={() => runValidationTasks(\\"name\\", name)}
+        errorMessage={errors.name?.errorMessage}
+        hasError={errors.name?.hasError}
+        {...getOverrideProps(overrides, \\"name\\")}
+      ></TextField>
+      <ArrayField
+        onChange={async (items) => {
+          let values = items;
+          if (onChange) {
+            const modelFields = {
+              name,
+              comments: values,
+            };
+            const result = onChange(modelFields);
+            values = result?.comments ?? values;
+          }
+          setComments(values);
+          setCurrentCommentsValue(undefined);
+          setCurrentCommentsDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentCommentsValue}
+        label={\\"Comments\\"}
+        items={comments}
+        hasError={errors.comments?.hasError}
+        getBadgeText={getDisplayValue.comments}
+        setFieldValue={(model) => {
+          setCurrentCommentsDisplayValue(getDisplayValue.comments(model));
+          setCurrentCommentsValue(model);
+        }}
+        inputFieldRef={commentsRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Comments\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Comment\\"
+          value={currentCommentsDisplayValue}
+          options={commentRecords
+            .filter((r) => !commentsIdSet.has(getIDValue.comments?.(r)))
+            .map((r) => ({
+              id: getIDValue.comments?.(r),
+              label: getDisplayValue.comments?.(r),
+            }))}
+          onSelect={({ id, label }) => {
+            setCurrentCommentsValue(
+              commentRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentCommentsDisplayValue(label);
+          }}
+          onClear={() => {
+            setCurrentCommentsDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.comments?.hasError) {
+              runValidationTasks(\\"comments\\", value);
+            }
+            setCurrentCommentsDisplayValue(value);
+            setCurrentCommentsValue(undefined);
+          }}
+          onBlur={() =>
+            runValidationTasks(\\"comments\\", currentCommentsDisplayValue)
+          }
+          errorMessage={errors.comments?.errorMessage}
+          hasError={errors.comments?.hasError}
+          ref={commentsRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"comments\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          isDisabled={!(idProp || org)}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={
+              !(idProp || org) || Object.values(errors).some((e) => e?.hasError)
+            }
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests datastore form tests custom form tests should render a update form for parent of 1:m-belongsTo relationship 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Org, Comment } from \\"../models\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type UpdateOrgFormInputValues = {
+    name?: string;
+    comments?: Comment[];
+};
+export declare type UpdateOrgFormValidationValues = {
+    name?: ValidationFunction<string>;
+    comments?: ValidationFunction<Comment>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type UpdateOrgFormOverridesProps = {
+    UpdateOrgFormGrid?: PrimitiveOverrideProps<GridProps>;
+    name?: PrimitiveOverrideProps<TextFieldProps>;
+    comments?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type UpdateOrgFormProps = React.PropsWithChildren<{
+    overrides?: UpdateOrgFormOverridesProps | undefined | null;
+} & {
+    id?: string;
+    org?: Org;
+    onSubmit?: (fields: UpdateOrgFormInputValues) => UpdateOrgFormInputValues;
+    onSuccess?: (fields: UpdateOrgFormInputValues) => void;
+    onError?: (fields: UpdateOrgFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: UpdateOrgFormInputValues) => UpdateOrgFormInputValues;
+    onValidate?: UpdateOrgFormValidationValues;
+} & React.CSSProperties>;
+export default function UpdateOrgForm(props: UpdateOrgFormProps): React.ReactElement;
 "
 `;
 

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -522,6 +522,37 @@ describe('amplify form renderer tests', () => {
         expect(componentText).toMatchSnapshot();
         expect(declaration).toMatchSnapshot();
       });
+
+      it('should render a create form for child of 1:m-belongsTo relationship', () => {
+        const { componentText, declaration } = generateWithAmplifyFormRenderer(
+          'forms/comment-datastore-create',
+          'datastore/comment-hasMany-belongsTo-relationships',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
+        );
+
+        expect(componentText).toContain('postCommentsId');
+        expect(componentText).not.toContain('postID');
+        expect(componentText).not.toContain('userCommentsId');
+        expect(componentText).not.toContain('orgCommentsId');
+
+        expect(componentText).toMatchSnapshot();
+        expect(declaration).toMatchSnapshot();
+      });
+
+      it('should render a update form for parent of 1:m-belongsTo relationship', () => {
+        const { componentText, declaration } = generateWithAmplifyFormRenderer(
+          'forms/org-datastore-update',
+          'datastore/comment-hasMany-belongsTo-relationships',
+          undefined,
+          { isNonModelSupported: true, isRelationshipSupported: true },
+        );
+
+        expect(componentText).toContain('updated.Org = orgRecord');
+        expect(componentText).toContain('updated.Org = null');
+        expect(componentText).toMatchSnapshot();
+        expect(declaration).toMatchSnapshot();
+      });
     });
   });
 });

--- a/packages/codegen-ui/example-schemas/datastore/comment-hasMany-belongsTo-relationships.json
+++ b/packages/codegen-ui/example-schemas/datastore/comment-hasMany-belongsTo-relationships.json
@@ -1,0 +1,301 @@
+{
+    "models": {
+        "User": {
+            "name": "User",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "name": {
+                    "name": "name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "comments": {
+                    "name": "comments",
+                    "isArray": true,
+                    "type": {
+                        "model": "Comment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": [
+                            "userCommentsId"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Users",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                }
+            ]
+        },
+        "Comment": {
+            "name": "Comment",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "name": {
+                    "name": "name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "postID": {
+                    "name": "postID",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "post": {
+                    "name": "post",
+                    "isArray": false,
+                    "type": {
+                        "model": "Post"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "BELONGS_TO",
+                        "targetNames": [
+                            "postID"
+                        ]
+                    }
+                },
+                "User": {
+                    "name": "User",
+                    "isArray": false,
+                    "type": {
+                        "model": "User"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "BELONGS_TO",
+                        "targetNames": [
+                            "userCommentsId"
+                        ]
+                    }
+                },
+                "Org": {
+                    "name": "Org",
+                    "isArray": false,
+                    "type": {
+                        "model": "Org"
+                    },
+                    "isRequired": true,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "BELONGS_TO",
+                        "targetNames": [
+                            "orgCommentsId"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "userCommentsId": {
+                    "name": "userCommentsId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "orgCommentsId": {
+                    "name": "orgCommentsId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "postCommentsId": {
+                    "name": "postCommentsId",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": false,
+                    "attributes": []
+                }
+            },
+            "syncable": true,
+            "pluralName": "Comments",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                }
+            ]
+        },
+        "Post": {
+            "name": "Post",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "name": {
+                    "name": "name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "comments": {
+                    "name": "comments",
+                    "isArray": true,
+                    "type": {
+                        "model": "Comment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": [
+                            "postCommentsId"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Posts",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                }
+            ]
+        },
+        "Org": {
+            "name": "Org",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "name": {
+                    "name": "name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "comments": {
+                    "name": "comments",
+                    "isArray": true,
+                    "type": {
+                        "model": "Comment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": [
+                            "orgCommentsId"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Orgs",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                }
+            ]
+        }
+    },
+    "enums": {},
+    "nonModels": {},
+    "codegenVersion": "3.3.5",
+    "version": "f2f8e885f81740e5be20b201c850fa05"
+}

--- a/packages/codegen-ui/example-schemas/forms/comment-datastore-create.json
+++ b/packages/codegen-ui/example-schemas/forms/comment-datastore-create.json
@@ -1,0 +1,12 @@
+{
+    "name": "CreateCommentForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "Comment"
+    },
+    "formActionType": "create",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+}

--- a/packages/codegen-ui/example-schemas/forms/org-datastore-update.json
+++ b/packages/codegen-ui/example-schemas/forms/org-datastore-update.json
@@ -1,0 +1,12 @@
+{
+    "name": "UpdateOrgForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "Org"
+    },
+    "formActionType": "update",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+}

--- a/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/mock-schemas.ts
@@ -2364,3 +2364,320 @@ export const schemaWithCompositeKeys: Schema = {
   codegenVersion: '3.3.5',
   version: '8f8e59ee8fb2e3ca4efda3aa25b0211f',
 };
+
+/**
+type User @model {
+    name: String
+    comments: [Comment] @hasMany
+}
+
+type Org @model {
+    id: ID!
+    name: String
+    comments: [Comment] @hasMany
+}
+
+type Post @model  {
+    id: ID!
+    name: String
+    comments: [Comment] @hasMany
+}
+
+type Comment @model  {
+    id: ID!
+    name: String!
+    postID: ID
+    post: Post @belongsTo(fields: ["postID"])
+    User: User @belongsTo
+    Org: Org! @belongsTo
+}
+ */
+export const schemaWithHasManyBelongsTo: Schema = {
+  models: {
+    User: {
+      name: 'User',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        name: {
+          name: 'name',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        comments: {
+          name: 'comments',
+          isArray: true,
+          type: {
+            model: 'Comment',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['userCommentsId'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'Users',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+      ],
+    },
+    Comment: {
+      name: 'Comment',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        name: {
+          name: 'name',
+          isArray: false,
+          type: 'String',
+          isRequired: true,
+          attributes: [],
+        },
+        postID: {
+          name: 'postID',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        post: {
+          name: 'post',
+          isArray: false,
+          type: {
+            model: 'Post',
+          },
+          isRequired: false,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['postID'],
+          },
+        },
+        User: {
+          name: 'User',
+          isArray: false,
+          type: {
+            model: 'User',
+          },
+          isRequired: false,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['userCommentsId'],
+          },
+        },
+        Org: {
+          name: 'Org',
+          isArray: false,
+          type: {
+            model: 'Org',
+          },
+          isRequired: true,
+          attributes: [],
+          association: {
+            connectionType: 'BELONGS_TO',
+            targetNames: ['orgCommentsId'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        userCommentsId: {
+          name: 'userCommentsId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+        orgCommentsId: {
+          name: 'orgCommentsId',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        postCommentsId: {
+          name: 'postCommentsId',
+          isArray: false,
+          type: 'ID',
+          isRequired: false,
+          attributes: [],
+        },
+      },
+      syncable: true,
+      pluralName: 'Comments',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+      ],
+    },
+    Post: {
+      name: 'Post',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        name: {
+          name: 'name',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        comments: {
+          name: 'comments',
+          isArray: true,
+          type: {
+            model: 'Comment',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['postCommentsId'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'Posts',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+      ],
+    },
+    Org: {
+      name: 'Org',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        name: {
+          name: 'name',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        comments: {
+          name: 'comments',
+          isArray: true,
+          type: {
+            model: 'Comment',
+          },
+          isRequired: false,
+          attributes: [],
+          isArrayNullable: true,
+          association: {
+            connectionType: 'HAS_MANY',
+            associatedWith: ['orgCommentsId'],
+          },
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'Orgs',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+      ],
+    },
+  },
+  enums: {},
+  nonModels: {},
+  codegenVersion: '3.3.5',
+  version: 'f2f8e885f81740e5be20b201c850fa05',
+};

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -428,7 +428,7 @@ describe('mapModelFieldsConfigs', () => {
     });
   });
 
-  it('should add not-model type relationship fields to configs and to matrix if it is hasMany index', () => {
+  it('should add not-model type relationship fields to configs and matrix if HAS_ONE & hasMany index', () => {
     const formDefinition: FormDefinition = getBasicFormDefinition();
 
     const dataSchema: GenericDataSchema = {
@@ -438,7 +438,28 @@ describe('mapModelFieldsConfigs', () => {
       models: {
         Owner: {
           primaryKeys: ['id'],
-          fields: {},
+          fields: {
+            id: {
+              dataType: 'ID',
+              required: true,
+              readOnly: false,
+              isArray: false,
+            },
+            CompositeToys: {
+              dataType: {
+                model: 'CompositeToy',
+              },
+              required: false,
+              readOnly: false,
+              isArray: true,
+              relationship: {
+                canUnlinkAssociatedModel: true,
+                type: 'HAS_MANY',
+                relatedModelName: 'CompositeToy',
+                relatedModelFields: ['ownerCompositeToysID'],
+              },
+            },
+          },
         },
         CompositeDog: {
           primaryKeys: ['name', 'description'],
@@ -504,6 +525,17 @@ describe('mapModelFieldsConfigs', () => {
               relationship: {
                 type: 'HAS_ONE',
                 relatedModelName: 'CompositeDog',
+                isHasManyIndex: true,
+              },
+            },
+            ownerID: {
+              dataType: 'ID',
+              required: true,
+              readOnly: false,
+              isArray: false,
+              relationship: {
+                type: 'BELONGS_TO',
+                relatedModelName: 'Owner',
                 isHasManyIndex: true,
               },
             },

--- a/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generic-from-datastore.test.ts
@@ -23,6 +23,7 @@ import {
   schemaWithAssumptions,
   schemaWithCPK,
   schemaWithCompositeKeys,
+  schemaWithHasManyBelongsTo,
 } from './__utils__/mock-schemas';
 
 describe('getGenericFromDataStore', () => {
@@ -74,6 +75,7 @@ describe('getGenericFromDataStore', () => {
       type: 'HAS_MANY',
       relatedModelName: 'Teacher',
       relatedModelFields: ['student'],
+      belongsToFieldOnRelatedModel: 'student',
       canUnlinkAssociatedModel: false,
       relatedJoinFieldName: 'teacher',
       relatedJoinTableName: 'StudentTeacher',
@@ -82,6 +84,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Teacher.fields.students.relationship).toStrictEqual<HasManyRelationshipType>({
       type: 'HAS_MANY',
       relatedModelName: 'Student',
+      belongsToFieldOnRelatedModel: 'teacher',
       relatedModelFields: ['teacher'],
       canUnlinkAssociatedModel: false,
       relatedJoinFieldName: 'student',
@@ -139,6 +142,7 @@ describe('getGenericFromDataStore', () => {
       type: 'HAS_MANY',
       relatedModelName: 'Teacher',
       relatedModelFields: ['student'],
+      belongsToFieldOnRelatedModel: 'student',
       canUnlinkAssociatedModel: false,
       relatedJoinFieldName: 'teacher',
       relatedJoinTableName: 'StudentTeacher',
@@ -147,6 +151,7 @@ describe('getGenericFromDataStore', () => {
     expect(genericSchema.models.Teacher.fields.students.relationship).toStrictEqual<HasManyRelationshipType>({
       type: 'HAS_MANY',
       relatedModelName: 'Student',
+      belongsToFieldOnRelatedModel: 'teacher',
       relatedModelFields: ['teacher'],
       canUnlinkAssociatedModel: false,
       relatedJoinFieldName: 'student',
@@ -257,6 +262,64 @@ describe('getGenericFromDataStore', () => {
       type: 'BELONGS_TO',
       relatedModelName: 'CompositeOwner',
       associatedFields: ['compositeDogCompositeOwnerLastName', 'compositeDogCompositeOwnerFirstName'],
+    });
+  });
+
+  it('should correctly map schema with hasMany-belongsTo', () => {
+    const genericSchema = getGenericFromDataStore(schemaWithHasManyBelongsTo);
+    const { User, Org, Post, Comment } = genericSchema.models;
+
+    expect(User.fields.comments.relationship).toStrictEqual({
+      type: 'HAS_MANY',
+      canUnlinkAssociatedModel: true,
+      relatedModelName: 'Comment',
+      relatedModelFields: ['userCommentsId'],
+      belongsToFieldOnRelatedModel: 'User',
+      relatedJoinFieldName: undefined,
+      relatedJoinTableName: undefined,
+    });
+
+    expect(Post.fields.comments.relationship).toStrictEqual({
+      type: 'HAS_MANY',
+      canUnlinkAssociatedModel: true,
+      relatedModelName: 'Comment',
+      relatedModelFields: ['postCommentsId'],
+      belongsToFieldOnRelatedModel: 'post',
+      relatedJoinFieldName: undefined,
+      relatedJoinTableName: undefined,
+    });
+
+    expect(Org.fields.comments.relationship).toStrictEqual({
+      type: 'HAS_MANY',
+      canUnlinkAssociatedModel: false,
+      relatedModelName: 'Comment',
+      relatedModelFields: ['orgCommentsId'],
+      belongsToFieldOnRelatedModel: 'Org',
+      relatedJoinFieldName: undefined,
+      relatedJoinTableName: undefined,
+    });
+
+    expect(Comment.fields.postID.relationship).toStrictEqual({
+      type: 'BELONGS_TO',
+      relatedModelName: 'Post',
+    });
+
+    expect(Comment.fields.userCommentsId.relationship).toStrictEqual({
+      type: 'BELONGS_TO',
+      relatedModelName: 'User',
+      isHasManyIndex: true,
+    });
+
+    expect(Comment.fields.orgCommentsId.relationship).toStrictEqual({
+      type: 'BELONGS_TO',
+      relatedModelName: 'Org',
+      isHasManyIndex: true,
+    });
+
+    expect(Comment.fields.postCommentsId.relationship).toStrictEqual({
+      type: 'HAS_ONE',
+      relatedModelName: 'Post',
+      isHasManyIndex: true,
     });
   });
 });

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -289,7 +289,12 @@ export function mapModelFieldsConfigs({
       !checkIsSupportedAsFormField(field, featureFlags) ||
       (field.relationship &&
         !(typeof field.dataType === 'object' && 'model' in field.dataType) &&
-        !('isHasManyIndex' in field.relationship && field.relationship.isHasManyIndex));
+        // if index overlaps with that of BELONGS_TO, the model field will establish bidirectionality automatically
+        !(
+          'isHasManyIndex' in field.relationship &&
+          field.relationship.isHasManyIndex &&
+          field.relationship.type === 'HAS_ONE'
+        ));
 
     if (!isAutoExcludedField) {
       formDefinition.elementMatrix.push([fieldName]);

--- a/packages/codegen-ui/lib/types/data.ts
+++ b/packages/codegen-ui/lib/types/data.ts
@@ -40,6 +40,7 @@ export type HasManyRelationshipType = {
   canUnlinkAssociatedModel: boolean;
   relatedJoinFieldName?: string;
   relatedJoinTableName?: string;
+  belongsToFieldOnRelatedModel?: string;
 } & CommonRelationshipType;
 
 export type HasOneRelationshipType = {
@@ -51,6 +52,7 @@ export type HasOneRelationshipType = {
 export type BelongsToRelationshipType = {
   type: 'BELONGS_TO';
   associatedFields?: string[];
+  isHasManyIndex?: boolean;
 } & CommonRelationshipType;
 
 export type GenericDataRelationshipType = HasManyRelationshipType | HasOneRelationshipType | BelongsToRelationshipType;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If Post `hasMany` Comment and Comment `belongsTo` Post:
- update `belongsTo` on Comment through the Post form
- render index for `hasMany` relationship on Comment form if this index is different from that of the `belongsTo` relationship.
- if `belongsTo` is required on Comment, set `canUnlink..` to false for Post's comments field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
