### PR TITLE
fix: handle 12AM when converting to local time

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -17634,7 +17634,7 @@ export default function BlogCreateForm(props) {
       minute: \\"2-digit\\",
       calendar: \\"iso8601\\",
       numberingSystem: \\"latn\\",
-      hour12: false,
+      hourCycle: \\"h23\\",
     });
     const parts = df.formatToParts(date).reduce((acc, part) => {
       acc[part.type] = part.value;
@@ -18215,7 +18215,7 @@ export default function InputGalleryCreateForm(props) {
       minute: \\"2-digit\\",
       calendar: \\"iso8601\\",
       numberingSystem: \\"latn\\",
-      hour12: false,
+      hourCycle: \\"h23\\",
     });
     const parts = df.formatToParts(date).reduce((acc, part) => {
       acc[part.type] = part.value;
@@ -19117,7 +19117,7 @@ export default function InputGalleryUpdateForm(props) {
       minute: \\"2-digit\\",
       calendar: \\"iso8601\\",
       numberingSystem: \\"latn\\",
-      hour12: false,
+      hourCycle: \\"h23\\",
     });
     const parts = df.formatToParts(date).reduce((acc, part) => {
       acc[part.type] = part.value;

--- a/packages/codegen-ui-react/lib/utils/forms/value-mappers.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/value-mappers.ts
@@ -45,7 +45,7 @@ export const convertToLocal = (date: Date) => {
     minute: '2-digit',
     calendar: 'iso8601',
     numberingSystem: 'latn',
-    hour12: false,
+    hourCycle: 'h23',
   });
   const parts = df.formatToParts(date).reduce<Record<string, string>>((acc, part) => {
     acc[part.type] = part.value;
@@ -241,8 +241,8 @@ export const convertToLocalAST = factory.createVariableStatement(
                                 factory.createStringLiteral('latn'),
                               ),
                               factory.createPropertyAssignment(
-                                factory.createIdentifier('hour12'),
-                                factory.createFalse(),
+                                factory.createIdentifier('hourCycle'),
+                                factory.createStringLiteral('h23'),
                               ),
                             ],
                             true,

--- a/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
@@ -123,7 +123,11 @@ describe('CreateForms', () => {
         getInputByLabel('Aws date').type('2022-10-12');
         getInputByLabel('Aws time').type('10:12');
         getInputByLabel('Aws date time').type('2017-06-01T08:30');
-        getInputByLabel('Aws timestamp').type('2022-12-01T10:30');
+        getInputByLabel('Aws timestamp').type('2022-12-01T00:30');
+
+        // handle chrome bug - https://support.google.com/chrome/thread/29828561?hl=en
+        getInputByLabel('Aws timestamp').should('have.value', '2022-12-01T00:30');
+
         getInputByLabel('Aws email').type('myemail@yahoo.com');
         getInputByLabel('Aws url').type('https://amazon.com');
         getInputByLabel('Aws ip address').type('192.0.2.146');
@@ -197,7 +201,7 @@ describe('CreateForms', () => {
           expect(record.awsDate).to.equal('2022-10-12');
           expect(record.awsTime).to.equal('10:12');
           expect(record.awsDateTime).to.equal('2017-06-01T08:30:00.000Z');
-          expect(record.awsTimestamp).to.equal(1669890600000);
+          expect(record.awsTimestamp).to.equal(1669854600000);
           expect(record.awsEmail).to.equal('myemail@yahoo.com');
           expect(record.awsUrl).to.equal('https://amazon.com');
           expect(record.awsIPAddress).to.equal('192.0.2.146');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When the customer inputs 12AM in either the timestamp field or the date time field, the value would not persist and their field would reset to blank. This was because 12AM was being converted to the 24th hour by `Intl.DateTimeFormat` in chrome ([related issue](https://support.google.com/chrome/thread/29828561?hl=en)) and the `datetime-local` `type` `input` element could not handle this. 
The workaround is to replace `hour12: false'` with `hourCycle: 'h23'`.

Added an integ test. Made sure it fails before this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
