### PR TITLE
feat: support between predicates

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -799,6 +799,7 @@ export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
     width?: Number;
     backgroundColor?: String;
     buttonColor?: UserPreferences;
+    buttonEnabled?: UserPreferences;
     items?: any[];
     overrideItems?: (collectionItem: {
       item: any;
@@ -815,6 +816,7 @@ export default function CollectionOfCustomButtons(
     width,
     backgroundColor,
     buttonColor: buttonColorProp,
+    buttonEnabled: buttonEnabledProp,
     items,
     overrideItems,
     overrides,
@@ -824,6 +826,12 @@ export default function CollectionOfCustomButtons(
     and: [
       { field: \\"age\\", operand: \\"10\\", operator: \\"gt\\" },
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
+      {
+        and: [
+          { field: \\"date\\", operator: \\"ge\\", operand: \\"2022-03-10\\" },
+          { field: \\"date\\", operator: \\"le\\", operand: \\"2023-03-11\\" },
+        ],
+      },
     ],
   };
   const buttonUserFilter = createDataStorePredicate<User>(buttonUserFilterObj);
@@ -854,6 +862,24 @@ export default function CollectionOfCustomButtons(
   }).items[0];
   const buttonColor =
     buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;
+  const buttonEnabledFilterObj = {
+    and: [
+      { field: \\"date\\", operator: \\"ge\\", operand: \\"2022-03-10\\" },
+      { field: \\"date\\", operator: \\"le\\", operand: \\"2023-03-11\\" },
+    ],
+  };
+  const buttonEnabledFilter = createDataStorePredicate<UserPreferences>(
+    buttonEnabledFilterObj
+  );
+  const buttonEnabledDataStore = useDataStoreBinding({
+    type: \\"collection\\",
+    model: UserPreferences,
+    criteria: buttonEnabledFilter,
+  }).items[0];
+  const buttonEnabled =
+    buttonEnabledProp !== undefined
+      ? buttonEnabledProp
+      : buttonEnabledDataStore;
   return (
     /* @ts-ignore: TS2322 */
     <Collection

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -37,6 +37,7 @@ import {
   getBreakpoints,
   isValidVariableName,
   InternalError,
+  resolveBetweenPredicateToMultiplePredicates,
 } from '@aws-amplify/codegen-ui';
 import { EOL } from 'os';
 import ts, {
@@ -1437,6 +1438,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
   private predicateToObjectLiteralExpression(predicate: StudioComponentPredicate): ObjectLiteralExpression {
     const { operandType, ...filteredPredicate } = predicate;
+
+    if (filteredPredicate.operator === 'between') {
+      return this.predicateToObjectLiteralExpression(resolveBetweenPredicateToMultiplePredicates(predicate));
+    }
+
     const objectAssignments = Object.entries(filteredPredicate).map(([key, value]) => {
       if (key === 'and' || key === 'or') {
         return factory.createPropertyAssignment(

--- a/packages/codegen-ui/example-schemas/collectionWithBinding.json
+++ b/packages/codegen-ui/example-schemas/collectionWithBinding.json
@@ -35,6 +35,17 @@
           "operator": "eq"
         }
       }
+    },
+    "buttonEnabled": {
+      "type": "Data",
+      "bindingProperties": {
+        "model": "UserPreferences",
+        "predicate": {
+          "field": "date",
+          "operand": "2022-03-10<Amplify.OperandDelimiter>2023-03-11",
+          "operator": "between"
+      }
+      }
     }
   },
   "collectionProperties": {
@@ -51,6 +62,11 @@
             "field": "lastName",
             "operand": "L",
             "operator": "beginsWith"
+          },
+          {
+            "field": "date",
+            "operand": "2022-03-10<Amplify.OperandDelimiter>2023-03-11",
+            "operator": "between"
           }
         ]
       }

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generate-spec.cy.ts
@@ -70,6 +70,7 @@ const EXPECTED_SUCCESSFUL_CASES = new Set([
   'CollectionWithBindingItemsName',
   'CompositeDogCard',
   'CollectionWithCompositeKeysAndRelationships',
+  'CollectionWithBetweenPredicate',
   'PaginatedCollection',
   'SearchableCollection',
   'CustomParent',

--- a/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/generated-components-spec.cy.ts
@@ -236,6 +236,15 @@ describe('Generated Components', () => {
         cy.contains('Toys: stick, ball');
       });
     });
+
+    it('Supports between predicates', () => {
+      cy.get('#collectionWithBetweenPredicate').within(() => {
+        cy.contains('Real');
+        cy.contains('Last');
+        cy.contains('Another').should('not.exist');
+        cy.contains('Too Young').should('not.exist');
+      });
+    });
   });
 
   describe('Default Value', () => {

--- a/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
+++ b/packages/test-generator/integration-test-templates/src/ComponentTests.tsx
@@ -61,6 +61,7 @@ import {
   ComponentWithAuthBinding,
   DataBindingNamedClass,
   CollectionWithCompositeKeysAndRelationships,
+  CollectionWithBetweenPredicate,
 } from './ui-components'; // eslint-disable-line import/extensions
 import { initializeAuthMockData } from './mock-utils';
 
@@ -420,6 +421,7 @@ export default function ComponentTests() {
             };
           }}
         />
+        <CollectionWithBetweenPredicate id="collectionWithBetweenPredicate" />
       </div>
       <div id="default-value">
         <h2>Default Value</h2>

--- a/packages/test-generator/lib/components/collections/collectionWithBetweenPredicate.json
+++ b/packages/test-generator/lib/components/collections/collectionWithBetweenPredicate.json
@@ -1,0 +1,59 @@
+{
+  "id": "1234-5678-9010",
+  "componentType": "Collection",
+  "name": "CollectionWithBetweenPredicate",
+  "properties": {
+    "type": {
+      "value": "list"
+    },
+    "isPaginated": {
+      "value": true
+    },
+    "gap": {
+      "value": "1.5rem"
+    }
+  },
+  "bindingProperties": {},
+  "collectionProperties": {
+    "buttonUser": {
+      "model": "User",
+      "predicate": {
+        "and": [
+          {
+            "field": "age",
+            "operand": "5<Amplify.OperandDelimiter>71",
+            "operator": "between"
+          },
+          {
+            "field": "lastName",
+            "operand": "LUser0",
+            "operator": "ne"
+          }
+        ]
+      }
+    }
+  },
+  "children": [
+    {
+      "componentType": "Flex",
+      "name": "MyFlex",
+      "properties": {},
+      "children": [
+        {
+          "componentType": "Button",
+          "name": "MyButton",
+          "properties": {
+            "children": {
+              "collectionBindingProperties": {
+                "property": "buttonUser",
+                "field": "firstName"
+              },
+              "defaultValue": "hspain@gmail.com"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "schemaVersion": "1.0"
+}

--- a/packages/test-generator/lib/components/collections/index.ts
+++ b/packages/test-generator/lib/components/collections/index.ts
@@ -21,3 +21,4 @@ export { default as PaginatedCollection } from './paginatedCollection.json';
 export { default as SearchableCollection } from './searchableCollection.json';
 export { default as SimpleUserCollection } from './simpleUserCollection.json';
 export { default as CollectionWithCompositeKeysAndRelationships } from './collectionWithCompositeKeysAndRelationships.json';
+export { default as CollectionWithBetweenPredicate } from './collectionWithBetweenPredicate.json';


### PR DESCRIPTION
## Problem
predicates with operator `between` are currently not supported because it requires 2 operands.

## Solution
1. add a way to handle 2 operands
2. resolve `between` predicates into combined predicate of `le` and `ge`

## Additional Notes
Alternatives explored:
- Adding `operandList: string[]` to `StudioComponentPredicate` to handle multiple operands: was advised against bloating model.
- Changing the `createDataStorePredicate` helper to handle 2 operands: still an option. Breaking down the `between` predicate just avoided 1) submitting change to `amplify-ui` and 2) waiting for the release and 3) updating Studio w/ the release and updating CLI dep warning w/ the release

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.