### PR TITLE
feat: init composite key property on update form

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -5491,7 +5491,7 @@ function ArrayField({
 }
 export default function UpdateCompositeDogForm(props) {
   const {
-    name: nameProp,
+    id: idProp,
     compositeDog,
     onSuccess,
     onError,
@@ -5561,8 +5561,8 @@ export default function UpdateCompositeDogForm(props) {
   const canUnlinkCompositeVets = false;
   React.useEffect(() => {
     const queryData = async () => {
-      const record = nameProp
-        ? await DataStore.query(CompositeDog, nameProp)
+      const record = idProp
+        ? await DataStore.query(CompositeDog, idProp)
         : compositeDog;
       setCompositeDogRecord(record);
       const CompositeBowlRecord = record
@@ -5589,7 +5589,7 @@ export default function UpdateCompositeDogForm(props) {
       setLinkedCompositeVets(linkedCompositeVets);
     };
     queryData();
-  }, [nameProp, compositeDog]);
+  }, [idProp, compositeDog]);
   React.useEffect(resetStateValues, [
     compositeDogRecord,
     CompositeBowl,
@@ -6351,7 +6351,7 @@ export default function UpdateCompositeDogForm(props) {
             event.preventDefault();
             resetStateValues();
           }}
-          isDisabled={!(nameProp || compositeDog)}
+          isDisabled={!(idProp || compositeDog)}
           {...getOverrideProps(overrides, \\"ResetButton\\")}
         ></Button>
         <Flex
@@ -6363,7 +6363,7 @@ export default function UpdateCompositeDogForm(props) {
             type=\\"submit\\"
             variation=\\"primary\\"
             isDisabled={
-              !(nameProp || compositeDog) ||
+              !(idProp || compositeDog) ||
               Object.values(errors).some((e) => e?.hasError)
             }
             {...getOverrideProps(overrides, \\"SubmitButton\\")}
@@ -6415,7 +6415,10 @@ export declare type UpdateCompositeDogFormOverridesProps = {
 export declare type UpdateCompositeDogFormProps = React.PropsWithChildren<{
     overrides?: UpdateCompositeDogFormOverridesProps | undefined | null;
 } & {
-    name?: string;
+    id?: {
+        name: string;
+        description: string;
+    };
     compositeDog?: CompositeDog;
     onSubmit?: (fields: UpdateCompositeDogFormInputValues) => UpdateCompositeDogFormInputValues;
     onSuccess?: (fields: UpdateCompositeDogFormInputValues) => void;
@@ -8715,7 +8718,7 @@ function ArrayField({
 }
 export default function UpdateCompositeDogForm(props) {
   const {
-    name: nameProp,
+    id: idProp,
     compositeDog,
     onSuccess,
     onError,
@@ -8785,8 +8788,8 @@ export default function UpdateCompositeDogForm(props) {
   const canUnlinkCompositeVets = false;
   React.useEffect(() => {
     const queryData = async () => {
-      const record = nameProp
-        ? await DataStore.query(CompositeDog, nameProp)
+      const record = idProp
+        ? await DataStore.query(CompositeDog, idProp)
         : compositeDog;
       setCompositeDogRecord(record);
       const CompositeOwnerRecord = record
@@ -8813,7 +8816,7 @@ export default function UpdateCompositeDogForm(props) {
       setCompositeDogCompositeBowlShape(compositeDogCompositeBowlShapeRecord);
     };
     queryData();
-  }, [nameProp, compositeDog]);
+  }, [idProp, compositeDog]);
   React.useEffect(resetStateValues, [
     compositeDogRecord,
     CompositeOwner,
@@ -9551,7 +9554,7 @@ export default function UpdateCompositeDogForm(props) {
             event.preventDefault();
             resetStateValues();
           }}
-          isDisabled={!(nameProp || compositeDog)}
+          isDisabled={!(idProp || compositeDog)}
           {...getOverrideProps(overrides, \\"ResetButton\\")}
         ></Button>
         <Flex
@@ -9563,7 +9566,7 @@ export default function UpdateCompositeDogForm(props) {
             type=\\"submit\\"
             variation=\\"primary\\"
             isDisabled={
-              !(nameProp || compositeDog) ||
+              !(idProp || compositeDog) ||
               Object.values(errors).some((e) => e?.hasError)
             }
             {...getOverrideProps(overrides, \\"SubmitButton\\")}
@@ -9615,7 +9618,10 @@ export declare type UpdateCompositeDogFormOverridesProps = {
 export declare type UpdateCompositeDogFormProps = React.PropsWithChildren<{
     overrides?: UpdateCompositeDogFormOverridesProps | undefined | null;
 } & {
-    name?: string;
+    id?: {
+        name: string;
+        description: string;
+    };
     compositeDog?: CompositeDog;
     onSubmit?: (fields: UpdateCompositeDogFormInputValues) => UpdateCompositeDogFormInputValues;
     onSuccess?: (fields: UpdateCompositeDogFormInputValues) => void;

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -27,3 +27,19 @@ exports[`form-render utils should render cancel props if included cancel object 
     onValidate?: myCustomFormValidationValues;
 }"
 `;
+
+exports[`form-render utils should render composite primary keys 1`] = `
+"{
+    id?: {
+        myKey: string;
+        description: number;
+    };
+    post?: Post;
+    onSubmit?: (fields: mySampleFormInputValues) => mySampleFormInputValues;
+    onSuccess?: (fields: mySampleFormInputValues) => void;
+    onError?: (fields: mySampleFormInputValues, errorMessage: string) => void;
+    onCancel?: () => void;
+    onChange?: (fields: mySampleFormInputValues) => mySampleFormInputValues;
+    onValidate?: mySampleFormValidationValues;
+}"
+`;

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
@@ -40,7 +40,7 @@ describe('form-render utils', () => {
       cta: {},
     };
 
-    const propSignatures = buildFormPropNode(form);
+    const propSignatures = buildFormPropNode(form, {});
     const node = printNode(propSignatures);
     expect(node).toMatchSnapshot();
   });
@@ -56,7 +56,7 @@ describe('form-render utils', () => {
       style: {},
       cta: {},
     };
-    const propSignatures = buildFormPropNode(form);
+    const propSignatures = buildFormPropNode(form, {});
     const node = printNode(propSignatures);
     expect(node).toMatchSnapshot();
   });
@@ -74,9 +74,35 @@ describe('form-render utils', () => {
         cancel: {},
       },
     };
-    const propSignatures = buildFormPropNode(form);
+    const propSignatures = buildFormPropNode(form, {});
     const node = printNode(propSignatures);
     expect(node).toContain('onCancel?: () => void;');
+    expect(node).toMatchSnapshot();
+  });
+
+  it('should render composite primary keys', () => {
+    const form: StudioForm = {
+      id: '123',
+      name: 'mySampleForm',
+      formActionType: 'update',
+      dataType: { dataSourceType: 'DataStore', dataTypeName: 'Post' },
+      fields: {},
+      sectionalElements: {},
+      style: {},
+      cta: {
+        cancel: {},
+      },
+    };
+    const propSignatures = buildFormPropNode(
+      form,
+      { description: { dataType: 'Int', validationRules: [], componentType: 'TextField' } },
+      undefined,
+      ['myKey', 'description'],
+    );
+    const node = printNode(propSignatures);
+    expect(node).toContain('id?: {');
+    expect(node).toContain('myKey: string;');
+    expect(node).toContain('description: number;');
     expect(node).toMatchSnapshot();
   });
 });

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
@@ -34,6 +34,7 @@ import { shouldWrapInArrayField } from './render-checkers';
 import { getAutocompleteOptionsProp } from './model-values';
 import { buildCtaLayoutProperties } from '../../react-component-render-helper';
 import { lowerCaseFirst } from '../../helpers';
+import { COMPOSITE_PRIMARY_KEY_PROP_NAME } from '../../utils/constants';
 
 export const addFormAttributes = (
   component: StudioComponent | StudioComponentChild,
@@ -165,8 +166,11 @@ export const addFormAttributes = (
       resetStateValues();
     }}
   */
-  const firstPrimaryKey = dataSchema?.models[dataTypeName]?.primaryKeys[0];
-  const idProp = firstPrimaryKey ? getPropName(firstPrimaryKey) : '';
+  // multiple primary keys means it is a composite key
+  const primaryKeys = dataSchema?.models[dataTypeName]?.primaryKeys?.length
+    ? dataSchema.models[dataTypeName].primaryKeys
+    : [''];
+  const idProp = primaryKeys.length > 1 ? getPropName(COMPOSITE_PRIMARY_KEY_PROP_NAME) : getPropName(primaryKeys[0]);
   if (componentName === 'ClearButton' || componentName === 'ResetButton') {
     attributes.push(
       factory.createJsxAttribute(

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
@@ -54,21 +54,25 @@ import { getOnChangeValidationBlock } from './validation';
 import { buildModelFieldObject } from './model-fields';
 import { isModelDataType, shouldWrapInArrayField } from './render-checkers';
 import { extractModelAndKeys, getMatchEveryModelFieldCallExpression } from './model-values';
+import { COMPOSITE_PRIMARY_KEY_PROP_NAME } from '../../utils/constants';
 
-export const buildMutationBindings = (form: StudioForm, primaryKey?: string) => {
+export const buildMutationBindings = (form: StudioForm, primaryKeys: string[] = []) => {
   const {
     dataType: { dataSourceType, dataTypeName },
     formActionType,
   } = form;
   const elements: BindingElement[] = [];
-  if (dataSourceType === 'DataStore' && primaryKey) {
+  if (dataSourceType === 'DataStore' && primaryKeys.length) {
     if (formActionType === 'update') {
       elements.push(
         // id: idProp
         factory.createBindingElement(
           undefined,
-          factory.createIdentifier(primaryKey),
-          factory.createIdentifier(getPropName(primaryKey)),
+          // if greater than 1, it's a composite key. using 'id' for a composite key prop name.
+          factory.createIdentifier(primaryKeys.length > 1 ? COMPOSITE_PRIMARY_KEY_PROP_NAME : primaryKeys[0]),
+          factory.createIdentifier(
+            primaryKeys.length > 1 ? getPropName(COMPOSITE_PRIMARY_KEY_PROP_NAME) : getPropName(primaryKeys[0]),
+          ),
           undefined,
         ),
         factory.createBindingElement(

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/typescript-type-map.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/typescript-type-map.ts
@@ -20,6 +20,7 @@ export const DATA_TYPE_TO_TYPESCRIPT_MAP: { [key: string]: KeywordTypeSyntaxKind
   Float: SyntaxKind.NumberKeyword,
   Boolean: SyntaxKind.BooleanKeyword,
   AWSTimestamp: SyntaxKind.NumberKeyword,
+  String: SyntaxKind.StringKeyword,
 };
 
 export const FIELD_TYPE_TO_TYPESCRIPT_MAP: { [key: string]: KeywordTypeSyntaxKind } = {

--- a/packages/codegen-ui-react/lib/utils/constants.ts
+++ b/packages/codegen-ui-react/lib/utils/constants.ts
@@ -1,0 +1,16 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+export const COMPOSITE_PRIMARY_KEY_PROP_NAME = 'id';

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form/DSCompositeDog-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form/DSCompositeDog-spec.cy.ts
@@ -136,4 +136,11 @@ describe('FormTests - DSCompositeDog', () => {
       });
     });
   });
+
+  specify('update form should load Data Store model with composite key', () => {
+    cy.get('#DataStoreFormUpdateCompositeDogById').within(() => {
+      getInputByLabel('Name').should('have.value', 'Yundoo');
+      getInputByLabel('Description').should('have.value', 'tiny but mighty');
+    });
+  });
 });

--- a/packages/test-generator/integration-test-templates/src/FormTests/DSCompositeDog.tsx
+++ b/packages/test-generator/integration-test-templates/src/FormTests/DSCompositeDog.tsx
@@ -102,6 +102,7 @@ export default function () {
   const [dataStoreFormUpdateCompositeDogRecord, setDataStoreFormUpdateCompositeDogRecord] = useState<
     CompositeDog | undefined
   >();
+
   const [isInitialized, setInitialized] = useState(false);
 
   const initializeStarted = useRef(false);
@@ -114,7 +115,7 @@ export default function () {
       // DataStore.clear() doesn't appear to reliably work in this scenario.
       indexedDB.deleteDatabase('amplify-datastore');
       await initializeTestData();
-      await Promise.all([initializeUpdate1TestData({ setDataStoreFormUpdateCompositeDogRecord })]);
+      await initializeUpdate1TestData({ setDataStoreFormUpdateCompositeDogRecord });
       setInitialized(true);
     };
 
@@ -208,6 +209,10 @@ export default function () {
           }}
         />
         <Text>{dataStoreFormUpdateCompositeDogResults}</Text>
+      </View>
+      <Heading>DataStoreFormUpdateCompositeDogById</Heading>
+      <View id="DataStoreFormUpdateCompositeDogById">
+        <DataStoreFormUpdateCompositeDog id={{ name: 'Yundoo', description: 'tiny but mighty' }} />
       </View>
     </AmplifyProvider>
   );


### PR DESCRIPTION
## Problem
<!-- Why are we making this code change? -->

Allow customer's to use a composite key on an update form

## Solution
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

The form now accepts a composite key

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.