### PR TITLE
fix: make operandType more generic

### DIFF
--- a/packages/codegen-ui/lib/types/bindings.ts
+++ b/packages/codegen-ui/lib/types/bindings.ts
@@ -109,7 +109,7 @@ export type StudioComponentPredicate = {
   field?: string;
   operand?: string;
   operator?: string;
-  operandType?: 'string' | 'boolean' | 'number';
+  operandType?: string;
 };
 
 /**


### PR DESCRIPTION
## Problem
<!-- Why are we making this code change? -->

union type doesn't work with the aws sdk types

## Solution
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

make operandType a string

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

Tests already exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.