### PR TITLE
fix: clear form button on create form resets select value incorrectly

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -2322,7 +2322,7 @@ export default function CustomDataForm(props) {
   const initialValues = {
     name: \\"John Doe\\",
     email: \\"johndoe@amplify.com\\",
-    city: undefined,
+    city: \\"\\",
     category: undefined,
     pages: 0,
     phone: \\"+1-401-152-6995\\",
@@ -2719,7 +2719,7 @@ export default function CustomDataForm(props) {
   const initialValues = {
     name: \\"John Doe\\",
     email: \\"johndoe@amplify.com\\",
-    city: undefined,
+    city: \\"\\",
     category: undefined,
     pages: 0,
     phone: \\"+1-401-152-6995\\",
@@ -3625,7 +3625,7 @@ export default function CustomDataForm(props) {
     name: \\"John Doe\\",
     email: \\"johndoe@amplify.com\\",
     \\"metadata-field\\": \\"\\",
-    city: undefined,
+    city: \\"\\",
     category: undefined,
     pages: 0,
   };
@@ -8201,7 +8201,7 @@ export default function NestedJson(props) {
     props;
   const initialValues = {
     firstName: \\"\\",
-    \\"last-Name\\": undefined,
+    \\"last-Name\\": \\"\\",
     lastName: [],
     bio: {},
   };
@@ -12748,15 +12748,14 @@ export default function TagCreateForm(props) {
     setCurrentPostsValue(undefined);
     setCurrentPostsDisplayValue(\\"\\");
     setStatuses(initialValues.statuses);
-    setCurrentStatusesValue(undefined);
+    setCurrentStatusesValue(\\"\\");
     setErrors({});
   };
   const [currentPostsDisplayValue, setCurrentPostsDisplayValue] =
     React.useState(\\"\\");
   const [currentPostsValue, setCurrentPostsValue] = React.useState(undefined);
   const PostsRef = React.createRef();
-  const [currentStatusesValue, setCurrentStatusesValue] =
-    React.useState(undefined);
+  const [currentStatusesValue, setCurrentStatusesValue] = React.useState(\\"\\");
   const statusesRef = React.createRef();
   const getIDValue = {
     Posts: (r) => JSON.stringify({ id: r?.id }),
@@ -12997,7 +12996,7 @@ export default function TagCreateForm(props) {
             values = result?.statuses ?? values;
           }
           setStatuses(values);
-          setCurrentStatusesValue(undefined);
+          setCurrentStatusesValue(\\"\\");
         }}
         currentFieldValue={currentStatusesValue}
         label={\\"Statuses\\"}
@@ -13007,7 +13006,7 @@ export default function TagCreateForm(props) {
         getBadgeText={getDisplayValue.statuses}
         setFieldValue={setCurrentStatusesValue}
         inputFieldRef={statusesRef}
-        defaultFieldValue={undefined}
+        defaultFieldValue={\\"\\"}
       >
         <SelectField
           label=\\"Statuses\\"
@@ -14902,15 +14901,14 @@ export default function TagCreateForm(props) {
     setCurrentPostsValue(undefined);
     setCurrentPostsDisplayValue(\\"\\");
     setStatuses(initialValues.statuses);
-    setCurrentStatusesValue(undefined);
+    setCurrentStatusesValue(\\"\\");
     setErrors({});
   };
   const [currentPostsDisplayValue, setCurrentPostsDisplayValue] =
     React.useState(\\"\\");
   const [currentPostsValue, setCurrentPostsValue] = React.useState(undefined);
   const PostsRef = React.createRef();
-  const [currentStatusesValue, setCurrentStatusesValue] =
-    React.useState(undefined);
+  const [currentStatusesValue, setCurrentStatusesValue] = React.useState(\\"\\");
   const statusesRef = React.createRef();
   const getIDValue = {
     Posts: (r) => JSON.stringify({ id: r?.id }),
@@ -15151,7 +15149,7 @@ export default function TagCreateForm(props) {
             values = result?.statuses ?? values;
           }
           setStatuses(values);
-          setCurrentStatusesValue(undefined);
+          setCurrentStatusesValue(\\"\\");
         }}
         currentFieldValue={currentStatusesValue}
         label={\\"Statuses\\"}
@@ -15161,7 +15159,7 @@ export default function TagCreateForm(props) {
         getBadgeText={getDisplayValue.statuses}
         setFieldValue={setCurrentStatusesValue}
         inputFieldRef={statusesRef}
-        defaultFieldValue={undefined}
+        defaultFieldValue={\\"\\"}
       >
         <SelectField
           label=\\"Statuses\\"
@@ -18019,7 +18017,7 @@ export default function TagUpdateForm(props) {
     setCurrentPostsValue(undefined);
     setCurrentPostsDisplayValue(\\"\\");
     setStatuses(cleanValues.statuses ?? []);
-    setCurrentStatusesValue(undefined);
+    setCurrentStatusesValue(\\"\\");
     setErrors({});
   };
   const [tagRecord, setTagRecord] = React.useState(tag);
@@ -18047,8 +18045,7 @@ export default function TagUpdateForm(props) {
     React.useState(\\"\\");
   const [currentPostsValue, setCurrentPostsValue] = React.useState(undefined);
   const PostsRef = React.createRef();
-  const [currentStatusesValue, setCurrentStatusesValue] =
-    React.useState(undefined);
+  const [currentStatusesValue, setCurrentStatusesValue] = React.useState(\\"\\");
   const statusesRef = React.createRef();
   const getIDValue = {
     Posts: (r) => JSON.stringify({ id: r?.id }),
@@ -18342,7 +18339,7 @@ export default function TagUpdateForm(props) {
             values = result?.statuses ?? values;
           }
           setStatuses(values);
-          setCurrentStatusesValue(undefined);
+          setCurrentStatusesValue(\\"\\");
         }}
         currentFieldValue={currentStatusesValue}
         label={\\"Statuses\\"}
@@ -18352,7 +18349,7 @@ export default function TagUpdateForm(props) {
         getBadgeText={getDisplayValue.statuses}
         setFieldValue={setCurrentStatusesValue}
         inputFieldRef={statusesRef}
-        defaultFieldValue={undefined}
+        defaultFieldValue={\\"\\"}
       >
         <SelectField
           label=\\"Statuses\\"
@@ -22291,7 +22288,7 @@ export default function PostCreateFormRow(props) {
     caption: \\"\\",
     post_url: \\"\\",
     profile_url: \\"\\",
-    status: undefined,
+    status: \\"\\",
     metadata: \\"\\",
     nonModelField: \\"\\",
     nonModelFieldArray: [],

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
@@ -154,6 +154,7 @@ export const getDefaultValueExpression = (
     CheckboxField: factory.createFalse(),
     TextField: factory.createStringLiteral(''),
     TextAreaField: factory.createStringLiteral(''),
+    SelectField: factory.createStringLiteral(''),
   };
 
   if (defaultValue) {

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomDog-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomDog-spec.cy.ts
@@ -47,9 +47,12 @@ describe('FormTests - CustomDog', () => {
       getInputByLabel('Email').type('jd@yahoo.com');
       cy.contains(ErrorMessageMap.validEmail).should('not.exist');
 
-      getInputByLabel('Color').type('Blue');
+      cy.get('select').select('Green').should('have.value', 'Green');
 
       cy.contains('Clear').click();
+
+      // validate select field is cleared
+      cy.get('select').should('have.value', '');
 
       // validates on blur & extends with onValidate prop
       getInputByLabel('Name').type('S');
@@ -68,7 +71,6 @@ describe('FormTests - CustomDog', () => {
 
       // clears and submits
       cy.contains('Clear').click();
-      cy.contains('color: Red');
       getInputByLabel('Name').type('Spot');
       blurField();
       getInputByLabel('Age').type('3');
@@ -77,6 +79,7 @@ describe('FormTests - CustomDog', () => {
       blurField();
       getInputByLabel('IP Address').type('192.0.2.146');
       blurField();
+      cy.get('select').select('Blue');
       typeInAutocomplete('Ret{downArrow}{enter}');
       cy.contains('Submit').click();
       cy.contains('submitted: true');
@@ -84,6 +87,7 @@ describe('FormTests - CustomDog', () => {
       cy.contains('age: 3');
       cy.contains('email: spot@yahoo.com');
       cy.contains('ip: 192.0.2.146');
+      cy.contains('color: Blue');
       cy.contains('Retriever');
     });
   });

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomDog-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form/CustomDog-spec.cy.ts
@@ -47,6 +47,8 @@ describe('FormTests - CustomDog', () => {
       getInputByLabel('Email').type('jd@yahoo.com');
       cy.contains(ErrorMessageMap.validEmail).should('not.exist');
 
+      getInputByLabel('Color').type('Blue');
+
       cy.contains('Clear').click();
 
       // validates on blur & extends with onValidate prop
@@ -66,6 +68,7 @@ describe('FormTests - CustomDog', () => {
 
       // clears and submits
       cy.contains('Clear').click();
+      cy.contains('color: Red');
       getInputByLabel('Name').type('Spot');
       blurField();
       getInputByLabel('Age').type('3');

--- a/packages/test-generator/integration-test-templates/src/FormTests/CustomDog.tsx
+++ b/packages/test-generator/integration-test-templates/src/FormTests/CustomDog.tsx
@@ -45,6 +45,7 @@ export default function () {
         <Text>{`email: ${customFormCreateDogResults.email}`}</Text>
         <Text>{`ip: ${customFormCreateDogResults.ip}`}</Text>
         <Text>{`ip: ${customFormCreateDogResults.breed}`}</Text>
+        <Text>{`color: ${customFormCreateDogResults.color}`}</Text>
       </View>
     </AmplifyProvider>
   );

--- a/packages/test-generator/lib/forms/custom-form-create-dog.json
+++ b/packages/test-generator/lib/forms/custom-form-create-dog.json
@@ -56,12 +56,11 @@
         }
       },
       "color": {
-        "label": "Color",
         "inputType": {
           "type": "SelectField",
+          "bindingProperties": {},
           "defaultValue": "Red",
           "valueMappings": {
-            "bindingProperties": {},
             "values": [{"value": {"value": "Red"}}, {"value": {"value": "Blue"}}, {"value": {"value": "Green"}}]
           }
         }

--- a/packages/test-generator/lib/forms/custom-form-create-dog.json
+++ b/packages/test-generator/lib/forms/custom-form-create-dog.json
@@ -56,10 +56,10 @@
         }
       },
       "color": {
+        "label": "Color",
         "inputType": {
           "type": "SelectField",
           "bindingProperties": {},
-          "defaultValue": "Red",
           "valueMappings": {
             "values": [{"value": {"value": "Red"}}, {"value": {"value": "Blue"}}, {"value": {"value": "Green"}}]
           }

--- a/packages/test-generator/lib/forms/custom-form-create-dog.json
+++ b/packages/test-generator/lib/forms/custom-form-create-dog.json
@@ -54,6 +54,17 @@
           },
           "required": false
         }
+      },
+      "color": {
+        "label": "Color",
+        "inputType": {
+          "type": "SelectField",
+          "defaultValue": "Red",
+          "valueMappings": {
+            "bindingProperties": {},
+            "values": [{"value": {"value": "Red"}}, {"value": {"value": "Blue"}}, {"value": {"value": "Green"}}]
+          }
+        }
       }
   },
   "sectionalElements": {


### PR DESCRIPTION
## Problem
The Clear button on a Create Form does not reset a SelectField correctly.

## Solution
Setting the value of a SelectField to an empty string `""` rather than `undefined` will correctly set the value of the field to the first option of the dropdown, either the Placeholder, or the first option if no placeholder exists.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.