### PR TITLE
Update cypress get to contains for DS tests

### DIFF
--- a/packages/test-generator/integration-test-templates/cypress/e2e/form/DSCar-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form/DSCar-spec.cy.ts
@@ -29,7 +29,7 @@ describe('FormTests - DSCar', () => {
       clickAddToArray();
       cy.contains('Submit').click();
 
-      cy.get('.results').then((recordElement: JQuery) => {
+      cy.contains('.results', /Tustin Toyota/).then((recordElement: JQuery) => {
         const record = JSON.parse(recordElement.text());
 
         expect(record.dealership.name).to.equal('Tustin Toyota');

--- a/packages/test-generator/integration-test-templates/cypress/e2e/form/DSDealership-spec.cy.ts
+++ b/packages/test-generator/integration-test-templates/cypress/e2e/form/DSDealership-spec.cy.ts
@@ -29,7 +29,7 @@ describe('FormTests - DSDealership', () => {
       clickAddToArray();
       cy.contains('Submit').click();
 
-      cy.get('.results').then((recordElement: JQuery) => {
+      cy.contains('.results', /Toyota/).then((recordElement: JQuery) => {
         const record = JSON.parse(recordElement.text());
 
         expect(record.cars[0].name).to.equal('Toyota');


### PR DESCRIPTION
## Problem
Integration tests for some datastore forms are failing due to the results taking too long to render for cypress.

## Solution
Updating `cy.get('.results').then(...` to `cy.contains('.results', {desiredResult}).then(...` forces cypress to wait for results to render where we are expecting them to.

## Additional Notes
This pattern matches other datastore form tests where we don't have issues.

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->
After the update, ran `npm run integ` locally and tests are consistently passing after several runs.

### Automated tests
- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.