### PR TITLE
chore: stop throwing for unhandled relationship indexes

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/helpers/model-fields-configs.test.ts
@@ -505,6 +505,61 @@ describe('mapModelFieldsConfigs', () => {
     });
   });
 
+  it('should handle invalid relationship indexes with default', () => {
+    const formDefinition: FormDefinition = getBasicFormDefinition();
+
+    const dataSchema: GenericDataSchema = {
+      dataSourceType: 'DataStore',
+      enums: {},
+      nonModels: {},
+      models: {
+        CompositeDog: {
+          fields: {
+            compositeDogCompositeBowlSize: {
+              dataType: 'String',
+              required: false,
+              readOnly: false,
+              isArray: false,
+              relationship: {
+                type: 'HAS_ONE',
+                relatedModelName: 'CompositeBowl',
+              },
+            },
+          },
+          primaryKeys: ['name'],
+        },
+      },
+    };
+
+    const modelFieldsConfigs = mapModelFieldsConfigs({
+      dataTypeName: 'CompositeDog',
+      formDefinition,
+      dataSchema,
+      featureFlags: { isRelationshipSupported: true },
+    });
+
+    expect(modelFieldsConfigs.compositeDogCompositeBowlSize.inputType?.valueMappings).toStrictEqual({
+      values: [
+        {
+          value: {
+            bindingProperties: {
+              property: 'CompositeBowl',
+              field: 'id',
+            },
+          },
+        },
+      ],
+      bindingProperties: {
+        CompositeBowl: {
+          type: 'Data',
+          bindingProperties: {
+            model: 'CompositeBowl',
+          },
+        },
+      },
+    });
+  });
+
   it('should add not-model type relationship fields to configs and matrix if HAS_ONE & hasMany index', () => {
     const formDefinition: FormDefinition = getBasicFormDefinition();
 

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/model-fields-configs.ts
@@ -17,7 +17,7 @@
 import { sentenceCase } from 'change-case';
 import { checkIsSupportedAsFormField } from '../../check-support';
 
-import { InternalError, InvalidInputError } from '../../errors';
+import { InvalidInputError } from '../../errors';
 import {
   FieldTypeMapKeys,
   FormDefinition,
@@ -103,7 +103,8 @@ function extractCorrespondingKey({
     }
   }
 
-  throw new InternalError(`Cannot find corresponding key for scalar relationship field ${relationshipFieldName}`);
+  // defaultValue for unhandled cases
+  return 'id';
 }
 
 export function getFieldTypeMapKey(field: GenericDataField): FieldTypeMapKeys {


### PR DESCRIPTION
## Problem
We are encountering customers running into the error `Cannot find corresponding key for scalar relationship field`. It is technically correct to throw this as a service fault when we can't handle a schema. We handled one such case in this PR: https://github.com/aws-amplify/amplify-codegen-ui/pull/953.
But there may be other types of schemas we do not yet handle.

## Solution
Mitigate the issue by setting a default that will handle all cases except custom primary keys instead of throwing.

Q: Aren't we just masking the issue and generating potentially broken forms?
A: Setting the default to `id` will handle all cases except CPKs. Even if the form is broken, customers would be able to use the generated form to update non-relationship fields.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.