### PR TITLE
fix: change timestamp check in date validation function

### DIFF
--- a/packages/codegen-ui-react/lib/utils/forms/validation-helpers.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/validation-helpers.ts
@@ -266,6 +266,85 @@ export const generateValidateFieldFunction = () =>
     ),
   );
 
+export const generateParseDateValidatorFunction = () =>
+  factory.createVariableStatement(
+    [factory.createToken(ts.SyntaxKind.ExportKeyword)],
+    factory.createVariableDeclarationList(
+      [
+        factory.createVariableDeclaration(
+          factory.createIdentifier('parseDateValidator'),
+          undefined,
+          undefined,
+          factory.createArrowFunction(
+            undefined,
+            undefined,
+            [
+              factory.createParameterDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                factory.createIdentifier('dateValidator'),
+                undefined,
+                factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                undefined,
+              ),
+            ],
+            undefined,
+            factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            factory.createBlock(
+              [
+                factory.createVariableStatement(
+                  undefined,
+                  factory.createVariableDeclarationList(
+                    [
+                      factory.createVariableDeclaration(
+                        factory.createIdentifier('isTimestamp'),
+                        undefined,
+                        undefined,
+                        factory.createBinaryExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createTemplateExpression(factory.createTemplateHead('', ''), [
+                              factory.createTemplateSpan(
+                                factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [
+                                  factory.createIdentifier('dateValidator'),
+                                ]),
+                                factory.createTemplateTail('', ''),
+                              ),
+                            ]),
+                            factory.createIdentifier('length'),
+                          ),
+                          factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('dateValidator'),
+                            factory.createIdentifier('length'),
+                          ),
+                        ),
+                      ),
+                    ],
+                    ts.NodeFlags.Const,
+                  ),
+                ),
+                factory.createReturnStatement(
+                  factory.createConditionalExpression(
+                    factory.createIdentifier('isTimestamp'),
+                    factory.createToken(ts.SyntaxKind.QuestionToken),
+                    factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [
+                      factory.createIdentifier('dateValidator'),
+                    ]),
+                    factory.createToken(ts.SyntaxKind.ColonToken),
+                    factory.createIdentifier('dateValidator'),
+                  ),
+                ),
+              ],
+              true,
+            ),
+          ),
+        ),
+      ],
+      ts.NodeFlags.Const,
+    ),
+  );
+
 const numValuesSwitchStatement = () =>
   factory.createSwitchStatement(
     factory.createPropertyAccessExpression(factory.createIdentifier('validation'), factory.createIdentifier('type')),
@@ -902,61 +981,6 @@ const strValuesSwitchStatement = () =>
         ),
       ]),
       factory.createCaseClause(factory.createStringLiteral('BeAfter'), [
-        factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                factory.createIdentifier('afterTimeValue'),
-                undefined,
-                undefined,
-                factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [
-                  factory.createElementAccessExpression(
-                    factory.createPropertyAccessExpression(
-                      factory.createIdentifier('validation'),
-                      factory.createIdentifier('strValues'),
-                    ),
-                    factory.createNumericLiteral('0'),
-                  ),
-                ]),
-              ),
-            ],
-            ts.NodeFlags.Const,
-          ),
-        ),
-        factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                factory.createIdentifier('afterTimeValidator'),
-                undefined,
-                undefined,
-                factory.createConditionalExpression(
-                  factory.createCallExpression(
-                    factory.createPropertyAccessExpression(
-                      factory.createIdentifier('Number'),
-                      factory.createIdentifier('isNaN'),
-                    ),
-                    undefined,
-                    [factory.createIdentifier('afterTimeValue')],
-                  ),
-                  factory.createToken(ts.SyntaxKind.QuestionToken),
-                  factory.createElementAccessExpression(
-                    factory.createPropertyAccessExpression(
-                      factory.createIdentifier('validation'),
-                      factory.createIdentifier('strValues'),
-                    ),
-                    factory.createNumericLiteral('0'),
-                  ),
-                  factory.createToken(ts.SyntaxKind.ColonToken),
-                  factory.createIdentifier('afterTimeValue'),
-                ),
-              ),
-            ],
-            ts.NodeFlags.Const,
-          ),
-        ),
         factory.createReturnStatement(
           factory.createObjectLiteralExpression(
             [
@@ -971,7 +995,15 @@ const strValuesSwitchStatement = () =>
                       ]),
                       factory.createToken(ts.SyntaxKind.GreaterThanToken),
                       factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
-                        factory.createIdentifier('afterTimeValidator'),
+                        factory.createCallExpression(factory.createIdentifier('parseDateValidator'), undefined, [
+                          factory.createElementAccessExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('validation'),
+                              factory.createIdentifier('strValues'),
+                            ),
+                            factory.createNumericLiteral('0'),
+                          ),
+                        ]),
                       ]),
                     ),
                   ),
@@ -1008,61 +1040,6 @@ const strValuesSwitchStatement = () =>
         ),
       ]),
       factory.createCaseClause(factory.createStringLiteral('BeBefore'), [
-        factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                factory.createIdentifier('beforeTimeValue'),
-                undefined,
-                undefined,
-                factory.createCallExpression(factory.createIdentifier('parseInt'), undefined, [
-                  factory.createElementAccessExpression(
-                    factory.createPropertyAccessExpression(
-                      factory.createIdentifier('validation'),
-                      factory.createIdentifier('strValues'),
-                    ),
-                    factory.createNumericLiteral('0'),
-                  ),
-                ]),
-              ),
-            ],
-            ts.NodeFlags.Const,
-          ),
-        ),
-        factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                factory.createIdentifier('beforeTimevalue'),
-                undefined,
-                undefined,
-                factory.createConditionalExpression(
-                  factory.createCallExpression(
-                    factory.createPropertyAccessExpression(
-                      factory.createIdentifier('Number'),
-                      factory.createIdentifier('isNaN'),
-                    ),
-                    undefined,
-                    [factory.createIdentifier('beforeTimeValue')],
-                  ),
-                  factory.createToken(ts.SyntaxKind.QuestionToken),
-                  factory.createElementAccessExpression(
-                    factory.createPropertyAccessExpression(
-                      factory.createIdentifier('validation'),
-                      factory.createIdentifier('strValues'),
-                    ),
-                    factory.createNumericLiteral('0'),
-                  ),
-                  factory.createToken(ts.SyntaxKind.ColonToken),
-                  factory.createIdentifier('beforeTimeValue'),
-                ),
-              ),
-            ],
-            ts.NodeFlags.Const,
-          ),
-        ),
         factory.createReturnStatement(
           factory.createObjectLiteralExpression(
             [
@@ -1077,7 +1054,15 @@ const strValuesSwitchStatement = () =>
                       ]),
                       factory.createToken(ts.SyntaxKind.LessThanToken),
                       factory.createNewExpression(factory.createIdentifier('Date'), undefined, [
-                        factory.createIdentifier('beforeTimevalue'),
+                        factory.createCallExpression(factory.createIdentifier('parseDateValidator'), undefined, [
+                          factory.createElementAccessExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('validation'),
+                              factory.createIdentifier('strValues'),
+                            ),
+                            factory.createNumericLiteral('0'),
+                          ),
+                        ]),
                       ]),
                     ),
                   ),

--- a/packages/codegen-ui-react/lib/utils/forms/validation.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/validation.ts
@@ -2,6 +2,7 @@
 import {
   fieldValidationConfigurationDeclaration,
   generateCheckValidationFunction,
+  generateParseDateValidatorFunction,
   generateValidateFieldFunction,
   validationResponseDeclaration,
 } from './validation-helpers';
@@ -36,6 +37,11 @@ export const validateField = (value: any, validations: FieldValidationConfigurat
     }
   }
   return { hasError: false };
+};
+
+export const parseDateValidator = (dateValidator: string) => {
+  const isTimestamp = `${parseInt(dateValidator)}`.length === dateValidator.length;
+  return isTimestamp ? parseInt(dateValidator) : dateValidator;
 };
 
 const checkValidation = (value: any, validation: FieldValidationConfiguration) => {
@@ -94,17 +100,13 @@ const checkValidation = (value: any, validation: FieldValidationConfiguration) =
           errorMessage: validation.validationMessage || `The value must not contain ${validation.strValues.join(', ')}`,
         };
       case 'BeAfter':
-        const afterTimeValue = parseInt(validation.strValues[0]);
-        const afterTimeValidator = Number.isNaN(afterTimeValue) ? validation.strValues[0] : afterTimeValue;
         return {
-          hasError: !(new Date(value) > new Date(afterTimeValidator)),
+          hasError: !(new Date(value) > new Date(parseDateValidator(validation.strValues[0]))),
           errorMessage: validation.validationMessage || `The value must be after ${validation.strValues[0]}`,
         };
       case 'BeBefore':
-        const beforeTimeValue = parseInt(validation.strValues[0]);
-        const beforeTimevalue = Number.isNaN(beforeTimeValue) ? validation.strValues[0] : beforeTimeValue;
         return {
-          hasError: !(new Date(value) < new Date(beforeTimevalue)),
+          hasError: !(new Date(value) < new Date(parseDateValidator(validation.strValues[0]))),
           errorMessage: validation.validationMessage || `The value must be before ${validation.strValues[0]}`,
         };
     }
@@ -164,6 +166,7 @@ export const generateValidationFunction = () => {
     validationResponseDeclaration(),
     fieldValidationConfigurationDeclaration(),
     generateValidateFieldFunction(),
+    generateParseDateValidatorFunction(),
     generateCheckValidationFunction(),
   ];
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- fix before/after validation for parsing dates without alpha characters ex: 2022-01-01 and 01/01/2022

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
