### PR TITLE
chore: downgrade yarn to 1.18.0 for check action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,9 @@ jobs:
         run: npx lerna exec npm pack
       - name: Build amplify-cli
         working-directory: amplify-cli
-        run: yarn setup-dev
+        run: |
+          yarn policies set-version 1.18.0
+          yarn setup-dev
       - name: Install updated codegen libraries
         working-directory: amplify-cli/packages/amplify-util-uibuilder
         run: |
@@ -49,6 +51,7 @@ jobs:
       - name: Build amplify-cli with updated codegen libraries
         working-directory: amplify-cli
         run: |
+          yarn policies set-version 1.18.0
           yarn dev-build
       - name: Create a test react app
         run: npx create-react-app e2e-test-app


### PR DESCRIPTION
## Problem
`amplify-cli-tests` are consistently failing during either the `Build amplify-cli` or `Install updated codegen libraries` steps.

## Solution
Downgrade yarn to v1.18.0 for both of these steps.

## Additional Notes
Previously tested with downgrading to yarn v1.19.0 but still fails, our last PRs that passed `amplify-cli-tests` were using v1.18.0.

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - (only updated Github action `check.yml`)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.