### PR TITLE
feat: allow boolean operand on predicate

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/react-component-render-helper.test.ts.snap
@@ -254,7 +254,15 @@ exports[`react-component-render-helper buildConcatExpression should build concat
 
 exports[`react-component-render-helper buildContionalExpression operandType does not exist 1`] = `"(user?.age && user?.age > \\"18\\") ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;
 
+exports[`react-component-render-helper buildContionalExpression operandType does not exist 2`] = `"(user?.age && user?.age > \\"true\\") ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;
+
+exports[`react-component-render-helper buildContionalExpression operandType does not exist 3`] = `"(user?.age && user?.age > \\"dlo\\") ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;
+
 exports[`react-component-render-helper buildContionalExpression operandType exists 1`] = `"(user?.age && user?.age > 18) ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;
+
+exports[`react-component-render-helper buildContionalExpression operandType exists 2`] = `"(user?.age && user?.age > true) ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;
+
+exports[`react-component-render-helper buildContionalExpression operandType exists 3`] = `"(user?.age && user?.age > \\"true\\") ? \\"Vote\\" : \\"Sorry you cannot vote\\""`;
 
 exports[`react-component-render-helper buildFixedJsxExpression boolean 1`] = `"{true}"`;
 

--- a/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
@@ -280,16 +280,39 @@ describe('react-component-render-helper', () => {
 
   describe('buildContionalExpression', () => {
     test('operandType exists', () => {
-      const exp = buildConditionalExpression(
+      const numberExpression = buildConditionalExpression(
         buildEmptyComponentMetadata(),
         buildConditionalWithOperand('18', 'number'),
       );
-      assertASTMatchesSnapshot(exp);
+      assertASTMatchesSnapshot(numberExpression);
+      const booleanExpression = buildConditionalExpression(
+        buildEmptyComponentMetadata(),
+        buildConditionalWithOperand('true', 'boolean'),
+      );
+      assertASTMatchesSnapshot(booleanExpression);
+      const stringExpression = buildConditionalExpression(
+        buildEmptyComponentMetadata(),
+        buildConditionalWithOperand('true', 'string'),
+      );
+      assertASTMatchesSnapshot(stringExpression);
     });
 
     test('operandType does not exist', () => {
-      const exp = buildConditionalExpression(buildEmptyComponentMetadata(), buildConditionalWithOperand('18'));
-      assertASTMatchesSnapshot(exp);
+      const numberExpression = buildConditionalExpression(
+        buildEmptyComponentMetadata(),
+        buildConditionalWithOperand('18'),
+      );
+      assertASTMatchesSnapshot(numberExpression);
+      const booleanExpression = buildConditionalExpression(
+        buildEmptyComponentMetadata(),
+        buildConditionalWithOperand('true'),
+      );
+      assertASTMatchesSnapshot(booleanExpression);
+      const stringExpression = buildConditionalExpression(
+        buildEmptyComponentMetadata(),
+        buildConditionalWithOperand('dlo'),
+      );
+      assertASTMatchesSnapshot(stringExpression);
     });
 
     test('operand and operandType mismatch', () => {

--- a/packages/codegen-ui/lib/types/bindings.ts
+++ b/packages/codegen-ui/lib/types/bindings.ts
@@ -109,6 +109,7 @@ export type StudioComponentPredicate = {
   field?: string;
   operand?: string;
   operator?: string;
+  operandType?: 'string' | 'boolean' | 'number';
 };
 
 /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds the operandType property which is what was created to allow boolean operands on the conditional component property. 

Adds this same conditional property feature to the predicate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
