### PR TITLE
fix: show arrayField error message in non-edit mode

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -14,6 +14,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -34,8 +35,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -138,6 +147,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -376,7 +390,8 @@ export default function CreateCompositeToyForm(props) {
         items={
           compositeDogCompositeToysName ? [compositeDogCompositeToysName] : []
         }
-        hasError={errors.compositeDogCompositeToysName?.hasError}
+        hasError={errors?.compositeDogCompositeToysName?.hasError}
+        errorMessage={errors?.compositeDogCompositeToysName?.errorMessage}
         setFieldValue={setCurrentCompositeDogCompositeToysNameValue}
         inputFieldRef={compositeDogCompositeToysNameRef}
         defaultFieldValue={\\"\\"}
@@ -393,6 +408,7 @@ export default function CreateCompositeToyForm(props) {
           }))}
           onSelect={({ id }) => {
             setCurrentCompositeDogCompositeToysNameValue(id);
+            runValidationTasks(\\"compositeDogCompositeToysName\\", id);
           }}
           onClear={() => {
             setCurrentCompositeDogCompositeToysNameDisplayValue(\\"\\");
@@ -441,7 +457,10 @@ export default function CreateCompositeToyForm(props) {
             ? [compositeDogCompositeToysDescription]
             : []
         }
-        hasError={errors.compositeDogCompositeToysDescription?.hasError}
+        hasError={errors?.compositeDogCompositeToysDescription?.hasError}
+        errorMessage={
+          errors?.compositeDogCompositeToysDescription?.errorMessage
+        }
         setFieldValue={setCurrentCompositeDogCompositeToysDescriptionValue}
         inputFieldRef={compositeDogCompositeToysDescriptionRef}
         defaultFieldValue={\\"\\"}
@@ -458,6 +477,7 @@ export default function CreateCompositeToyForm(props) {
           }))}
           onSelect={({ id }) => {
             setCurrentCompositeDogCompositeToysDescriptionValue(id);
+            runValidationTasks(\\"compositeDogCompositeToysDescription\\", id);
           }}
           onClear={() => {
             setCurrentCompositeDogCompositeToysDescriptionDisplayValue(\\"\\");
@@ -576,6 +596,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -596,8 +617,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -700,6 +729,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -962,7 +996,8 @@ export default function CreateCommentForm(props) {
         currentFieldValue={currentPostValue}
         label={\\"Post\\"}
         items={post ? [post] : []}
-        hasError={errors.post?.hasError}
+        hasError={errors?.post?.hasError}
+        errorMessage={errors?.post?.errorMessage}
         getBadgeText={getDisplayValue.post}
         setFieldValue={(model) => {
           setCurrentPostDisplayValue(getDisplayValue.post(model));
@@ -992,6 +1027,7 @@ export default function CreateCommentForm(props) {
               )
             );
             setCurrentPostDisplayValue(label);
+            runValidationTasks(\\"post\\", label);
           }}
           onClear={() => {
             setCurrentPostDisplayValue(\\"\\");
@@ -1034,7 +1070,8 @@ export default function CreateCommentForm(props) {
         currentFieldValue={currentUserValue}
         label={\\"User\\"}
         items={User ? [User] : []}
-        hasError={errors.User?.hasError}
+        hasError={errors?.User?.hasError}
+        errorMessage={errors?.User?.errorMessage}
         getBadgeText={getDisplayValue.User}
         setFieldValue={(model) => {
           setCurrentUserDisplayValue(getDisplayValue.User(model));
@@ -1064,6 +1101,7 @@ export default function CreateCommentForm(props) {
               )
             );
             setCurrentUserDisplayValue(label);
+            runValidationTasks(\\"User\\", label);
           }}
           onClear={() => {
             setCurrentUserDisplayValue(\\"\\");
@@ -1106,7 +1144,8 @@ export default function CreateCommentForm(props) {
         currentFieldValue={currentOrgValue}
         label={\\"Org\\"}
         items={Org ? [Org] : []}
-        hasError={errors.Org?.hasError}
+        hasError={errors?.Org?.hasError}
+        errorMessage={errors?.Org?.errorMessage}
         getBadgeText={getDisplayValue.Org}
         setFieldValue={(model) => {
           setCurrentOrgDisplayValue(getDisplayValue.Org(model));
@@ -1136,6 +1175,7 @@ export default function CreateCommentForm(props) {
               )
             );
             setCurrentOrgDisplayValue(label);
+            runValidationTasks(\\"Org\\", label);
           }}
           onClear={() => {
             setCurrentOrgDisplayValue(\\"\\");
@@ -1177,7 +1217,8 @@ export default function CreateCommentForm(props) {
         currentFieldValue={currentPostCommentsIdValue}
         label={\\"Post comments id\\"}
         items={postCommentsId ? [postCommentsId] : []}
-        hasError={errors.postCommentsId?.hasError}
+        hasError={errors?.postCommentsId?.hasError}
+        errorMessage={errors?.postCommentsId?.errorMessage}
         setFieldValue={setCurrentPostCommentsIdValue}
         inputFieldRef={postCommentsIdRef}
         defaultFieldValue={\\"\\"}
@@ -1194,6 +1235,7 @@ export default function CreateCommentForm(props) {
           }))}
           onSelect={({ id }) => {
             setCurrentPostCommentsIdValue(id);
+            runValidationTasks(\\"postCommentsId\\", id);
           }}
           onClear={() => {
             setCurrentPostCommentsIdDisplayValue(\\"\\");
@@ -1308,6 +1350,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -1335,8 +1378,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -1439,6 +1490,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -1830,7 +1886,8 @@ export default function CreateCompositeDogForm(props) {
         currentFieldValue={currentCompositeBowlValue}
         label={\\"Composite bowl\\"}
         items={CompositeBowl ? [CompositeBowl] : []}
-        hasError={errors.CompositeBowl?.hasError}
+        hasError={errors?.CompositeBowl?.hasError}
+        errorMessage={errors?.CompositeBowl?.errorMessage}
         getBadgeText={getDisplayValue.CompositeBowl}
         setFieldValue={(model) => {
           setCurrentCompositeBowlDisplayValue(
@@ -1864,6 +1921,7 @@ export default function CreateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeBowlDisplayValue(label);
+            runValidationTasks(\\"CompositeBowl\\", label);
           }}
           onClear={() => {
             setCurrentCompositeBowlDisplayValue(\\"\\");
@@ -1912,7 +1970,8 @@ export default function CreateCompositeDogForm(props) {
         currentFieldValue={currentCompositeOwnerValue}
         label={\\"Composite owner\\"}
         items={CompositeOwner ? [CompositeOwner] : []}
-        hasError={errors.CompositeOwner?.hasError}
+        hasError={errors?.CompositeOwner?.hasError}
+        errorMessage={errors?.CompositeOwner?.errorMessage}
         getBadgeText={getDisplayValue.CompositeOwner}
         setFieldValue={(model) => {
           setCurrentCompositeOwnerDisplayValue(
@@ -1946,6 +2005,7 @@ export default function CreateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeOwnerDisplayValue(label);
+            runValidationTasks(\\"CompositeOwner\\", label);
           }}
           onClear={() => {
             setCurrentCompositeOwnerDisplayValue(\\"\\");
@@ -1993,7 +2053,8 @@ export default function CreateCompositeDogForm(props) {
         currentFieldValue={currentCompositeToysValue}
         label={\\"Composite toys\\"}
         items={CompositeToys}
-        hasError={errors.CompositeToys?.hasError}
+        hasError={errors?.CompositeToys?.hasError}
+        errorMessage={errors?.CompositeToys?.errorMessage}
         getBadgeText={getDisplayValue.CompositeToys}
         setFieldValue={(model) => {
           setCurrentCompositeToysDisplayValue(
@@ -2027,6 +2088,7 @@ export default function CreateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeToysDisplayValue(label);
+            runValidationTasks(\\"CompositeToys\\", label);
           }}
           onClear={() => {
             setCurrentCompositeToysDisplayValue(\\"\\");
@@ -2074,7 +2136,8 @@ export default function CreateCompositeDogForm(props) {
         currentFieldValue={currentCompositeVetsValue}
         label={\\"Composite vets\\"}
         items={CompositeVets}
-        hasError={errors.CompositeVets?.hasError}
+        hasError={errors?.CompositeVets?.hasError}
+        errorMessage={errors?.CompositeVets?.errorMessage}
         getBadgeText={getDisplayValue.CompositeVets}
         setFieldValue={(model) => {
           setCurrentCompositeVetsDisplayValue(
@@ -2108,6 +2171,7 @@ export default function CreateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeVetsDisplayValue(label);
+            runValidationTasks(\\"CompositeVets\\", label);
           }}
           onClear={() => {
             setCurrentCompositeVetsDisplayValue(\\"\\");
@@ -3018,6 +3082,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
@@ -3033,8 +3098,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -3137,6 +3210,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -3291,7 +3369,8 @@ export default function CustomDataForm(props) {
         currentFieldValue={currentEmailValue}
         label={\\"E-mail\\"}
         items={email}
-        hasError={errors.email?.hasError}
+        hasError={errors?.email?.hasError}
+        errorMessage={errors?.email?.errorMessage}
         setFieldValue={setCurrentEmailValue}
         inputFieldRef={emailRef}
         defaultFieldValue={\\"\\"}
@@ -3333,7 +3412,8 @@ export default function CustomDataForm(props) {
         currentFieldValue={currentPhoneValue}
         label={\\"phone\\"}
         items={phone}
-        hasError={errors.phone?.hasError}
+        hasError={errors?.phone?.hasError}
+        errorMessage={errors?.phone?.errorMessage}
         setFieldValue={setCurrentPhoneValue}
         inputFieldRef={phoneRef}
         defaultFieldValue={\\"\\"}
@@ -3869,6 +3949,7 @@ import {
   Text,
   TextAreaField,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
@@ -3886,8 +3967,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -3990,6 +4079,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -4307,7 +4401,8 @@ export default function MyPostForm(props) {
         currentFieldValue={currentCustomtagsValue}
         label={\\"Tags\\"}
         items={Customtags}
-        hasError={errors.Customtags?.hasError}
+        hasError={errors?.Customtags?.hasError}
+        errorMessage={errors?.Customtags?.errorMessage}
         setFieldValue={setCurrentCustomtagsValue}
         inputFieldRef={CustomtagsRef}
         defaultFieldValue={\\"\\"}
@@ -4478,7 +4573,8 @@ export default function MyPostForm(props) {
         currentFieldValue={currentNonModelFieldArrayValue}
         label={\\"Non model field array\\"}
         items={nonModelFieldArray}
-        hasError={errors.nonModelFieldArray?.hasError}
+        hasError={errors?.nonModelFieldArray?.hasError}
+        errorMessage={errors?.nonModelFieldArray?.errorMessage}
         setFieldValue={setCurrentNonModelFieldArrayValue}
         inputFieldRef={nonModelFieldArrayRef}
         defaultFieldValue={\\"\\"}
@@ -4585,6 +4681,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -4605,8 +4702,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -4709,6 +4814,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -4975,7 +5085,8 @@ export default function UpdateOrgForm(props) {
         currentFieldValue={currentCommentsValue}
         label={\\"Comments\\"}
         items={comments}
-        hasError={errors.comments?.hasError}
+        hasError={errors?.comments?.hasError}
+        errorMessage={errors?.comments?.errorMessage}
         getBadgeText={getDisplayValue.comments}
         setFieldValue={(model) => {
           setCurrentCommentsDisplayValue(getDisplayValue.comments(model));
@@ -5005,6 +5116,7 @@ export default function UpdateOrgForm(props) {
               )
             );
             setCurrentCommentsDisplayValue(label);
+            runValidationTasks(\\"comments\\", label);
           }}
           onClear={() => {
             setCurrentCommentsDisplayValue(\\"\\");
@@ -5115,6 +5227,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -5142,8 +5255,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -5246,6 +5367,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -5806,7 +5932,8 @@ export default function UpdateCompositeDogForm(props) {
         currentFieldValue={currentCompositeBowlValue}
         label={\\"Composite bowl\\"}
         items={CompositeBowl ? [CompositeBowl] : []}
-        hasError={errors.CompositeBowl?.hasError}
+        hasError={errors?.CompositeBowl?.hasError}
+        errorMessage={errors?.CompositeBowl?.errorMessage}
         getBadgeText={getDisplayValue.CompositeBowl}
         setFieldValue={(model) => {
           setCurrentCompositeBowlDisplayValue(
@@ -5840,6 +5967,7 @@ export default function UpdateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeBowlDisplayValue(label);
+            runValidationTasks(\\"CompositeBowl\\", label);
           }}
           onClear={() => {
             setCurrentCompositeBowlDisplayValue(\\"\\");
@@ -5889,7 +6017,8 @@ export default function UpdateCompositeDogForm(props) {
         currentFieldValue={currentCompositeOwnerValue}
         label={\\"Composite owner\\"}
         items={CompositeOwner ? [CompositeOwner] : []}
-        hasError={errors.CompositeOwner?.hasError}
+        hasError={errors?.CompositeOwner?.hasError}
+        errorMessage={errors?.CompositeOwner?.errorMessage}
         getBadgeText={getDisplayValue.CompositeOwner}
         setFieldValue={(model) => {
           setCurrentCompositeOwnerDisplayValue(
@@ -5923,6 +6052,7 @@ export default function UpdateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeOwnerDisplayValue(label);
+            runValidationTasks(\\"CompositeOwner\\", label);
           }}
           onClear={() => {
             setCurrentCompositeOwnerDisplayValue(\\"\\");
@@ -5971,7 +6101,8 @@ export default function UpdateCompositeDogForm(props) {
         currentFieldValue={currentCompositeToysValue}
         label={\\"Composite toys\\"}
         items={CompositeToys}
-        hasError={errors.CompositeToys?.hasError}
+        hasError={errors?.CompositeToys?.hasError}
+        errorMessage={errors?.CompositeToys?.errorMessage}
         getBadgeText={getDisplayValue.CompositeToys}
         setFieldValue={(model) => {
           setCurrentCompositeToysDisplayValue(
@@ -6005,6 +6136,7 @@ export default function UpdateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeToysDisplayValue(label);
+            runValidationTasks(\\"CompositeToys\\", label);
           }}
           onClear={() => {
             setCurrentCompositeToysDisplayValue(\\"\\");
@@ -6052,7 +6184,8 @@ export default function UpdateCompositeDogForm(props) {
         currentFieldValue={currentCompositeVetsValue}
         label={\\"Composite vets\\"}
         items={CompositeVets}
-        hasError={errors.CompositeVets?.hasError}
+        hasError={errors?.CompositeVets?.hasError}
+        errorMessage={errors?.CompositeVets?.errorMessage}
         getBadgeText={getDisplayValue.CompositeVets}
         setFieldValue={(model) => {
           setCurrentCompositeVetsDisplayValue(
@@ -6086,6 +6219,7 @@ export default function UpdateCompositeDogForm(props) {
               )
             );
             setCurrentCompositeVetsDisplayValue(label);
+            runValidationTasks(\\"CompositeVets\\", label);
           }}
           onClear={() => {
             setCurrentCompositeVetsDisplayValue(\\"\\");
@@ -6212,6 +6346,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -6238,8 +6373,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -6342,6 +6485,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -6767,7 +6915,8 @@ export default function UpdateCPKTeacherForm(props) {
         currentFieldValue={currentCPKStudentValue}
         label={\\"Cpk student\\"}
         items={CPKStudent ? [CPKStudent] : []}
-        hasError={errors.CPKStudent?.hasError}
+        hasError={errors?.CPKStudent?.hasError}
+        errorMessage={errors?.CPKStudent?.errorMessage}
         getBadgeText={getDisplayValue.CPKStudent}
         setFieldValue={(model) => {
           setCurrentCPKStudentDisplayValue(getDisplayValue.CPKStudent(model));
@@ -6797,6 +6946,7 @@ export default function UpdateCPKTeacherForm(props) {
               )
             );
             setCurrentCPKStudentDisplayValue(label);
+            runValidationTasks(\\"CPKStudent\\", label);
           }}
           onClear={() => {
             setCurrentCPKStudentDisplayValue(\\"\\");
@@ -6840,7 +6990,8 @@ export default function UpdateCPKTeacherForm(props) {
         currentFieldValue={currentCPKClassesValue}
         label={\\"Cpk classes\\"}
         items={CPKClasses}
-        hasError={errors.CPKClasses?.hasError}
+        hasError={errors?.CPKClasses?.hasError}
+        errorMessage={errors?.CPKClasses?.errorMessage}
         getBadgeText={getDisplayValue.CPKClasses}
         setFieldValue={(model) => {
           setCurrentCPKClassesDisplayValue(getDisplayValue.CPKClasses(model));
@@ -6870,6 +7021,7 @@ export default function UpdateCPKTeacherForm(props) {
               )
             );
             setCurrentCPKClassesDisplayValue(label);
+            runValidationTasks(\\"CPKClasses\\", label);
           }}
           onClear={() => {
             setCurrentCPKClassesDisplayValue(\\"\\");
@@ -6912,7 +7064,8 @@ export default function UpdateCPKTeacherForm(props) {
         currentFieldValue={currentCPKProjectsValue}
         label={\\"Cpk projects\\"}
         items={CPKProjects}
-        hasError={errors.CPKProjects?.hasError}
+        hasError={errors?.CPKProjects?.hasError}
+        errorMessage={errors?.CPKProjects?.errorMessage}
         getBadgeText={getDisplayValue.CPKProjects}
         setFieldValue={(model) => {
           setCurrentCPKProjectsDisplayValue(getDisplayValue.CPKProjects(model));
@@ -6942,6 +7095,7 @@ export default function UpdateCPKTeacherForm(props) {
               )
             );
             setCurrentCPKProjectsDisplayValue(label);
+            runValidationTasks(\\"CPKProjects\\", label);
           }}
           onClear={() => {
             setCurrentCPKProjectsDisplayValue(\\"\\");
@@ -7076,8 +7230,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -7180,6 +7342,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -7465,6 +7632,7 @@ export default function NestedJson(props) {
         label={\\"favorite trees\\"}
         items={bio.favorite - trees ?? []}
         hasError={errors?.[\\"bio.favorite-trees\\"]?.hasError}
+        errorMessage={errors?.[\\"bio.favorite-trees\\"]?.errorMessage}
         setFieldValue={setCurrentBioFavoritetreesValue}
         inputFieldRef={bioFavoritetreesRef}
         defaultFieldValue={\\"\\"}
@@ -7519,7 +7687,8 @@ export default function NestedJson(props) {
         currentFieldValue={currentNicknames1Value}
         label={\\"Nick Names1\\"}
         items={Nicknames1}
-        hasError={errors.Nicknames1?.hasError}
+        hasError={errors?.Nicknames1?.hasError}
+        errorMessage={errors?.Nicknames1?.errorMessage}
         setFieldValue={setCurrentNicknames1Value}
         inputFieldRef={Nicknames1Ref}
         defaultFieldValue={\\"\\"}
@@ -7567,6 +7736,7 @@ export default function NestedJson(props) {
         label={\\"nick-Names2\\"}
         items={nickNames}
         hasError={errors?.[\\"nick-names2\\"]?.hasError}
+        errorMessage={errors?.[\\"nick-names2\\"]?.errorMessage}
         setFieldValue={setCurrentNickNamesValue}
         inputFieldRef={nickNamesRef}
         defaultFieldValue={\\"\\"}
@@ -7760,6 +7930,7 @@ import {
   SelectField,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
@@ -7775,8 +7946,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -7879,6 +8058,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -8075,7 +8259,8 @@ export default function NestedJson(props) {
         currentFieldValue={currentLastName1Value}
         label={\\"lastName\\"}
         items={lastName1}
-        hasError={errors.lastName?.hasError}
+        hasError={errors?.lastName?.hasError}
+        errorMessage={errors?.lastName?.errorMessage}
         setFieldValue={setCurrentLastName1Value}
         inputFieldRef={lastName1Ref}
         defaultFieldValue={\\"\\"}
@@ -8442,6 +8627,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -8462,8 +8648,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -8566,6 +8760,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -8787,7 +8986,8 @@ export default function CreateDogForm(props) {
         currentFieldValue={currentOwnerValue}
         label={\\"Owner\\"}
         items={Owner ? [Owner] : []}
-        hasError={errors.Owner?.hasError}
+        hasError={errors?.Owner?.hasError}
+        errorMessage={errors?.Owner?.errorMessage}
         getBadgeText={getDisplayValue.Owner}
         setFieldValue={(model) => {
           setCurrentOwnerDisplayValue(getDisplayValue.Owner(model));
@@ -8817,6 +9017,7 @@ export default function CreateDogForm(props) {
               )
             );
             setCurrentOwnerDisplayValue(label);
+            runValidationTasks(\\"Owner\\", label);
           }}
           onClear={() => {
             setCurrentOwnerDisplayValue(\\"\\");
@@ -8921,6 +9122,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -8941,8 +9143,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -9045,6 +9255,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -9298,7 +9513,8 @@ export default function UpdateDogForm(props) {
         currentFieldValue={currentOwnerValue}
         label={\\"Owner\\"}
         items={Owner ? [Owner] : []}
-        hasError={errors.Owner?.hasError}
+        hasError={errors?.Owner?.hasError}
+        errorMessage={errors?.Owner?.errorMessage}
         getBadgeText={getDisplayValue.Owner}
         setFieldValue={(model) => {
           setCurrentOwnerDisplayValue(getDisplayValue.Owner(model));
@@ -9328,6 +9544,7 @@ export default function UpdateDogForm(props) {
               )
             );
             setCurrentOwnerDisplayValue(label);
+            runValidationTasks(\\"Owner\\", label);
           }}
           onClear={() => {
             setCurrentOwnerDisplayValue(\\"\\");
@@ -9437,6 +9654,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -9457,8 +9675,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -9561,6 +9787,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -9785,7 +10016,8 @@ export default function CreateOwnerForm(props) {
         currentFieldValue={currentDogValue}
         label={\\"Dog\\"}
         items={Dog ? [Dog] : []}
-        hasError={errors.Dog?.hasError}
+        hasError={errors?.Dog?.hasError}
+        errorMessage={errors?.Dog?.errorMessage}
         getBadgeText={getDisplayValue.Dog}
         setFieldValue={(model) => {
           setCurrentDogDisplayValue(getDisplayValue.Dog(model));
@@ -9815,6 +10047,7 @@ export default function CreateOwnerForm(props) {
               )
             );
             setCurrentDogDisplayValue(label);
+            runValidationTasks(\\"Dog\\", label);
           }}
           onClear={() => {
             setCurrentDogDisplayValue(\\"\\");
@@ -9919,6 +10152,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -9939,8 +10173,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -10043,6 +10285,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -10298,7 +10545,8 @@ export default function UpdateOwnerForm(props) {
         currentFieldValue={currentDogValue}
         label={\\"Dog\\"}
         items={Dog ? [Dog] : []}
-        hasError={errors.Dog?.hasError}
+        hasError={errors?.Dog?.hasError}
+        errorMessage={errors?.Dog?.errorMessage}
         getBadgeText={getDisplayValue.Dog}
         setFieldValue={(model) => {
           setCurrentDogDisplayValue(getDisplayValue.Dog(model));
@@ -10328,6 +10576,7 @@ export default function UpdateOwnerForm(props) {
               )
             );
             setCurrentDogDisplayValue(label);
+            runValidationTasks(\\"Dog\\", label);
           }}
           onClear={() => {
             setCurrentDogDisplayValue(\\"\\");
@@ -10438,6 +10687,7 @@ import {
   Text,
   TextAreaField,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
@@ -10455,8 +10705,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -10559,6 +10817,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -10967,7 +11230,8 @@ export default function MyPostForm(props) {
         currentFieldValue={currentNonModelFieldArrayValue}
         label={\\"Non model field array\\"}
         items={nonModelFieldArray}
-        hasError={errors.nonModelFieldArray?.hasError}
+        hasError={errors?.nonModelFieldArray?.hasError}
+        errorMessage={errors?.nonModelFieldArray?.errorMessage}
         setFieldValue={setCurrentNonModelFieldArrayValue}
         inputFieldRef={nonModelFieldArrayRef}
         defaultFieldValue={\\"\\"}
@@ -11071,6 +11335,7 @@ import {
   SelectField,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -11091,8 +11356,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -11195,6 +11468,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -11435,7 +11713,8 @@ export default function TagCreateForm(props) {
         currentFieldValue={currentPostsValue}
         label={\\"Posts\\"}
         items={Posts}
-        hasError={errors.Posts?.hasError}
+        hasError={errors?.Posts?.hasError}
+        errorMessage={errors?.Posts?.errorMessage}
         getBadgeText={getDisplayValue.Posts}
         setFieldValue={(model) => {
           setCurrentPostsDisplayValue(getDisplayValue.Posts(model));
@@ -11465,6 +11744,7 @@ export default function TagCreateForm(props) {
               )
             );
             setCurrentPostsDisplayValue(label);
+            runValidationTasks(\\"Posts\\", label);
           }}
           onClear={() => {
             setCurrentPostsDisplayValue(\\"\\");
@@ -11503,7 +11783,8 @@ export default function TagCreateForm(props) {
         currentFieldValue={currentStatusesValue}
         label={\\"Statuses\\"}
         items={statuses}
-        hasError={errors.statuses?.hasError}
+        hasError={errors?.statuses?.hasError}
+        errorMessage={errors?.statuses?.errorMessage}
         getBadgeText={getDisplayValue.statuses}
         setFieldValue={setCurrentStatusesValue}
         inputFieldRef={statusesRef}
@@ -11641,6 +11922,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -11661,8 +11943,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -11765,6 +12055,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -12010,7 +12305,8 @@ export default function MyMemberForm(props) {
         currentFieldValue={currentTeamIDValue}
         label={\\"Team id\\"}
         items={teamID ? [teamID] : []}
-        hasError={errors.teamID?.hasError}
+        hasError={errors?.teamID?.hasError}
+        errorMessage={errors?.teamID?.errorMessage}
         setFieldValue={setCurrentTeamIDValue}
         inputFieldRef={teamIDRef}
         defaultFieldValue={\\"\\"}
@@ -12027,6 +12323,7 @@ export default function MyMemberForm(props) {
           }))}
           onSelect={({ id }) => {
             setCurrentTeamIDValue(id);
+            runValidationTasks(\\"teamID\\", id);
           }}
           onClear={() => {
             setCurrentTeamIDDisplayValue(\\"\\");
@@ -12066,7 +12363,8 @@ export default function MyMemberForm(props) {
         currentFieldValue={currentTeamValue}
         label={\\"Team Label\\"}
         items={Team ? [Team] : []}
-        hasError={errors.Team?.hasError}
+        hasError={errors?.Team?.hasError}
+        errorMessage={errors?.Team?.errorMessage}
         getBadgeText={getDisplayValue.Team}
         setFieldValue={(model) => {
           setCurrentTeamDisplayValue(getDisplayValue.Team(model));
@@ -12096,6 +12394,7 @@ export default function MyMemberForm(props) {
               )
             );
             setCurrentTeamDisplayValue(label);
+            runValidationTasks(\\"Team\\", label);
           }}
           onClear={() => {
             setCurrentTeamDisplayValue(\\"\\");
@@ -12178,6 +12477,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -12198,8 +12498,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -12302,6 +12610,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -12523,7 +12836,8 @@ export default function SchoolCreateForm(props) {
         currentFieldValue={currentStudentsValue}
         label={\\"Students\\"}
         items={Students}
-        hasError={errors.Students?.hasError}
+        hasError={errors?.Students?.hasError}
+        errorMessage={errors?.Students?.errorMessage}
         getBadgeText={getDisplayValue.Students}
         setFieldValue={(model) => {
           setCurrentStudentsDisplayValue(getDisplayValue.Students(model));
@@ -12553,6 +12867,7 @@ export default function SchoolCreateForm(props) {
               )
             );
             setCurrentStudentsDisplayValue(label);
+            runValidationTasks(\\"Students\\", label);
           }}
           onClear={() => {
             setCurrentStudentsDisplayValue(\\"\\");
@@ -12668,6 +12983,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -12688,8 +13004,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -12792,6 +13116,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -13033,7 +13362,8 @@ export default function BookCreateForm(props) {
         currentFieldValue={currentPrimaryAuthorValue}
         label={\\"Primary author\\"}
         items={primaryAuthor ? [primaryAuthor] : []}
-        hasError={errors.primaryAuthor?.hasError}
+        hasError={errors?.primaryAuthor?.hasError}
+        errorMessage={errors?.primaryAuthor?.errorMessage}
         getBadgeText={getDisplayValue.primaryAuthor}
         setFieldValue={(model) => {
           setCurrentPrimaryAuthorDisplayValue(
@@ -13067,6 +13397,7 @@ export default function BookCreateForm(props) {
               )
             );
             setCurrentPrimaryAuthorDisplayValue(label);
+            runValidationTasks(\\"primaryAuthor\\", label);
           }}
           onClear={() => {
             setCurrentPrimaryAuthorDisplayValue(\\"\\");
@@ -13152,6 +13483,7 @@ import {
   SelectField,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -13172,8 +13504,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -13276,6 +13616,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -13516,7 +13861,8 @@ export default function TagCreateForm(props) {
         currentFieldValue={currentPostsValue}
         label={\\"Posts\\"}
         items={Posts}
-        hasError={errors.Posts?.hasError}
+        hasError={errors?.Posts?.hasError}
+        errorMessage={errors?.Posts?.errorMessage}
         getBadgeText={getDisplayValue.Posts}
         setFieldValue={(model) => {
           setCurrentPostsDisplayValue(getDisplayValue.Posts(model));
@@ -13546,6 +13892,7 @@ export default function TagCreateForm(props) {
               )
             );
             setCurrentPostsDisplayValue(label);
+            runValidationTasks(\\"Posts\\", label);
           }}
           onClear={() => {
             setCurrentPostsDisplayValue(\\"\\");
@@ -13584,7 +13931,8 @@ export default function TagCreateForm(props) {
         currentFieldValue={currentStatusesValue}
         label={\\"Statuses\\"}
         items={statuses}
-        hasError={errors.statuses?.hasError}
+        hasError={errors?.statuses?.hasError}
+        errorMessage={errors?.statuses?.errorMessage}
         getBadgeText={getDisplayValue.statuses}
         setFieldValue={setCurrentStatusesValue}
         inputFieldRef={statusesRef}
@@ -13722,6 +14070,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -13742,8 +14091,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -13846,6 +14203,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -14114,7 +14476,8 @@ export default function BookCreateForm(props) {
         currentFieldValue={currentPrimaryAuthorValue}
         label={\\"Primary author\\"}
         items={primaryAuthor ? [primaryAuthor] : []}
-        hasError={errors.primaryAuthor?.hasError}
+        hasError={errors?.primaryAuthor?.hasError}
+        errorMessage={errors?.primaryAuthor?.errorMessage}
         getBadgeText={getDisplayValue.primaryAuthor}
         setFieldValue={(model) => {
           setCurrentPrimaryAuthorDisplayValue(
@@ -14148,6 +14511,7 @@ export default function BookCreateForm(props) {
               )
             );
             setCurrentPrimaryAuthorDisplayValue(label);
+            runValidationTasks(\\"primaryAuthor\\", label);
           }}
           onClear={() => {
             setCurrentPrimaryAuthorDisplayValue(\\"\\");
@@ -14193,7 +14557,8 @@ export default function BookCreateForm(props) {
         currentFieldValue={currentPrimaryTitleValue}
         label={\\"Primary title\\"}
         items={primaryTitle ? [primaryTitle] : []}
-        hasError={errors.primaryTitle?.hasError}
+        hasError={errors?.primaryTitle?.hasError}
+        errorMessage={errors?.primaryTitle?.errorMessage}
         getBadgeText={getDisplayValue.primaryTitle}
         setFieldValue={(model) => {
           setCurrentPrimaryTitleDisplayValue(
@@ -14225,6 +14590,7 @@ export default function BookCreateForm(props) {
               )
             );
             setCurrentPrimaryTitleDisplayValue(label);
+            runValidationTasks(\\"primaryTitle\\", label);
           }}
           onClear={() => {
             setCurrentPrimaryTitleDisplayValue(\\"\\");
@@ -14309,6 +14675,7 @@ import {
   Text,
   TextAreaField,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
@@ -14326,8 +14693,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -14430,6 +14805,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -14913,7 +15293,8 @@ export default function MyPostForm(props) {
         currentFieldValue={currentNonModelFieldArrayValue}
         label={\\"Non model field array\\"}
         items={nonModelFieldArray}
-        hasError={errors.nonModelFieldArray?.hasError}
+        hasError={errors?.nonModelFieldArray?.hasError}
+        errorMessage={errors?.nonModelFieldArray?.errorMessage}
         setFieldValue={setCurrentNonModelFieldArrayValue}
         inputFieldRef={nonModelFieldArrayRef}
         defaultFieldValue={\\"\\"}
@@ -15059,6 +15440,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -15079,8 +15461,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -15183,6 +15573,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -15448,7 +15843,8 @@ export default function SchoolUpdateForm(props) {
         currentFieldValue={currentStudentsValue}
         label={\\"Students\\"}
         items={Students}
-        hasError={errors.Students?.hasError}
+        hasError={errors?.Students?.hasError}
+        errorMessage={errors?.Students?.errorMessage}
         getBadgeText={getDisplayValue.Students}
         setFieldValue={(model) => {
           setCurrentStudentsDisplayValue(getDisplayValue.Students(model));
@@ -15478,6 +15874,7 @@ export default function SchoolUpdateForm(props) {
               )
             );
             setCurrentStudentsDisplayValue(label);
+            runValidationTasks(\\"Students\\", label);
           }}
           onClear={() => {
             setCurrentStudentsDisplayValue(\\"\\");
@@ -15598,6 +15995,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -15618,8 +16016,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -15722,6 +16128,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -15992,7 +16403,8 @@ export default function MyMemberForm(props) {
         currentFieldValue={currentTeamIDValue}
         label={\\"Team id\\"}
         items={teamID ? [teamID] : []}
-        hasError={errors.teamID?.hasError}
+        hasError={errors?.teamID?.hasError}
+        errorMessage={errors?.teamID?.errorMessage}
         setFieldValue={setCurrentTeamIDValue}
         inputFieldRef={teamIDRef}
         defaultFieldValue={\\"\\"}
@@ -16009,6 +16421,7 @@ export default function MyMemberForm(props) {
           }))}
           onSelect={({ id }) => {
             setCurrentTeamIDValue(id);
+            runValidationTasks(\\"teamID\\", id);
           }}
           onClear={() => {
             setCurrentTeamIDDisplayValue(\\"\\");
@@ -16049,7 +16462,8 @@ export default function MyMemberForm(props) {
         currentFieldValue={currentTeamValue}
         label={\\"Team Label\\"}
         items={Team ? [Team] : []}
-        hasError={errors.Team?.hasError}
+        hasError={errors?.Team?.hasError}
+        errorMessage={errors?.Team?.errorMessage}
         getBadgeText={getDisplayValue.Team}
         setFieldValue={(model) => {
           setCurrentTeamDisplayValue(getDisplayValue.Team(model));
@@ -16079,6 +16493,7 @@ export default function MyMemberForm(props) {
               )
             );
             setCurrentTeamDisplayValue(label);
+            runValidationTasks(\\"Team\\", label);
           }}
           onClear={() => {
             setCurrentTeamDisplayValue(\\"\\");
@@ -16164,6 +16579,7 @@ import {
   SelectField,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -16184,8 +16600,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -16288,6 +16712,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -16601,7 +17030,8 @@ export default function TagUpdateForm(props) {
         currentFieldValue={currentPostsValue}
         label={\\"Posts\\"}
         items={Posts}
-        hasError={errors.Posts?.hasError}
+        hasError={errors?.Posts?.hasError}
+        errorMessage={errors?.Posts?.errorMessage}
         getBadgeText={getDisplayValue.Posts}
         setFieldValue={(model) => {
           setCurrentPostsDisplayValue(getDisplayValue.Posts(model));
@@ -16631,6 +17061,7 @@ export default function TagUpdateForm(props) {
               )
             );
             setCurrentPostsDisplayValue(label);
+            runValidationTasks(\\"Posts\\", label);
           }}
           onClear={() => {
             setCurrentPostsDisplayValue(\\"\\");
@@ -16669,7 +17100,8 @@ export default function TagUpdateForm(props) {
         currentFieldValue={currentStatusesValue}
         label={\\"Statuses\\"}
         items={statuses}
-        hasError={errors.statuses?.hasError}
+        hasError={errors?.statuses?.hasError}
+        errorMessage={errors?.statuses?.errorMessage}
         getBadgeText={getDisplayValue.statuses}
         setFieldValue={setCurrentStatusesValue}
         inputFieldRef={statusesRef}
@@ -16810,6 +17242,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Flex as Flex0 } from \\"../models\\";
@@ -16827,8 +17260,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -16931,6 +17372,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -17209,7 +17655,8 @@ export default function MyFlexCreateForm(props) {
         currentFieldValue={currentCustomtagsValue}
         label={\\"Tags\\"}
         items={Customtags}
-        hasError={errors.Customtags?.hasError}
+        hasError={errors?.Customtags?.hasError}
+        errorMessage={errors?.Customtags?.errorMessage}
         setFieldValue={setCurrentCustomtagsValue}
         inputFieldRef={CustomtagsRef}
         defaultFieldValue={\\"\\"}
@@ -17255,7 +17702,8 @@ export default function MyFlexCreateForm(props) {
         currentFieldValue={currentTagsValue}
         label={\\"Tags\\"}
         items={tags}
-        hasError={errors.tags?.hasError}
+        hasError={errors?.tags?.hasError}
+        errorMessage={errors?.tags?.errorMessage}
         setFieldValue={setCurrentTagsValue}
         inputFieldRef={tagsRef}
         defaultFieldValue={\\"\\"}
@@ -17376,6 +17824,7 @@ import {
   SwitchField,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Blog } from \\"../models\\";
@@ -17393,8 +17842,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -17497,6 +17954,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -17800,7 +18262,8 @@ export default function BlogCreateForm(props) {
         currentFieldValue={currentEditedAtValue}
         label={\\"Edited at\\"}
         items={editedAt}
-        hasError={errors.editedAt?.hasError}
+        hasError={errors?.editedAt?.hasError}
+        errorMessage={errors?.editedAt?.errorMessage}
         setFieldValue={setCurrentEditedAtValue}
         inputFieldRef={editedAtRef}
         defaultFieldValue={\\"\\"}
@@ -17926,6 +18389,7 @@ import {
   TextAreaField,
   TextField,
   ToggleButton,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { InputGallery } from \\"../models\\";
@@ -17943,8 +18407,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -18047,6 +18519,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -18469,7 +18946,8 @@ export default function InputGalleryCreateForm(props) {
         currentFieldValue={currentArrayTypeFieldValue}
         label={\\"Array type field\\"}
         items={arrayTypeField}
-        hasError={errors.arrayTypeField?.hasError}
+        hasError={errors?.arrayTypeField?.hasError}
+        errorMessage={errors?.arrayTypeField?.errorMessage}
         setFieldValue={setCurrentArrayTypeFieldValue}
         inputFieldRef={arrayTypeFieldRef}
         defaultFieldValue={\\"\\"}
@@ -18522,7 +19000,8 @@ export default function InputGalleryCreateForm(props) {
         currentFieldValue={currentJsonArrayValue}
         label={\\"Json array\\"}
         items={jsonArray}
-        hasError={errors.jsonArray?.hasError}
+        hasError={errors?.jsonArray?.hasError}
+        errorMessage={errors?.jsonArray?.errorMessage}
         setFieldValue={setCurrentJsonArrayValue}
         inputFieldRef={jsonArrayRef}
         defaultFieldValue={\\"\\"}
@@ -18808,6 +19287,7 @@ import {
   TextAreaField,
   TextField,
   ToggleButton,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { InputGallery } from \\"../models\\";
@@ -18825,8 +19305,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -18929,6 +19417,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -19374,7 +19867,8 @@ export default function InputGalleryUpdateForm(props) {
         currentFieldValue={currentArrayTypeFieldValue}
         label={\\"Array type field\\"}
         items={arrayTypeField}
-        hasError={errors.arrayTypeField?.hasError}
+        hasError={errors?.arrayTypeField?.hasError}
+        errorMessage={errors?.arrayTypeField?.errorMessage}
         setFieldValue={setCurrentArrayTypeFieldValue}
         inputFieldRef={arrayTypeFieldRef}
         defaultFieldValue={\\"\\"}
@@ -19427,7 +19921,8 @@ export default function InputGalleryUpdateForm(props) {
         currentFieldValue={currentJsonArrayValue}
         label={\\"Json array\\"}
         items={jsonArray}
-        hasError={errors.jsonArray?.hasError}
+        hasError={errors?.jsonArray?.hasError}
+        errorMessage={errors?.jsonArray?.errorMessage}
         setFieldValue={setCurrentJsonArrayValue}
         inputFieldRef={jsonArrayRef}
         defaultFieldValue={\\"\\"}
@@ -19715,6 +20210,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Flex as Flex0 } from \\"../models\\";
@@ -19732,8 +20228,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -19836,6 +20340,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -20132,7 +20641,8 @@ export default function MyFlexUpdateForm(props) {
         currentFieldValue={currentCustomtagsValue}
         label={\\"Tags\\"}
         items={Customtags}
-        hasError={errors.Customtags?.hasError}
+        hasError={errors?.Customtags?.hasError}
+        errorMessage={errors?.Customtags?.errorMessage}
         setFieldValue={setCurrentCustomtagsValue}
         inputFieldRef={CustomtagsRef}
         defaultFieldValue={\\"\\"}
@@ -20178,7 +20688,8 @@ export default function MyFlexUpdateForm(props) {
         currentFieldValue={currentTagsValue}
         label={\\"Tags\\"}
         items={tags}
-        hasError={errors.tags?.hasError}
+        hasError={errors?.tags?.hasError}
+        errorMessage={errors?.tags?.errorMessage}
         setFieldValue={setCurrentTagsValue}
         inputFieldRef={tagsRef}
         defaultFieldValue={\\"\\"}
@@ -20302,6 +20813,7 @@ import {
   Text,
   TextAreaField,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { Post } from \\"../models\\";
@@ -20319,8 +20831,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -20423,6 +20943,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -20856,7 +21381,8 @@ export default function PostCreateFormRow(props) {
         currentFieldValue={currentNonModelFieldArrayValue}
         label={\\"Non model field array\\"}
         items={nonModelFieldArray}
-        hasError={errors.nonModelFieldArray?.hasError}
+        hasError={errors?.nonModelFieldArray?.hasError}
+        errorMessage={errors?.nonModelFieldArray?.errorMessage}
         setFieldValue={setCurrentNonModelFieldArrayValue}
         inputFieldRef={nonModelFieldArrayRef}
         defaultFieldValue={\\"\\"}
@@ -20997,6 +21523,7 @@ import {
   ScrollView,
   Text,
   TextField,
+  useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import {
   getOverrideProps,
@@ -21017,8 +21544,16 @@ function ArrayField({
   defaultFieldValue,
   lengthLimit,
   getBadgeText,
+  errorMessage,
 }) {
   const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
   const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
   const [isEditing, setIsEditing] = React.useState();
   React.useEffect(() => {
@@ -21121,6 +21656,11 @@ function ArrayField({
           >
             Add item
           </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
         </>
       ) : (
         <Flex justifyContent=\\"flex-end\\">
@@ -21366,7 +21906,8 @@ export default function MyMemberForm(props) {
         currentFieldValue={currentTeamIDValue}
         label={\\"Team id\\"}
         items={teamID ? [teamID] : []}
-        hasError={errors.teamID?.hasError}
+        hasError={errors?.teamID?.hasError}
+        errorMessage={errors?.teamID?.errorMessage}
         setFieldValue={setCurrentTeamIDValue}
         inputFieldRef={teamIDRef}
         defaultFieldValue={\\"\\"}
@@ -21383,6 +21924,7 @@ export default function MyMemberForm(props) {
           }))}
           onSelect={({ id }) => {
             setCurrentTeamIDValue(id);
+            runValidationTasks(\\"teamID\\", id);
           }}
           onClear={() => {
             setCurrentTeamIDDisplayValue(\\"\\");
@@ -21422,7 +21964,8 @@ export default function MyMemberForm(props) {
         currentFieldValue={currentTeamValue}
         label={\\"Team Label\\"}
         items={Team ? [Team] : []}
-        hasError={errors.Team?.hasError}
+        hasError={errors?.Team?.hasError}
+        errorMessage={errors?.Team?.errorMessage}
         getBadgeText={getDisplayValue.Team}
         setFieldValue={(model) => {
           setCurrentTeamDisplayValue(getDisplayValue.Team(model));
@@ -21452,6 +21995,7 @@ export default function MyMemberForm(props) {
               )
             );
             setCurrentTeamDisplayValue(label);
+            runValidationTasks(\\"Team\\", label);
           }}
           onClear={() => {
             setCurrentTeamDisplayValue(\\"\\");

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
@@ -94,7 +94,9 @@ export const addFormAttributes = (
     // TODO: Allow for other relationship types once valueMappings available
     if (fieldConfig.componentType === 'Autocomplete' && fieldConfig.relationship) {
       attributes.push(getAutocompleteOptionsProp({ fieldName: componentName, fieldConfig }));
-      attributes.push(buildOnSelect({ sanitizedFieldName: renderedVariableName, fieldConfig }));
+      attributes.push(
+        buildOnSelect({ sanitizedFieldName: renderedVariableName, fieldConfig, fieldName: componentName }),
+      );
       attributes.push(buildOnClearStatement(componentName, fieldConfig));
     }
 

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
@@ -345,9 +345,11 @@ examples:
  */
 export function buildOnSelect({
   sanitizedFieldName,
+  fieldName,
   fieldConfig,
 }: {
   sanitizedFieldName: string;
+  fieldName: string;
   fieldConfig: FieldConfigMetadata;
 }): JsxAttribute {
   const labelString = 'label';
@@ -385,6 +387,15 @@ export function buildOnSelect({
       setStateExpression(getCurrentDisplayValueName(sanitizedFieldName), nextCurrentDisplayValue),
     );
   }
+
+  setStateExpressions.push(
+    factory.createExpressionStatement(
+      factory.createCallExpression(factory.createIdentifier('runValidationTasks'), undefined, [
+        factory.createStringLiteral(fieldName),
+        factory.createIdentifier(isModelDataType(fieldConfig) ? labelString : idString),
+      ]),
+    ),
+  );
 
   return factory.createJsxAttribute(
     factory.createIdentifier('onSelect'),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
@@ -13,9 +13,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { FieldConfigMetadata, isValidVariableName } from '@aws-amplify/codegen-ui';
+import { FieldConfigMetadata } from '@aws-amplify/codegen-ui';
 import { Expression, factory, Identifier, JsxAttribute, JsxChild, NodeFlags, SyntaxKind } from 'typescript';
 import {
+  buildAccessChain,
   getArrayChildRefName,
   getCurrentDisplayValueName,
   getCurrentValueIdentifier,
@@ -189,23 +190,14 @@ export const renderArrayFieldComponent = (
   props.push(
     factory.createJsxAttribute(
       factory.createIdentifier('hasError'),
-      factory.createJsxExpression(
-        undefined,
-        factory.createPropertyAccessChain(
-          isValidVariableName(fieldName)
-            ? factory.createPropertyAccessExpression(
-                factory.createIdentifier('errors'),
-                factory.createIdentifier(fieldName),
-              )
-            : factory.createElementAccessChain(
-                factory.createIdentifier('errors'),
-                factory.createToken(SyntaxKind.QuestionDotToken),
-                factory.createStringLiteral(fieldName),
-              ),
-          factory.createToken(SyntaxKind.QuestionDotToken),
-          factory.createIdentifier('hasError'),
-        ),
-      ),
+      factory.createJsxExpression(undefined, buildAccessChain(['errors', fieldName, 'hasError'])),
+    ),
+  );
+
+  props.push(
+    factory.createJsxAttribute(
+      factory.createIdentifier('errorMessage'),
+      factory.createJsxExpression(undefined, buildAccessChain(['errors', fieldName, 'errorMessage'])),
     ),
   );
 

--- a/packages/codegen-ui-react/lib/react-component-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-renderer.ts
@@ -87,6 +87,7 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
       this.importCollection.addImport(ImportSource.UI_REACT, 'ScrollView');
       this.importCollection.addImport(ImportSource.UI_REACT, 'Divider');
       this.importCollection.addImport(ImportSource.UI_REACT, 'Text');
+      this.importCollection.addImport(ImportSource.UI_REACT, 'useTheme');
 
       let label = '';
       if (typeof this.component.properties.label === 'object' && 'value' in this.component.properties.label) {

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -17,6 +17,9 @@ import { factory, JsxTagNamePropertyAccess, NodeFlags, SyntaxKind } from 'typesc
 import { addUseEffectWrapper } from '../generate-react-hooks';
 
 export const generateArrayFieldComponent = () => {
+  const errorMessagePropName = 'errorMessage';
+  const errorStylesVariableName = 'errorStyles';
+
   const iconPath = 'M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z';
 
   const labelElementIdentifier = 'labelElement';
@@ -41,6 +44,57 @@ export const generateArrayFieldComponent = () => {
               [factory.createJsxExpression(undefined, factory.createIdentifier('label'))],
               factory.createJsxClosingElement(factory.createIdentifier('Text')),
             ),
+          ),
+        ],
+        NodeFlags.Const,
+      ),
+    ),
+    /**
+      const {
+        tokens: {
+          components: {
+            fieldmessages: { error: errorStyles },
+          },
+        },
+      } = useTheme();
+     */
+    factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createObjectBindingPattern([
+              factory.createBindingElement(
+                undefined,
+                factory.createIdentifier('tokens'),
+                factory.createObjectBindingPattern([
+                  factory.createBindingElement(
+                    undefined,
+                    factory.createIdentifier('components'),
+                    factory.createObjectBindingPattern([
+                      factory.createBindingElement(
+                        undefined,
+                        factory.createIdentifier('fieldmessages'),
+                        factory.createObjectBindingPattern([
+                          factory.createBindingElement(
+                            undefined,
+                            factory.createIdentifier('error'),
+                            factory.createIdentifier(errorStylesVariableName),
+                            undefined,
+                          ),
+                        ]),
+                        undefined,
+                      ),
+                    ]),
+                    undefined,
+                  ),
+                ]),
+                undefined,
+              ),
+            ]),
+            undefined,
+            undefined,
+            factory.createCallExpression(factory.createIdentifier('useTheme'), undefined, []),
           ),
         ],
         NodeFlags.Const,
@@ -872,7 +926,58 @@ export const generateArrayFieldComponent = () => {
                         [factory.createJsxText('Add item', false)],
                         factory.createJsxClosingElement(factory.createIdentifier('Button')),
                       ),
+                      /**
+                        {errorMessage && hasError && (
+                          <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+                            {errorMessage}
+                          </Text>
+                        )}
+                      */
+                      factory.createJsxExpression(
+                        undefined,
+                        factory.createBinaryExpression(
+                          factory.createBinaryExpression(
+                            factory.createIdentifier(errorMessagePropName),
+                            factory.createToken(SyntaxKind.AmpersandAmpersandToken),
+                            factory.createIdentifier('hasError'),
+                          ),
+                          factory.createToken(SyntaxKind.AmpersandAmpersandToken),
+                          factory.createParenthesizedExpression(
+                            factory.createJsxElement(
+                              factory.createJsxOpeningElement(
+                                factory.createIdentifier('Text'),
+                                undefined,
+                                factory.createJsxAttributes([
+                                  factory.createJsxAttribute(
+                                    factory.createIdentifier('color'),
+                                    factory.createJsxExpression(
+                                      undefined,
+                                      factory.createPropertyAccessExpression(
+                                        factory.createIdentifier(errorStylesVariableName),
+                                        factory.createIdentifier('color'),
+                                      ),
+                                    ),
+                                  ),
+                                  factory.createJsxAttribute(
+                                    factory.createIdentifier('fontSize'),
+                                    factory.createJsxExpression(
+                                      undefined,
+                                      factory.createPropertyAccessExpression(
+                                        factory.createIdentifier(errorStylesVariableName),
+                                        factory.createIdentifier('fontSize'),
+                                      ),
+                                    ),
+                                  ),
+                                ]),
+                              ),
+                              [factory.createJsxExpression(undefined, factory.createIdentifier(errorMessagePropName))],
+                              factory.createJsxClosingElement(factory.createIdentifier('Text')),
+                            ),
+                          ),
+                        ),
+                      ),
                     ],
+
                     factory.createJsxJsxClosingFragment(),
                   ),
                 ),
@@ -1053,6 +1158,7 @@ export const generateArrayFieldComponent = () => {
           factory.createBindingElement(undefined, undefined, factory.createIdentifier('defaultFieldValue'), undefined),
           factory.createBindingElement(undefined, undefined, factory.createIdentifier('lengthLimit'), undefined),
           factory.createBindingElement(undefined, undefined, factory.createIdentifier('getBadgeText'), undefined),
+          factory.createBindingElement(undefined, undefined, factory.createIdentifier(errorMessagePropName), undefined),
         ]),
         undefined,
         undefined,

--- a/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
@@ -241,6 +241,10 @@ describe('CreateForms', () => {
       cy.get('#dataStoreFormCreateCPKTeacher').within(() => {
         getInputByLabel('Special teacher id').type('Teacher ID');
 
+        // check error message shows on closed ArrayField
+        cy.contains('Submit').click();
+        cy.contains('CPKStudent is required');
+
         // hasOne
         getArrayFieldButtonByLabel('Cpk student').click();
         typeInAutocomplete('Her{downArrow}{enter}');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Have errors on ArrayFields show up even when not in editing mode.
Integ test included.
Additional change - refine validation behavior for Autocompletes - refresh validation onSelect.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
