### PR TITLE
fix: add default value on nested inputs to avoid console errors

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -7657,7 +7657,7 @@ export default function HappyPathJSONCreate(props) {
       ></Heading>
       <TextField
         label=\\"First name\\"
-        value={basics[\\"firstName\\"]}
+        value={basics[\\"firstName\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -7684,7 +7684,7 @@ export default function HappyPathJSONCreate(props) {
       ></TextField>
       <TextField
         label=\\"Email address\\"
-        value={basics[\\"emailAddress\\"]}
+        value={basics[\\"emailAddress\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -7764,7 +7764,7 @@ export default function HappyPathJSONCreate(props) {
       </ArrayField>
       <TextField
         label=\\"Month\\"
-        value={favoriteThings[\\"month\\"]}
+        value={favoriteThings[\\"month\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -7793,7 +7793,7 @@ export default function HappyPathJSONCreate(props) {
         label=\\"Number\\"
         type=\\"number\\"
         step=\\"any\\"
-        value={favoriteThings[\\"number\\"]}
+        value={favoriteThings[\\"number\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -8254,7 +8254,7 @@ export default function HappyPathJSONUpdate(props) {
       ></Heading>
       <TextField
         label=\\"First name\\"
-        value={basics[\\"firstName\\"]}
+        value={basics[\\"firstName\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -8281,7 +8281,7 @@ export default function HappyPathJSONUpdate(props) {
       ></TextField>
       <TextField
         label=\\"Email address\\"
-        value={basics[\\"emailAddress\\"]}
+        value={basics[\\"emailAddress\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -8361,7 +8361,7 @@ export default function HappyPathJSONUpdate(props) {
       </ArrayField>
       <TextField
         label=\\"Month\\"
-        value={favoriteThings[\\"month\\"]}
+        value={favoriteThings[\\"month\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -8390,7 +8390,7 @@ export default function HappyPathJSONUpdate(props) {
         label=\\"Number\\"
         type=\\"number\\"
         step=\\"any\\"
-        value={favoriteThings[\\"number\\"]}
+        value={favoriteThings[\\"number\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -8917,7 +8917,7 @@ export default function NestedJson(props) {
       ></Heading>
       <TextField
         label=\\"favoriteQuote\\"
-        value={bio[\\"favorite Quote\\"]}
+        value={bio[\\"favorite Quote\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -8947,7 +8947,7 @@ export default function NestedJson(props) {
       ></TextField>
       <TextField
         label=\\"favoriteAnimal\\"
-        value={bio[\\"favorite-Animal\\"]}
+        value={bio[\\"favorite-Animal\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -9657,7 +9657,7 @@ export default function NestedJson(props) {
       ></Heading>
       <TextField
         label=\\"favoriteQuote\\"
-        value={bio[\\"favoriteQuote\\"]}
+        value={bio[\\"favoriteQuote\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {
@@ -9684,7 +9684,7 @@ export default function NestedJson(props) {
       ></TextField>
       <TextField
         label=\\"favoriteAnimal\\"
-        value={bio[\\"favoriteAnimal\\"]}
+        value={bio[\\"favoriteAnimal\\"] ?? \\"\\"}
         onChange={(e) => {
           let { value } = e.target;
           if (onChange) {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/value-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/value-props.ts
@@ -15,7 +15,7 @@
  */
 
 import { FieldConfigMetadata, StudioDataSourceType, StudioFormActionType } from '@aws-amplify/codegen-ui';
-import { factory, Identifier, JsxAttribute, SyntaxKind, ElementAccessExpression } from 'typescript';
+import { factory, Identifier, JsxAttribute, SyntaxKind, Expression } from 'typescript';
 import { getCurrentDisplayValueName, getCurrentValueName, resetValuesName } from './form-state';
 import { shouldWrapInArrayField } from './render-checkers';
 import { FIELD_TYPE_TO_TYPESCRIPT_MAP } from './typescript-type-map';
@@ -125,16 +125,19 @@ export const renderValueAttribute = ({
   if (fieldConfig.isArray) {
     renderedFieldName = getCurrentValueName(renderedFieldName);
   }
-  let fieldNameIdentifier: Identifier | ElementAccessExpression = factory.createIdentifier(renderedFieldName);
+  let fieldNameIdentifier: Identifier | Expression = factory.createIdentifier(renderedFieldName);
 
   // If a component has a '.', it's nested and needs an object ref.
   // but if it's an array, it needs to use the currentArrayValue whether it's nested or not
   // The ArrayField component will update the nested value.
   if (componentName.includes('.') && !fieldConfig.isArray) {
     const [parent, child] = componentName.split('.');
-    fieldNameIdentifier = factory.createElementAccessExpression(
-      factory.createIdentifier(parent),
-      factory.createStringLiteral(child),
+    // if it's nested default to an empty string because initial value is undefined.
+    // favoriteThings["animals"] ?? ""
+    fieldNameIdentifier = factory.createBinaryExpression(
+      factory.createElementAccessExpression(factory.createIdentifier(parent), factory.createStringLiteral(child)),
+      factory.createToken(SyntaxKind.QuestionQuestionToken),
+      factory.createStringLiteral(''),
     );
   }
 


### PR DESCRIPTION
## Problem
<!-- Why are we making this code change? -->

Nested inputs have an initial value that is undefined. This causes console errors "uncontrolled to controlled component"

## Solution
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

Add a fallback defined value if it's a nested form field.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

https://github.com/aws-amplify/amplify-studio/issues/817

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.