### PR TITLE
feat: add optional or required decorator on form labels

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3358,7 +3358,12 @@ export default function CustomDataForm(props) {
       {...rest}
     >
       <TextField
-        label=\\"name\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>name</span>
+            <span style={{ color: \\"red\\" }}>*</span>
+          </span>
+        }
         isRequired={true}
         value={name}
         onChange={(e) => {
@@ -3400,7 +3405,12 @@ export default function CustomDataForm(props) {
           setCurrentEmailValue(\\"\\");
         }}
         currentFieldValue={currentEmailValue}
-        label={\\"E-mail\\"}
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>E-mail</span>
+            <span style={{ color: \\"red\\" }}>*</span>
+          </span>
+        }
         items={email}
         hasError={errors?.email?.hasError}
         errorMessage={errors?.email?.errorMessage}
@@ -3444,7 +3454,12 @@ export default function CustomDataForm(props) {
           setCurrentPhoneValue(\\"\\");
         }}
         currentFieldValue={currentPhoneValue}
-        label={\\"phone\\"}
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>phone</span>
+            <span style={{ color: \\"red\\" }}>*</span>
+          </span>
+        }
         items={phone}
         hasError={errors?.phone?.hasError}
         errorMessage={errors?.phone?.errorMessage}
@@ -19977,7 +19992,15 @@ export default function InputGalleryCreateForm(props) {
       {...rest}
     >
       <TextField
-        label=\\"Num\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Num</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         isRequired={false}
         isReadOnly={false}
         type=\\"number\\"
@@ -20015,7 +20038,15 @@ export default function InputGalleryCreateForm(props) {
         {...getOverrideProps(overrides, \\"num\\")}
       ></TextField>
       <TextField
-        label=\\"Rootbeer\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Rootbeer</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         isRequired={false}
         isReadOnly={false}
         type=\\"number\\"
@@ -20053,7 +20084,15 @@ export default function InputGalleryCreateForm(props) {
         {...getOverrideProps(overrides, \\"rootbeer\\")}
       ></TextField>
       <RadioGroupField
-        label=\\"Attend\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Attend</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         name=\\"attend\\"
         isReadOnly={false}
         isRequired=\\"false\\"
@@ -20098,7 +20137,15 @@ export default function InputGalleryCreateForm(props) {
         ></Radio>
       </RadioGroupField>
       <ToggleButton
-        children=\\"Maybe slide\\"
+        children={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Maybe Slide</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         isDisabled={false}
         defaultPressed={false}
         isPressed={maybeSlide}
@@ -20132,7 +20179,15 @@ export default function InputGalleryCreateForm(props) {
         {...getOverrideProps(overrides, \\"maybeSlide\\")}
       ></ToggleButton>
       <CheckboxField
-        label=\\"Maybe check\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Maybe check</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         name=\\"maybeCheck\\"
         value=\\"maybeCheck\\"
         isDisabled={false}
@@ -20190,7 +20245,15 @@ export default function InputGalleryCreateForm(props) {
           setCurrentArrayTypeFieldValue(\\"\\");
         }}
         currentFieldValue={currentArrayTypeFieldValue}
-        label={\\"Array type field\\"}
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Array type field</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         items={arrayTypeField}
         hasError={errors?.arrayTypeField?.hasError}
         errorMessage={errors?.arrayTypeField?.errorMessage}
@@ -20244,7 +20307,15 @@ export default function InputGalleryCreateForm(props) {
           setCurrentJsonArrayValue(\\"\\");
         }}
         currentFieldValue={currentJsonArrayValue}
-        label={\\"Json array\\"}
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Json array</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         items={jsonArray}
         hasError={errors?.jsonArray?.hasError}
         errorMessage={errors?.jsonArray?.errorMessage}
@@ -20273,7 +20344,15 @@ export default function InputGalleryCreateForm(props) {
         ></TextAreaField>
       </ArrayField>
       <TextAreaField
-        label=\\"Json field\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Json field</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         isRequired={false}
         isReadOnly={false}
         onChange={(e) => {
@@ -20306,7 +20385,15 @@ export default function InputGalleryCreateForm(props) {
         {...getOverrideProps(overrides, \\"jsonField\\")}
       ></TextAreaField>
       <TextField
-        label=\\"Timestamp\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Timestamp</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         isRequired={false}
         isReadOnly={false}
         type=\\"datetime-local\\"
@@ -20342,7 +20429,15 @@ export default function InputGalleryCreateForm(props) {
         {...getOverrideProps(overrides, \\"timestamp\\")}
       ></TextField>
       <TextField
-        label=\\"Ippy\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Ippy</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         isRequired={false}
         isReadOnly={false}
         value={ippy}
@@ -20376,7 +20471,15 @@ export default function InputGalleryCreateForm(props) {
         {...getOverrideProps(overrides, \\"ippy\\")}
       ></TextField>
       <TextField
-        label=\\"Timeisnow\\"
+        label={
+          <span style={{ display: \\"inline-flex\\" }}>
+            <span>Timeisnow</span>
+            <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+              {\\" \\"}
+              - optional
+            </span>
+          </span>
+        }
         isRequired={false}
         isReadOnly={false}
         type=\\"time\\"

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/index.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/index.ts
@@ -34,3 +34,5 @@ export { buildRelationshipQuery, buildGetRelationshipModels } from './relationsh
 export { shouldWrapInArrayField } from './render-checkers';
 
 export { renderArrayFieldComponent } from './render-array-field';
+
+export { getDecoratedLabel } from './label-decorator';

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/label-decorator.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/label-decorator.ts
@@ -1,0 +1,110 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { LabelDecorator, StudioComponentProperty } from '@aws-amplify/codegen-ui/lib/types';
+import { factory } from 'typescript';
+
+/**
+ <span style={{ display: \\"inline-flex\\" }}>
+  <span>City</span>
+  <span style={{ whiteSpace: \\"pre\\", fontStyle: \\"italic\\" }}>
+    {\\" \\"}
+    - optional
+  </span>
+</span>
+ */
+
+export const getDecoratedLabel = (attribute: string, value: string, labelDecorator: LabelDecorator) =>
+  factory.createJsxAttribute(
+    factory.createIdentifier(attribute),
+    factory.createJsxExpression(
+      undefined,
+      factory.createJsxElement(
+        factory.createJsxOpeningElement(
+          factory.createIdentifier('span'),
+          undefined,
+          factory.createJsxAttributes([
+            factory.createJsxAttribute(
+              factory.createIdentifier('style'),
+              factory.createJsxExpression(
+                undefined,
+                factory.createObjectLiteralExpression(
+                  [
+                    factory.createPropertyAssignment(
+                      factory.createIdentifier('display'),
+                      factory.createStringLiteral('inline-flex'),
+                    ),
+                  ],
+                  false,
+                ),
+              ),
+            ),
+          ]),
+        ),
+        [
+          factory.createJsxElement(
+            factory.createJsxOpeningElement(
+              factory.createIdentifier('span'),
+              undefined,
+              factory.createJsxAttributes([]),
+            ),
+            [factory.createJsxText(value, false)],
+            factory.createJsxClosingElement(factory.createIdentifier('span')),
+          ),
+          generateLabelDecorator(labelDecorator),
+        ],
+        factory.createJsxClosingElement(factory.createIdentifier('span')),
+      ),
+    ),
+  );
+
+const generateLabelDecorator = (labelDecorator: LabelDecorator) => {
+  let styles = [
+    factory.createPropertyAssignment(factory.createIdentifier('whiteSpace'), factory.createStringLiteral('pre')),
+    factory.createPropertyAssignment(factory.createIdentifier('fontStyle'), factory.createStringLiteral('italic')),
+  ];
+  let decoratorText = ' - optional';
+
+  if (labelDecorator === 'required') {
+    styles = [factory.createPropertyAssignment(factory.createIdentifier('color'), factory.createStringLiteral('red'))];
+    decoratorText = '*';
+  }
+
+  return factory.createJsxElement(
+    factory.createJsxOpeningElement(
+      factory.createIdentifier('span'),
+      undefined,
+      factory.createJsxAttributes([
+        factory.createJsxAttribute(
+          factory.createIdentifier('style'),
+          factory.createJsxExpression(undefined, factory.createObjectLiteralExpression(styles, false)),
+        ),
+      ]),
+    ),
+    [factory.createJsxText(decoratorText, false)],
+    factory.createJsxClosingElement(factory.createIdentifier('span')),
+  );
+};
+
+export const getIsRequiredValue = (isRequiredProperty: StudioComponentProperty) => {
+  let isRequired = false;
+  if (isRequiredProperty && 'value' in isRequiredProperty) {
+    const isRequiredValue = isRequiredProperty.value;
+    if (typeof isRequiredValue === 'string') {
+      isRequired = isRequiredProperty.value === 'true';
+    }
+  }
+  return isRequired;
+};

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { FieldConfigMetadata } from '@aws-amplify/codegen-ui';
+import { FieldConfigMetadata, LabelDecorator } from '@aws-amplify/codegen-ui';
 import { Expression, factory, Identifier, JsxAttribute, JsxChild, NodeFlags, SyntaxKind } from 'typescript';
 import {
   buildAccessChain,
@@ -29,6 +29,7 @@ import { isModelDataType, shouldImplementDisplayValueFunction } from './render-c
 import { getDisplayValueObjectName } from './model-values';
 import { getElementAccessExpression } from './invalid-variable-helpers';
 import { getSetNameIdentifier, capitalizeFirstLetter } from '../../helpers';
+import { getDecoratedLabel } from './label-decorator';
 
 function getOnChangeAttribute({
   setStateName,
@@ -127,6 +128,8 @@ export const renderArrayFieldComponent = (
   fieldLabel: string,
   fieldConfigs: Record<string, FieldConfigMetadata>,
   inputField: JsxChild,
+  labelDecorator?: LabelDecorator,
+  isRequired?: boolean,
 ) => {
   const fieldConfig = fieldConfigs[fieldName];
   const { sanitizedFieldName, dataType, componentType } = fieldConfig;
@@ -168,16 +171,20 @@ export const renderArrayFieldComponent = (
   }
 
   props.push(getOnChangeAttribute({ fieldName, isLimitedToOneValue, fieldConfigs, renderedFieldName, setStateName }));
+  let labelAttribute = factory.createJsxAttribute(
+    factory.createIdentifier('label'),
+    factory.createJsxExpression(undefined, factory.createStringLiteral(fieldLabel)),
+  );
 
+  if ((labelDecorator === 'required' && isRequired) || (labelDecorator === 'optional' && !isRequired)) {
+    labelAttribute = getDecoratedLabel('label', fieldLabel, labelDecorator);
+  }
   props.push(
     factory.createJsxAttribute(
-      factory.createIdentifier(`currentFieldValue`),
+      factory.createIdentifier('currentFieldValue'),
       factory.createJsxExpression(undefined, stateName),
     ),
-    factory.createJsxAttribute(
-      factory.createIdentifier(`label`),
-      factory.createJsxExpression(undefined, factory.createStringLiteral(fieldLabel)),
-    ),
+    labelAttribute,
   );
 
   props.push(

--- a/packages/codegen-ui/example-schemas/forms/custom-with-array-field.json
+++ b/packages/codegen-ui/example-schemas/forms/custom-with-array-field.json
@@ -69,5 +69,6 @@
     "submit": {
       "children": "create"
     }
-  }
+  },
+  "labelDecorator": "required"
 }

--- a/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
+++ b/packages/codegen-ui/example-schemas/forms/input-gallery-create.json
@@ -8,10 +8,17 @@
       "inputType": {
         "required": "false",
         "type": "RadioGroupField",
-        "valueMappings": { "values": [{ "value": "{ value: 'Option' }" }] }
+        "valueMappings": {
+          "values": [
+            {
+              "value": "{ value: 'Option' }"
+            }
+          ]
+        }
       }
     },
     "maybeSlide": {
+      "label": "Maybe Slide",
       "inputType": {
         "type": "ToggleButton"
       }
@@ -24,7 +31,8 @@
     "timestamp": {
       "inputType": {
         "type": "DateTimeField"
-      }    }
+      }
+    }
   },
   "formActionType": "create",
   "name": "InputGalleryCreateForm",
@@ -36,5 +44,6 @@
     "cancel": {},
     "submit": {}
   },
+  "labelDecorator": "optional",
   "id": "00001"
 }

--- a/packages/codegen-ui/lib/__tests__/__utils__/basic-form-definition.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/basic-form-definition.ts
@@ -22,6 +22,7 @@ export const getBasicFormDefinition = (): FormDefinition => ({
       verticalGap: { value: '15px' },
       outerPadding: { value: '20px' },
     },
+    labelDecorator: 'none',
   },
   elements: {},
   elementMatrix: [],

--- a/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/form-component-metadata.test.ts
@@ -74,8 +74,9 @@ describe('mapFormMetaData', () => {
       cta: {},
     };
 
-    const { fieldConfigs } = mapFormMetadata(form, formDefinition);
+    const { fieldConfigs, labelDecorator } = mapFormMetadata(form, formDefinition);
 
+    expect(labelDecorator).toBe('none');
     expect('name' in fieldConfigs).toBe(true);
     expect('myDivider' in fieldConfigs || 'myText' in fieldConfigs || 'myHeading' in fieldConfigs).toBe(false);
   });

--- a/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/generate-form-definition.ts
@@ -42,7 +42,7 @@ export function generateFormDefinition({
   featureFlags?: FormFeatureFlags;
 }): FormDefinition {
   const formDefinition: FormDefinition = {
-    form: { layoutStyle: mapStyles(form.style) },
+    form: { layoutStyle: mapStyles(form.style), labelDecorator: form.labelDecorator || 'none' },
     elements: {},
     buttons: {
       buttonConfigs: {},

--- a/packages/codegen-ui/lib/types/form/fields.ts
+++ b/packages/codegen-ui/lib/types/form/fields.ts
@@ -22,7 +22,6 @@ import { FieldValidationConfiguration } from './form-validation';
  */
 type StudioFieldConfig = {
   label?: string;
-
   position?: StudioFieldPosition;
   validations?: FieldValidationConfiguration[];
 };

--- a/packages/codegen-ui/lib/types/form/form-definition.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { FormStyleConfig } from './style';
+import { FormStyleConfig, LabelDecorator } from './style';
 import { FormDefinitionElement, FormDefinitionButtonElement } from './form-definition-element';
 import { StudioGenericFieldConfig } from './fields';
 import { DataFieldDataType, GenericDataRelationshipType } from '../data';
@@ -37,7 +37,12 @@ export type ButtonConfig = {
 
 export type FormDefinition = {
   form: {
-    layoutStyle: { horizontalGap: FormStyleConfig; verticalGap: FormStyleConfig; outerPadding: FormStyleConfig };
+    layoutStyle: {
+      horizontalGap: FormStyleConfig;
+      verticalGap: FormStyleConfig;
+      outerPadding: FormStyleConfig;
+    };
+    labelDecorator: LabelDecorator;
   };
   elements: { [element: string]: FormDefinitionElement };
   buttons: ButtonConfig;

--- a/packages/codegen-ui/lib/types/form/form-metadata.ts
+++ b/packages/codegen-ui/lib/types/form/form-metadata.ts
@@ -16,7 +16,7 @@
 import { DataFieldDataType, GenericDataRelationshipType } from '../data';
 import { FieldValidationConfiguration } from './form-validation';
 import { StudioFormValueMappings } from './input-config';
-import { FormStyleConfig, StudioFormStyle } from './style';
+import { FormStyleConfig, LabelDecorator, StudioFormStyle } from './style';
 
 /**
  * Form Action type definition
@@ -55,5 +55,6 @@ export type FormMetadata = {
   dataType: StudioFormDataType;
   name: string;
   fieldConfigs: Record<string, FieldConfigMetadata>;
-  layoutConfigs: Record<keyof StudioFormStyle, FormStyleConfig>;
+  layoutConfigs: Record<keyof Omit<StudioFormStyle, 'labelDecorator'>, FormStyleConfig>;
+  labelDecorator: LabelDecorator;
 };

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 
-import { StudioFormStyle } from './style';
+import { LabelDecorator, StudioFormStyle } from './style';
 import { StudioFormFields, StudioFormFieldConfig, StudioGenericFieldConfig } from './fields';
 import { GenericSectionalElementConfig, SectionalElementConfig, SectionalElementFields } from './sectional-element';
 import { FormDefinition, ModelFieldsConfigs, FieldTypeMapKeys, ButtonConfig } from './form-definition';
@@ -48,6 +48,8 @@ export type StudioForm = {
   style: StudioFormStyle;
 
   cta: StudioFormCTA;
+
+  labelDecorator?: LabelDecorator;
 };
 
 export type FormInputType =

--- a/packages/codegen-ui/lib/types/form/style.ts
+++ b/packages/codegen-ui/lib/types/form/style.ts
@@ -21,6 +21,8 @@ export type FormStyleConfig = {
   value?: string;
 } & FormStyleConfigCommon;
 
+export type LabelDecorator = 'optional' | 'required' | 'none';
+
 export type StudioFormStyle = {
   horizontalGap?: FormStyleConfig;
   verticalGap?: FormStyleConfig;

--- a/packages/codegen-ui/lib/utils/form-component-metadata.ts
+++ b/packages/codegen-ui/lib/utils/form-component-metadata.ts
@@ -69,6 +69,7 @@ export const mapFormMetadata = (form: StudioForm, formDefinition: FormDefinition
     formActionType: form.formActionType,
     dataType: form.dataType,
     layoutConfigs: formDefinition.form.layoutStyle,
+    labelDecorator: formDefinition.form.labelDecorator,
     fieldConfigs: Object.entries(formDefinition.elements).reduce<Record<string, FieldConfigMetadata>>(
       (configs, [name, element]) => {
         if (!elementIsInput(element)) {

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomDog-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomDog-spec.cy.ts
@@ -60,7 +60,7 @@ describe('FormTests - CustomDog', () => {
       blurField();
       getInputByLabel('Email').type('spot@gmail.com');
       blurField();
-      getInputByLabel('IP Address').type('invalid ip');
+      getInputByLabel('IP Address*').type('invalid ip');
       blurField();
       cy.contains(ErrorMessageMap.name);
       cy.contains(ErrorMessageMap.age);
@@ -76,7 +76,7 @@ describe('FormTests - CustomDog', () => {
       blurField();
       getInputByLabel('Email').type('spot@yahoo.com');
       blurField();
-      getInputByLabel('IP Address').type('192.0.2.146');
+      getInputByLabel('IP Address*').type('192.0.2.146');
       blurField();
       cy.get('select').select('Blue');
       typeInAutocomplete('Ret{downArrow}{enter}');

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomNestedJSON-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomNestedJSON-spec.cy.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 
-import { getInputByLabel } from '../../utils/form';
+import { getDecoratedLabelSibling } from '../../utils/form';
 
 describe('FormTests - CustomNestedJSON', () => {
   beforeEach(() => {
@@ -24,10 +24,10 @@ describe('FormTests - CustomNestedJSON', () => {
   specify('create form should have a working ArrayField', () => {
     cy.get('#CustomFormCreateNestedJson').within(() => {
       cy.contains('Add item').click();
-      getInputByLabel('Animals').type('String1');
+      getDecoratedLabelSibling('Animals - optional').type('String1');
       cy.contains('Add').click();
       cy.contains('Add item').click();
-      getInputByLabel('Animals').type('String2');
+      getDecoratedLabelSibling('Animals - optional').type('String2');
       cy.contains('String1').should('exist');
     });
   });

--- a/packages/test-generator/integration-test-templates/cypress/utils/form.ts
+++ b/packages/test-generator/integration-test-templates/cypress/utils/form.ts
@@ -25,6 +25,10 @@ export const getArrayFieldButtonByLabel = (label) => {
   return cy.contains(label).next('button');
 };
 
+export const getDecoratedLabelSibling = (label) => {
+  return cy.contains(label).parent().next();
+};
+
 export const clickAddToArray = (container?: Cypress.Chainable<any>) => {
   if (container) {
     container.within(() => {

--- a/packages/test-generator/lib/forms/custom-form-create-dog.json
+++ b/packages/test-generator/lib/forms/custom-form-create-dog.json
@@ -7,74 +7,109 @@
     "dataTypeName": "Dog"
   },
   "fields": {
-      "name": {
-          "label": "Name",
-          "inputType": {
-              "type": "TextField"
-          },
-          "validations": [{"type": "GreaterThanChar", "numValues": ["1"], "validationMessage": "Name must be longer than 1 character"}]
+    "name": {
+      "label": "Name",
+      "inputType": {
+        "type": "TextField"
       },
-      "age": {
-          "label": "Age",
-          "inputType": {
-              "type": "NumberField"
-          },
-          "validations": [{"type": "GreaterThanNum","numValues": ["0"], "validationMessage": "Age must be greater than 0"}]
-      },
-      "email": {
-          "label": "Email",
-          "inputType": {
-              "type": "EmailField"
-          }
-      },
-      "ip": {
-          "label": "IP Address",
-          "inputType": {
-              "type": "IPAddressField",
-              "required": true
-          }
-      },
-      "breed": {
-        "label": "Breed",
-        "inputType": {
-          "type": "Autocomplete",
-          "valueMappings": {
-            "values": [
-              {
-                "value": {
-                  "value": "Retriever"
-                }
-              },
-              {
-                "value": {
-                  "value": "Shepherd"
-                }
-              }
-            ]
-          },
-          "required": false
+      "validations": [
+        {
+          "type": "GreaterThanChar",
+          "numValues": [
+            "1"
+          ],
+          "validationMessage": "Name must be longer than 1 character"
         }
-      },
-      "color": {
-        "label": "Color",
-        "inputType": {
-          "type": "SelectField",
+      ]
+    },
+    "color": {
+      "label": "Color",
+      "inputType": {
+        "type": "SelectField",
+        "bindingProperties": {},
+        "valueMappings": {
           "bindingProperties": {},
-            "valueMappings": {
-            "bindingProperties": {},
-              "values": [{"value": {"value": "Red"}}, {"value": {"value": "Blue"}}, {"value": {"value": "Green"}}]
+          "values": [
+            {
+              "value": {
+                "value": "Red"
+              }
+            },
+            {
+              "value": {
+                "value": "Blue"
+              }
+            },
+            {
+              "value": {
+                "value": "Green"
+              }
             }
+          ]
         }
       }
+    },
+    "age": {
+      "label": "Age",
+      "inputType": {
+        "type": "NumberField"
+      },
+      "validations": [
+        {
+          "type": "GreaterThanNum",
+          "numValues": [
+            "0"
+          ],
+          "validationMessage": "Age must be greater than 0"
+        }
+      ]
+    },
+    "email": {
+      "label": "Email",
+      "inputType": {
+        "type": "EmailField"
+      }
+    },
+    "ip": {
+      "label": "IP Address",
+      "inputType": {
+        "type": "IPAddressField",
+        "required": true
+      }
+    },
+    "breed": {
+      "label": "Breed",
+      "inputType": {
+        "type": "Autocomplete",
+        "valueMappings": {
+          "values": [
+            {
+              "value": {
+                "value": "Retriever"
+              }
+            },
+            {
+              "value": {
+                "value": "Shepherd"
+              }
+            }
+          ]
+        },
+        "required": false
+      }
+    }
   },
   "sectionalElements": {
-      "formHeading": {
-          "type": "Heading",
-          "position": {"fixed": "first"},
-          "text": "Register your dog"
-      }
+    "formHeading": {
+      "type": "Heading",
+      "position": {
+        "fixed": "first"
+      },
+      "text": "Register your dog"
+    }
   },
   "style": {},
   "cta": {},
+  "labelDecorator": "required",
   "schemaVersion": "1.0"
 }

--- a/packages/test-generator/lib/forms/custom-form-nested-json-create.json
+++ b/packages/test-generator/lib/forms/custom-form-nested-json-create.json
@@ -1,77 +1,78 @@
 {
-    "cta" : { },
-    "dataType" : {
-      "dataSourceType" : "Custom",
-      "dataTypeName" : "JSON"
+  "cta": {},
+  "dataType": {
+    "dataSourceType": "Custom",
+    "dataTypeName": "JSON"
+  },
+  "fields": {
+    "firstName": {
+      "inputType": {
+        "type": "TextField"
+      },
+      "label": "First name"
     },
-    "fields" : {
-      "firstName" : {
-        "inputType" : {
-          "type" : "TextField"
-        },
-        "label" : "First name"
+    "emailAddress": {
+      "inputType": {
+        "type": "EmailField"
       },
-      "emailAddress" : {
-        "inputType" : {
-          "type" : "EmailField"
-        },
-        "label" : "Email address"
-      },
-      "favoriteThings.animals" : {
-        "inputType" : {
-          "isArray" : true,
-          "type" : "TextField"
-        },
-        "label" : "Animals"
-      },
-      "favoriteThings.month" : {
-        "inputType" : {
-          "type" : "TextField"
-        },
-        "label" : "Month"
-      },
-      "favoriteThings.number" : {
-        "inputType" : {
-          "type" : "NumberField"
-        },
-        "label" : "Number"
-      },
-      "active" : {
-        "inputType" : {
-          "type" : "SwitchField"
-        },
-        "label" : "Active"
-      },
-      "enabled" : {
-        "inputType" : {
-          "type" : "SwitchField"
-        },
-        "label" : "Enabled"
-      }
+      "label": "Email address"
     },
-    "formActionType" : "create",
-    "name" : "CustomFormCreateNestedJson",
-    "schemaVersion" : "1.0",
-    "sectionalElements" : {
-      "favoriteThings" : {
-        "level" : 3,
-        "position" : {
-          "below" : "emailAddress"
-        },
-        "text" : "Favorite things",
-        "type" : "Heading"
+    "favoriteThings.animals": {
+      "inputType": {
+        "isArray": true,
+        "type": "TextField"
       },
-      "activeSectionalElement" : {
-        "orientation" : "horizontal",
-        "position" : {
-          "below" : "favoriteThings.number"
-        },
-        "type" : "Divider"
-      }
+      "label": "Animals"
     },
-    "style" : { },
-    "id" : "f-gqcrwPQpzC2aK41ibI",
-    "appId" : "d3oibjjn81cyer",
-    "environmentName" : "staging",
-    "createdAt" : "2022-11-03T22:05:00.463Z"
-  }
+    "favoriteThings.month": {
+      "inputType": {
+        "type": "TextField"
+      },
+      "label": "Month"
+    },
+    "favoriteThings.number": {
+      "inputType": {
+        "type": "NumberField"
+      },
+      "label": "Number"
+    },
+    "active": {
+      "inputType": {
+        "type": "SwitchField"
+      },
+      "label": "Active"
+    },
+    "enabled": {
+      "inputType": {
+        "type": "SwitchField"
+      },
+      "label": "Enabled"
+    }
+  },
+  "formActionType": "create",
+  "name": "CustomFormCreateNestedJson",
+  "schemaVersion": "1.0",
+  "sectionalElements": {
+    "favoriteThings": {
+      "level": 3,
+      "position": {
+        "below": "emailAddress"
+      },
+      "text": "Favorite things",
+      "type": "Heading"
+    },
+    "activeSectionalElement": {
+      "orientation": "horizontal",
+      "position": {
+        "below": "favoriteThings.number"
+      },
+      "type": "Divider"
+    }
+  },
+  "style": {},
+  "labelDecorator": "optional",
+  "id": "f-gqcrwPQpzC2aK41ibI",
+  "appId": "d3oibjjn81cyer",
+  "environmentName": "staging",
+  "createdAt": "2022-11-03T22:05:00.463Z"
+}

--- a/packages/test-generator/lib/forms/datastore-form-create-all-supported-form-fields.json
+++ b/packages/test-generator/lib/forms/datastore-form-create-all-supported-form-fields.json
@@ -7,6 +7,9 @@
     "dataTypeName": "AllSupportedFormFields"
   },
   "fields": {
+    "stringArray": {
+      "label": "String array"
+    },
     "HasOneUser": {
       "inputType": {
         "type": "Autocomplete",


### PR DESCRIPTION
## Problem
Add configured `* or  - optional` to form label

## Verification
### Manual tests
Add `labelDecorator` property to field config in form schema

### Automated tests
- [x] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.