### PR TITLE
add new PR template with tasks for each required section

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,27 @@
+## Problem
+<!-- Why are we making this code change? -->
+
+## Solution
+<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
+
+## Additional Notes
+<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->
+
+## Links
+### Ticket
+<!-- *do not link to private ticketing systems* -->
+GitHub issue _____
+
+### Other links
+
+## Verification
+### Manual tests
+<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->
+
+### Automated tests
+- [ ] Unit tests added/updated
+- [ ] E2E tests added/updated
+- [ ] N/A - (provide a reason)
+- [ ] deferred - (provide GitHub issue for tracking)
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
## Problem
We want to raise the bar and encourage our standard processes in our GitHub repos

## Solution
Use a modified PR template that matches expected contents/checks when submitting a PR

## Additional Notes
Open to feedback on this format. Making heavy use of the tasklist formatting since github renders them as checkboxes, but the overall completion counts are not useful since we'd only expect at least one check in the automated tests section instead of all checked.

Also, shifting emphasis onto github issues for tracking work related to this repo since I don't believe we want to link to internal/private ticketing systems here.

## Links
### Ticket
- [ ] GitHub issue _____
### Other links

## Verification
### Manual tests
- [x] template was copied into this PR body and filled out as an example since it does not exist in main branch yet.

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.