### PR TITLE
feat: change default component for AWSTimestamp to NumberField

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -18112,12 +18112,6 @@ export default function BlogCreateForm(props) {
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
-  const convertTimeStampToDate = (ts) => {
-    if (Math.abs(Date.now() - ts) < Math.abs(Date.now() - ts * 1000)) {
-      return new Date(ts);
-    }
-    return new Date(ts * 1000);
-  };
   const convertToLocal = (date) => {
     const df = new Intl.DateTimeFormat(\\"default\\", {
       year: \\"numeric\\",
@@ -18338,14 +18332,13 @@ export default function BlogCreateForm(props) {
           label=\\"Edited at\\"
           isRequired={false}
           isReadOnly={false}
-          type=\\"datetime-local\\"
-          value={
-            currentEditedAtValue &&
-            convertToLocal(convertTimeStampToDate(currentEditedAtValue))
-          }
+          type=\\"number\\"
+          step=\\"any\\"
+          value={currentEditedAtValue}
           onChange={(e) => {
-            let value =
-              e.target.value === \\"\\" ? \\"\\" : Number(new Date(e.target.value));
+            let value = isNaN(parseInt(e.target.value))
+              ? e.target.value
+              : parseInt(e.target.value);
             if (errors.editedAt?.hasError) {
               runValidationTasks(\\"editedAt\\", value);
             }
@@ -19628,29 +19621,6 @@ export default function InputGalleryUpdateForm(props) {
     setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
     return validationResponse;
   };
-  const convertTimeStampToDate = (ts) => {
-    if (Math.abs(Date.now() - ts) < Math.abs(Date.now() - ts * 1000)) {
-      return new Date(ts);
-    }
-    return new Date(ts * 1000);
-  };
-  const convertToLocal = (date) => {
-    const df = new Intl.DateTimeFormat(\\"default\\", {
-      year: \\"numeric\\",
-      month: \\"2-digit\\",
-      day: \\"2-digit\\",
-      hour: \\"2-digit\\",
-      minute: \\"2-digit\\",
-      calendar: \\"iso8601\\",
-      numberingSystem: \\"latn\\",
-      hourCycle: \\"h23\\",
-    });
-    const parts = df.formatToParts(date).reduce((acc, part) => {
-      acc[part.type] = part.value;
-      return acc;
-    }, {});
-    return \`\${parts.year}-\${parts.month}-\${parts.day}T\${parts.hour}:\${parts.minute}\`;
-  };
   return (
     <Grid
       as=\\"form\\"
@@ -20053,11 +20023,13 @@ export default function InputGalleryUpdateForm(props) {
         label=\\"Timestamp\\"
         isRequired={false}
         isReadOnly={false}
-        type=\\"datetime-local\\"
-        value={timestamp && convertToLocal(convertTimeStampToDate(timestamp))}
+        type=\\"number\\"
+        step=\\"any\\"
+        value={timestamp}
         onChange={(e) => {
-          let value =
-            e.target.value === \\"\\" ? \\"\\" : Number(new Date(e.target.value));
+          let value = isNaN(parseInt(e.target.value))
+            ? e.target.value
+            : parseInt(e.target.value);
           if (onChange) {
             const modelFields = {
               num,

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -292,7 +292,7 @@ describe('amplify form renderer tests', () => {
         { isNonModelSupported: true, isRelationshipSupported: true },
       );
       expect(componentText).toContain('DataStore.save');
-      expect(componentText).toContain('const convertToLocal');
+      expect(componentText).not.toContain('const convertToLocal');
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
@@ -270,11 +270,13 @@ export const buildOnChangeStatement = (
 ) => {
   const { name: fieldName, componentType: fieldType } = component;
   const fieldConfig = fieldConfigs[fieldName];
-  const { dataType, sanitizedFieldName } = fieldConfig;
+  const { dataType, sanitizedFieldName, studioFormComponentType } = fieldConfig;
   const renderedFieldName = sanitizedFieldName || fieldName;
 
   // build statements that handle new value
-  const handleChangeStatements: Statement[] = [...buildTargetVariable(fieldType, renderedFieldName, dataType)];
+  const handleChangeStatements: Statement[] = [
+    ...buildTargetVariable(studioFormComponentType || fieldType, renderedFieldName, dataType),
+  ];
 
   if (!shouldWrapInArrayField(fieldConfig)) {
     handleChangeStatements.push(buildOverrideOnChangeStatement(fieldName, fieldConfigs));

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-targets.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-targets.ts
@@ -85,24 +85,38 @@ export const buildTargetVariable = (fieldType: string, fieldName: string, dataTy
     fieldTypeToExpressionMap[fieldType]?.identifier ?? expressionMap.destructuredValue;
   switch (dataType) {
     case 'AWSTimestamp':
-      // value = e.target.value === '' ? '' : Number(new Date(e.target.value))
-      defaultIdentifier = expressionMap.value;
-      expression = factory.createConditionalExpression(
-        factory.createBinaryExpression(
+      if (fieldType === 'NumberField') {
+        // value = isNaN(parseInt(e.target.value)) ? e.target.value : parseInt(e.target.value);
+        defaultIdentifier = expressionMap.value;
+        expression = factory.createConditionalExpression(
+          factory.createCallExpression(factory.createIdentifier('isNaN'), undefined, [
+            factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [expressionMap.eTargetValue]),
+          ]),
+          factory.createToken(SyntaxKind.QuestionToken),
           expressionMap.eTargetValue,
-          factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+          factory.createToken(SyntaxKind.ColonToken),
+          factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [expressionMap.eTargetValue]),
+        );
+      } else if (fieldType === 'DateTimeField') {
+        // value = e.target.value === '' ? '' : Number(new Date(e.target.value))
+        defaultIdentifier = expressionMap.value;
+        expression = factory.createConditionalExpression(
+          factory.createBinaryExpression(
+            expressionMap.eTargetValue,
+            factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+            factory.createStringLiteral(''),
+          ),
+          factory.createToken(SyntaxKind.QuestionToken),
           factory.createStringLiteral(''),
-        ),
-        factory.createToken(SyntaxKind.QuestionToken),
-        factory.createStringLiteral(''),
-        factory.createToken(SyntaxKind.ColonToken),
-        factory.createCallExpression(factory.createIdentifier('Number'), undefined, [
-          factory.createNewExpression(factory.createIdentifier('Date'), undefined, [expressionMap.eTargetValue]),
-        ]),
-      );
+          factory.createToken(SyntaxKind.ColonToken),
+          factory.createCallExpression(factory.createIdentifier('Number'), undefined, [
+            factory.createNewExpression(factory.createIdentifier('Date'), undefined, [expressionMap.eTargetValue]),
+          ]),
+        );
+      }
       return [setVariableStatement(defaultIdentifier, expression)];
     case 'Float':
-      if (fieldType === 'TextField') {
+      if (fieldType === 'NumberField') {
         // value = isNaN(parseFloat(e.target.value)) ? e.target.value : parseFloat(e.target.value);
         defaultIdentifier = expressionMap.value;
         expression = factory.createConditionalExpression(
@@ -119,7 +133,7 @@ export const buildTargetVariable = (fieldType: string, fieldName: string, dataTy
       }
       return [setVariableStatement(defaultIdentifier, expression)];
     case 'Int':
-      if (fieldType === 'TextField') {
+      if (fieldType === 'NumberField') {
         // value = isNaN(parseInt(e.target.value)) ? e.target.value : parseInt(e.target.value);
         defaultIdentifier = expressionMap.value;
         expression = factory.createConditionalExpression(

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -614,7 +614,16 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     // timestamp type takes precedence over datetime as it includes formatter for datetime
     // we include both the timestamp conversion and local date formatter
-    if (dataTypesMap.AWSTimestamp) {
+    if (
+      dataTypesMap.AWSTimestamp &&
+      dataTypesMap.AWSTimestamp.some((fieldName) => {
+        const field = formMetadata.fieldConfigs[fieldName];
+        if (field && field.studioFormComponentType === 'DateTimeField') {
+          return true;
+        }
+        return false;
+      })
+    ) {
       statements.push(convertTimeStampToDateAST, convertToLocalAST);
     }
     // if we only have date time then we only need the local conversion

--- a/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
+++ b/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
@@ -20,7 +20,11 @@
       "inputType": {
         "type": "CheckboxField"
       }
-    }
+    },
+    "timestamp": {
+      "inputType": {
+        "type": "DateTimeField"
+      }    }
   },
   "formActionType": "create",
   "name": "InputGalleryCreateForm",

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
@@ -54,8 +54,8 @@ export const FIELD_TYPE_MAP: {
     supportedComponents: new Set(['DateTimeField']),
   },
   AWSTimestamp: {
-    defaultComponent: 'DateTimeField',
-    supportedComponents: new Set(['DateTimeField']),
+    defaultComponent: 'NumberField',
+    supportedComponents: new Set(['DateTimeField', 'NumberField']),
   },
   AWSEmail: {
     defaultComponent: 'EmailField',

--- a/packages/codegen-ui/lib/types/form/form-metadata.ts
+++ b/packages/codegen-ui/lib/types/form/form-metadata.ts
@@ -37,7 +37,7 @@ export type StudioFormDataType = {
 export type FieldConfigMetadata = {
   // ex. name field has a string validation type where the rule is char length > 5
   validationRules: FieldValidationConfiguration[];
-  // component field is of type AWSTimestamp will need to map this to date then get time from date
+  // needed for mapping conversions e.g. for Int
   dataType?: DataFieldDataType;
   relationship?: GenericDataRelationshipType;
   // for JSON type with invalid variable field name ie. { "1first-Name": "John" } => "firstName"

--- a/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/create-form-spec.cy.ts
@@ -123,10 +123,7 @@ describe('CreateForms', () => {
         getInputByLabel('Aws date').type('2022-10-12');
         getInputByLabel('Aws time').type('10:12');
         getInputByLabel('Aws date time').type('2017-06-01T08:30');
-        getInputByLabel('Aws timestamp').type('2022-12-01T00:30');
-
-        // handle chrome bug - https://support.google.com/chrome/thread/29828561?hl=en
-        getInputByLabel('Aws timestamp').should('have.value', '2022-12-01T00:30');
+        getInputByLabel('Aws timestamp').type('1669854600000');
 
         getInputByLabel('Aws email').type('myemail@yahoo.com');
         getInputByLabel('Aws url').type('https://amazon.com');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We currently default AWSTimestamp to DateTimeField, which does not have the option to specify seconds. So we're switching to NumberField, with an option to override to DateTimeField.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
