### PR TITLE
feat: generate form definition with file uploader config

### DIFF
--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -107,7 +107,7 @@ describe('generateFormDefinition', () => {
     });
   });
 
-  describe('form with FileUploaderFields', () => {
+  describe('forms with StorageField', () => {
     it('should generate form definition with default values from minimal config', () => {
       const result = generateFormDefinition({
         form: {
@@ -119,14 +119,7 @@ describe('generateFormDefinition', () => {
           formActionType: 'create',
           fields: {
             imgKeys: {
-              label: 'Images',
-              inputType: {
-                type: 'FileUploaderField',
-                fileUploaderConfig: {
-                  accessLevel: 'public',
-                  acceptedFileTypes: ['images/*', '.pdf'],
-                },
-              },
+              inputType: { type: 'StorageField' },
             },
           },
           sectionalElements: {},
@@ -150,23 +143,23 @@ describe('generateFormDefinition', () => {
 
       expect(result.elements).toStrictEqual({
         imgKeys: {
-          componentType: 'FileUploaderField',
+          componentType: 'StorageField',
           dataType: 'String',
           isArray: true,
           props: {
-            acceptedFileTypes: ['images/*', '.pdf'],
-            accessLevel: 'public',
+            acceptedFileTypes: [],
+            accessLevel: 'private',
             isReadOnly: false,
             isRequired: false,
             isResumable: false,
-            label: 'Images',
+            label: 'Img keys',
             showThumbnails: true,
           },
         },
       });
     });
 
-    it('should generate form definition with default values from minimal config', () => {
+    it('should generate form definition that matches the studio form shape', () => {
       const result = generateFormDefinition({
         form: {
           name: 'UpdateProductForm',
@@ -179,7 +172,7 @@ describe('generateFormDefinition', () => {
             imgKeys: {
               label: 'Images',
               inputType: {
-                type: 'FileUploaderField',
+                type: 'StorageField',
                 fileUploaderConfig: {
                   accessLevel: 'protected',
                   acceptedFileTypes: ['.txt', '.pdf'],
@@ -212,7 +205,7 @@ describe('generateFormDefinition', () => {
 
       expect(result.elements).toStrictEqual({
         imgKeys: {
-          componentType: 'FileUploaderField',
+          componentType: 'StorageField',
           dataType: 'String',
           isArray: false,
           props: {

--- a/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
+++ b/packages/codegen-ui/lib/__tests__/generate-form-definition/generate-form-definition.test.ts
@@ -107,6 +107,130 @@ describe('generateFormDefinition', () => {
     });
   });
 
+  describe('form with FileUploaderFields', () => {
+    it('should generate form definition with default values from minimal config', () => {
+      const result = generateFormDefinition({
+        form: {
+          name: 'CreateProductForm',
+          dataType: {
+            dataSourceType: 'DataStore',
+            dataTypeName: 'Product',
+          },
+          formActionType: 'create',
+          fields: {
+            imgKeys: {
+              label: 'Images',
+              inputType: {
+                type: 'FileUploaderField',
+                fileUploaderConfig: {
+                  accessLevel: 'public',
+                  acceptedFileTypes: ['images/*', '.pdf'],
+                },
+              },
+            },
+          },
+          sectionalElements: {},
+          style: {},
+          cta: {},
+        },
+        dataSchema: {
+          dataSourceType: 'DataStore',
+          enums: {},
+          nonModels: {},
+          models: {
+            Product: {
+              primaryKeys: ['id'],
+              fields: {
+                imgKeys: { dataType: 'String', readOnly: false, required: false, isArray: true },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.elements).toStrictEqual({
+        imgKeys: {
+          componentType: 'FileUploaderField',
+          dataType: 'String',
+          isArray: true,
+          props: {
+            acceptedFileTypes: ['images/*', '.pdf'],
+            accessLevel: 'public',
+            isReadOnly: false,
+            isRequired: false,
+            isResumable: false,
+            label: 'Images',
+            showThumbnails: true,
+          },
+        },
+      });
+    });
+
+    it('should generate form definition with default values from minimal config', () => {
+      const result = generateFormDefinition({
+        form: {
+          name: 'UpdateProductForm',
+          dataType: {
+            dataSourceType: 'DataStore',
+            dataTypeName: 'Product',
+          },
+          formActionType: 'update',
+          fields: {
+            imgKeys: {
+              label: 'Images',
+              inputType: {
+                type: 'FileUploaderField',
+                fileUploaderConfig: {
+                  accessLevel: 'protected',
+                  acceptedFileTypes: ['.txt', '.pdf'],
+                  showThumbnails: false,
+                  isResumable: true,
+                  maxFileCount: 5,
+                  maxSize: 1024,
+                },
+              },
+            },
+          },
+          sectionalElements: {},
+          style: {},
+          cta: {},
+        },
+        dataSchema: {
+          dataSourceType: 'DataStore',
+          enums: {},
+          nonModels: {},
+          models: {
+            Product: {
+              primaryKeys: ['id'],
+              fields: {
+                imgKeys: { dataType: 'String', readOnly: false, required: false, isArray: false },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.elements).toStrictEqual({
+        imgKeys: {
+          componentType: 'FileUploaderField',
+          dataType: 'String',
+          isArray: false,
+          props: {
+            acceptedFileTypes: ['.txt', '.pdf'],
+            accessLevel: 'protected',
+            isReadOnly: false,
+            isRequired: false,
+            isResumable: true,
+            label: 'Images',
+            showThumbnails: false,
+            maxFileCount: 5,
+            maxSize: 1024,
+          },
+        },
+      });
+    });
+  });
+
   it('should throw if form has source type DataStore, but no schema is available', () => {
     expect(() =>
       generateFormDefinition({

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/defaults.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/defaults.ts
@@ -36,6 +36,7 @@ export const FORM_DEFINITION_DEFAULTS = {
       valueMappings: { values: [{ value: { value: 'Option' } }] },
       fileUploaderConfig: {
         accessLevel: 'private',
+        acceptedFileTypes: [],
         isResumable: false,
         showThumbnails: true,
       },

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/defaults.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/defaults.ts
@@ -34,6 +34,11 @@ export const FORM_DEFINITION_DEFAULTS = {
       value: 'fieldName',
       name: 'fieldName',
       valueMappings: { values: [{ value: { value: 'Option' } }] },
+      fileUploaderConfig: {
+        accessLevel: 'private',
+        isResumable: false,
+        showThumbnails: true,
+      },
     },
     radioGroupFieldBooleanDisplayValue: { true: 'Yes', false: 'No' },
   },

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
@@ -31,7 +31,14 @@ export const FIELD_TYPE_MAP: {
   },
   String: {
     defaultComponent: 'TextField',
-    supportedComponents: new Set(['TextAreaField', 'TextField', 'PasswordField', 'Autocomplete', 'SelectField']),
+    supportedComponents: new Set([
+      'TextAreaField',
+      'TextField',
+      'PasswordField',
+      'Autocomplete',
+      'SelectField',
+      'FileUploaderField',
+    ]),
   },
   Int: {
     defaultComponent: 'NumberField',

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/field-type-map.ts
@@ -37,7 +37,7 @@ export const FIELD_TYPE_MAP: {
       'PasswordField',
       'Autocomplete',
       'SelectField',
-      'FileUploaderField',
+      'StorageField',
     ]),
   },
   Int: {

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -22,6 +22,7 @@ import {
   FieldValidationConfiguration,
   ValidationTypes,
   DataFieldDataType,
+  StorageAccessLevel,
 } from '../../types';
 import { InternalError, InvalidInputError } from '../../errors';
 import { FORM_DEFINITION_DEFAULTS } from './defaults';
@@ -193,6 +194,7 @@ export function getFormDefinitionInputElement(
 
   const defaultStringValue = getFirstString([config.inputType?.defaultValue, baseConfig?.inputType?.defaultValue]);
   const isRequiredValue = getFirstDefinedValue([config.inputType?.required, baseConfig?.inputType?.required]);
+
   let formDefinitionElement: FormDefinitionInputElement;
 
   switch (componentType) {
@@ -366,6 +368,46 @@ export function getFormDefinitionInputElement(
           defaultValue: defaultStringValue,
         },
         valueMappings: mergeValueMappings(baseConfig?.inputType?.valueMappings, config.inputType?.valueMappings),
+      };
+      break;
+
+    case 'FileUploaderField':
+      formDefinitionElement = {
+        componentType: 'FileUploaderField',
+        props: {
+          label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
+          descriptiveText: config.inputType?.descriptiveText ?? baseConfig?.inputType?.descriptiveText,
+          isRequired: isRequiredValue,
+          isReadOnly: getFirstDefinedValue([config.inputType?.readOnly, baseConfig?.inputType?.readOnly]),
+          defaultValue: defaultStringValue,
+
+          accessLevel: getFirstDefinedValue([
+            config.inputType?.fileUploaderConfig?.accessLevel,
+            baseConfig?.inputType?.fileUploaderConfig?.accessLevel,
+          ]) as StorageAccessLevel,
+          acceptedFileTypes: getFirstDefinedValue([
+            config.inputType?.fileUploaderConfig?.acceptedFileTypes,
+            baseConfig?.inputType?.fileUploaderConfig?.acceptedFileTypes,
+          ]) as string[],
+          isResumable: getFirstDefinedValue([
+            config.inputType?.fileUploaderConfig?.isResumable,
+            baseConfig?.inputType?.fileUploaderConfig?.isResumable,
+            FORM_DEFINITION_DEFAULTS.field.inputType.fileUploaderConfig.isResumable,
+          ]),
+          showThumbnails: getFirstDefinedValue([
+            config.inputType?.fileUploaderConfig?.showThumbnails,
+            baseConfig?.inputType?.fileUploaderConfig?.showThumbnails,
+            FORM_DEFINITION_DEFAULTS.field.inputType.fileUploaderConfig.showThumbnails,
+          ]),
+          maxFileCount: getFirstDefinedValue([
+            config.inputType?.fileUploaderConfig?.maxFileCount,
+            baseConfig?.inputType?.fileUploaderConfig?.maxFileCount,
+          ]),
+          maxSize: getFirstDefinedValue([
+            config.inputType?.fileUploaderConfig?.maxSize,
+            baseConfig?.inputType?.fileUploaderConfig?.maxSize,
+          ]),
+        },
       };
       break;
 

--- a/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
+++ b/packages/codegen-ui/lib/generate-form-definition/helpers/form-field.ts
@@ -371,9 +371,9 @@ export function getFormDefinitionInputElement(
       };
       break;
 
-    case 'FileUploaderField':
+    case 'StorageField':
       formDefinitionElement = {
-        componentType: 'FileUploaderField',
+        componentType: 'StorageField',
         props: {
           label: config.label || baseConfig?.label || FORM_DEFINITION_DEFAULTS.field.inputType.label,
           descriptiveText: config.inputType?.descriptiveText ?? baseConfig?.inputType?.descriptiveText,
@@ -384,10 +384,12 @@ export function getFormDefinitionInputElement(
           accessLevel: getFirstDefinedValue([
             config.inputType?.fileUploaderConfig?.accessLevel,
             baseConfig?.inputType?.fileUploaderConfig?.accessLevel,
+            FORM_DEFINITION_DEFAULTS.field.inputType.fileUploaderConfig.accessLevel,
           ]) as StorageAccessLevel,
           acceptedFileTypes: getFirstDefinedValue([
             config.inputType?.fileUploaderConfig?.acceptedFileTypes,
             baseConfig?.inputType?.fileUploaderConfig?.acceptedFileTypes,
+            FORM_DEFINITION_DEFAULTS.field.inputType.fileUploaderConfig.acceptedFileTypes,
           ]) as string[],
           isResumable: getFirstDefinedValue([
             config.inputType?.fileUploaderConfig?.isResumable,

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -128,8 +128,8 @@ export type FormDefinitionStepperFieldElement = {
   };
 };
 
-export type FormDefinitionFileUploaderFieldElement = {
-  componentType: 'FileUploaderField';
+export type FormDefinitionStorageFieldElement = {
+  componentType: 'StorageField';
   props: {
     label: string;
     descriptiveText?: string;
@@ -209,7 +209,7 @@ export type FormDefinitionInputElement = (
   | FormDefinitionRadioGroupFieldElement
   | FormDefinitionPasswordFieldElement
   | FormDefinitionAutocompleteElement
-  | FormDefinitionFileUploaderFieldElement
+  | FormDefinitionStorageFieldElement
 ) &
   FormDefinitionInputElementCommon;
 

--- a/packages/codegen-ui/lib/types/form/form-definition-element.ts
+++ b/packages/codegen-ui/lib/types/form/form-definition-element.ts
@@ -128,6 +128,23 @@ export type FormDefinitionStepperFieldElement = {
   };
 };
 
+export type FormDefinitionFileUploaderFieldElement = {
+  componentType: 'FileUploaderField';
+  props: {
+    label: string;
+    descriptiveText?: string;
+    isRequired?: boolean;
+    isReadOnly?: boolean;
+    defaultValue?: string;
+    accessLevel: StorageAccessLevel;
+    acceptedFileTypes: string[];
+    showThumbnails?: boolean;
+    isResumable?: boolean;
+    maxFileCount?: number;
+    maxSize?: number;
+  };
+};
+
 export type FormDefinitionToggleButtonElement = {
   componentType: 'ToggleButton';
   props: {
@@ -192,6 +209,7 @@ export type FormDefinitionInputElement = (
   | FormDefinitionRadioGroupFieldElement
   | FormDefinitionPasswordFieldElement
   | FormDefinitionAutocompleteElement
+  | FormDefinitionFileUploaderFieldElement
 ) &
   FormDefinitionInputElementCommon;
 
@@ -219,3 +237,5 @@ export type FormDefinitionElement =
   | FormDefinitionInputElement
   | FormDefinitionSectionalElement
   | FormDefinitionButtonElement;
+
+export type StorageAccessLevel = 'public' | 'protected' | 'private';

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -73,7 +73,7 @@ export type FormInputType =
   | 'EmailField'
   | 'JSONField'
   | 'Autocomplete'
-  | 'FileUploaderField';
+  | 'StorageField';
 
 export * from './form-definition-element';
 export * from './style';

--- a/packages/codegen-ui/lib/types/form/index.ts
+++ b/packages/codegen-ui/lib/types/form/index.ts
@@ -72,7 +72,8 @@ export type FormInputType =
   | 'URLField'
   | 'EmailField'
   | 'JSONField'
-  | 'Autocomplete';
+  | 'Autocomplete'
+  | 'FileUploaderField';
 
 export * from './form-definition-element';
 export * from './style';

--- a/packages/codegen-ui/lib/types/form/input-config.ts
+++ b/packages/codegen-ui/lib/types/form/input-config.ts
@@ -68,4 +68,20 @@ export type StudioFieldInputConfig = {
   value?: string;
 
   isArray?: boolean;
+
+  fileUploaderConfig?: {
+    accessLevel: StorageAccessLevel;
+
+    acceptedFileTypes: string[];
+
+    showThumbnails?: boolean;
+
+    isResumable?: boolean;
+
+    maxFileCount?: number;
+
+    maxSize?: number;
+  };
 };
+
+export type StorageAccessLevel = 'public' | 'protected' | 'private';


### PR DESCRIPTION
## Problem
To support new field type on form builder: FileUploaderField

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [X] Unit tests added/updated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.