### PR TITLE
feat: allow selectField or autoCompleteField to be used for String fi…

### DIFF
--- a/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
@@ -31,7 +31,7 @@ export const FIELD_TYPE_MAP: {
   },
   String: {
     defaultComponent: 'TextField',
-    supportedComponents: new Set(['TextAreaField', 'TextField', 'PasswordField']),
+    supportedComponents: new Set(['TextAreaField', 'TextField', 'PasswordField', 'Autocomplete', 'SelectField']),
   },
   Int: {
     defaultComponent: 'NumberField',


### PR DESCRIPTION
…elds

## Problem
Currently, users cannot use an Autocomplete or Select component to map to a "String" field in a data-bound form.

## Solution
Allows Autocomplete and Select components to represent a "String" field in a data-bound form.

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - Handled by type checking
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.