### PR TITLE
chore(release): v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.10.0...v2.11.0) (2023-03-20)
+
+
+### Bug Fixes
+
+* renames model variable name from props for update forms ([#950](https://github.com/aws-amplify/amplify-codegen-ui/issues/950)) ([3c64288](https://github.com/aws-amplify/amplify-codegen-ui/commit/3c64288f7783600229fb9050fcd8366b7cafa909))
+
+
+### Features
+
+* support between predicates ([#947](https://github.com/aws-amplify/amplify-codegen-ui/issues/947)) ([fa0daaf](https://github.com/aws-amplify/amplify-codegen-ui/commit/fa0daafd9c99f4a1986885a58bbc67200782df03))
+
+
+
+
+
 # [2.10.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.9.0...v2.10.0) (2023-03-18)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "packages/*"
   ],
   "exact": true,
-  "version": "2.10.0",
+  "version": "2.11.0",
   "command": {
     "version": {
       "message": "chore(release): %s"

--- a/packages/codegen-ui-golden-files/CHANGELOG.md
+++ b/packages/codegen-ui-golden-files/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.10.0...v2.11.0) (2023-03-20)
+
+**Note:** Version bump only for package @aws-amplify/codegen-ui-golden-files
+
+
+
+
+
 # [2.10.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.9.0...v2.10.0) (2023-03-18)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui-golden-files

--- a/packages/codegen-ui-golden-files/package-lock.json
+++ b/packages/codegen-ui-golden-files/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/codegen-ui-golden-files",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/codegen-ui-golden-files/package.json
+++ b/packages/codegen-ui-golden-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-golden-files",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Models of outputs to customer project",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",
@@ -11,7 +11,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.10.0",
+    "@aws-amplify/codegen-ui": "2.11.0",
     "@aws-amplify/datastore": "^3.12.12",
     "@aws-amplify/ui-react": "^3.5.7",
     "aws-amplify": "^4.3.37",

--- a/packages/codegen-ui-react/CHANGELOG.md
+++ b/packages/codegen-ui-react/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.10.0...v2.11.0) (2023-03-20)
+
+
+### Bug Fixes
+
+* renames model variable name from props for update forms ([#950](https://github.com/aws-amplify/amplify-codegen-ui/issues/950)) ([3c64288](https://github.com/aws-amplify/amplify-codegen-ui/commit/3c64288f7783600229fb9050fcd8366b7cafa909))
+
+
+### Features
+
+* support between predicates ([#947](https://github.com/aws-amplify/amplify-codegen-ui/issues/947)) ([fa0daaf](https://github.com/aws-amplify/amplify-codegen-ui/commit/fa0daafd9c99f4a1986885a58bbc67200782df03))
+
+
+
+
+
 # [2.10.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.9.0...v2.10.0) (2023-03-18)
 
 

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/codegen-ui-react",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Amplify UI React code generation implementation",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -30,7 +30,7 @@
     "semver": "^7.3.5"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.10.0",
+    "@aws-amplify/codegen-ui": "2.11.0",
     "@typescript/vfs": "~1.3.5",
     "typescript": "<=4.5.0"
   },

--- a/packages/codegen-ui/CHANGELOG.md
+++ b/packages/codegen-ui/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.10.0...v2.11.0) (2023-03-20)
+
+
+### Bug Fixes
+
+* renames model variable name from props for update forms ([#950](https://github.com/aws-amplify/amplify-codegen-ui/issues/950)) ([3c64288](https://github.com/aws-amplify/amplify-codegen-ui/commit/3c64288f7783600229fb9050fcd8366b7cafa909))
+
+
+### Features
+
+* support between predicates ([#947](https://github.com/aws-amplify/amplify-codegen-ui/issues/947)) ([fa0daaf](https://github.com/aws-amplify/amplify-codegen-ui/commit/fa0daafd9c99f4a1986885a58bbc67200782df03))
+
+
+
+
+
 # [2.10.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.9.0...v2.10.0) (2023-03-18)
 
 

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/codegen-ui",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "generic component code generation interface definitions",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",

--- a/packages/test-generator/CHANGELOG.md
+++ b/packages/test-generator/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.10.0...v2.11.0) (2023-03-20)
+
+
+### Bug Fixes
+
+* renames model variable name from props for update forms ([#950](https://github.com/aws-amplify/amplify-codegen-ui/issues/950)) ([3c64288](https://github.com/aws-amplify/amplify-codegen-ui/commit/3c64288f7783600229fb9050fcd8366b7cafa909))
+
+
+### Features
+
+* support between predicates ([#947](https://github.com/aws-amplify/amplify-codegen-ui/issues/947)) ([fa0daaf](https://github.com/aws-amplify/amplify-codegen-ui/commit/fa0daafd9c99f4a1986885a58bbc67200782df03))
+
+
+
+
+
 # [2.10.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.9.0...v2.10.0) (2023-03-18)
 
 

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/codegen-ui-test-generator",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Test generator with sample JSON files",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -19,8 +19,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.10.0",
-    "@aws-amplify/codegen-ui-react": "2.10.0",
+    "@aws-amplify/codegen-ui": "2.11.0",
+    "@aws-amplify/codegen-ui-react": "2.11.0",
     "@types/node": "^15.12.1",
     "loglevel": "^1.7.1",
     "typescript": "^4.2.4"


### PR DESCRIPTION
Release for:
- Sev2 bug fix for colliding datamodel and variable name for update form