### PR TITLE
chore: set yarn network concurrency to 1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: amplify-cli
         run: |
           yarn policies set-version 1.18.0
-          yarn setup-dev
+          yarn setup-dev --network-concurrency 1
       - name: Install updated codegen libraries
         working-directory: amplify-cli/packages/amplify-util-uibuilder
         run: |
@@ -52,7 +52,7 @@ jobs:
         working-directory: amplify-cli
         run: |
           yarn policies set-version 1.18.0
-          yarn dev-build
+          yarn dev-build --network-concurrency 1
       - name: Create a test react app
         run: npx create-react-app e2e-test-app
       - name: Install test app dependencies


### PR DESCRIPTION
## Problem
<!-- Why are we making this code change? -->
Check workflows intermittently fail due to missing/corrupt dependencies:
```
yarn run v1.18.0
$ yarn dev-build && yarn rm-dev-link && yarn link-dev && yarn rm-aa-dev-link && yarn link-aa-dev
$ yarn --cache-folder ~/.cache/yarn && nx run-many --target=build --all
[1/4] Resolving packages...
[2/4] Fetching packages...
[1/4] Resolving packages...
[2/4] Fetching packages...
error https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, open '/home/runner/.cache/yarn/v4/npm-type-fest-0.21.3-d260a24b0198436e[13](https://github.com/aws-amplify/amplify-codegen-ui/actions/runs/4599600666/jobs/8125169244#step:7:14)3fa26a524a6d65fa3b2e37/node_modules/type-fest/source/set-required.d.ts'"
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```
## Solution
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
Set yarn concurrency to mitigate until yarn v2.
## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->
Removed setting yarn version to 1.18.0, which was a previous attempt to fix the problem.
## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - only changes to workflow
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.