### PR TITLE
Updating StorageManager codegen prop onUploadSuccess

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -24938,7 +24938,7 @@ export default function CreateProductForm(props) {
       >
         <StorageManager
           ref={imgKeysRef}
-          onFileSuccess={(files) => {
+          onUploadSuccess={(files) => {
             let value = files.map(({ s3Key }) => s3Key);
             if (onChange) {
               const modelFields = {
@@ -25154,7 +25154,7 @@ export default function UpdateProductForm(props) {
         <StorageManager
           ref={imgKeysRef}
           defaultFiles={imgKeys.map((s3Key) => ({ s3Key }))}
-          onFileSuccess={(files) => {
+          onUploadSuccess={(files) => {
             let value = files.map(({ s3Key }) => s3Key);
             if (onChange) {
               const modelFields = {
@@ -25374,7 +25374,7 @@ export default function UpdateProductForm(props) {
         <StorageManager
           ref={singleImgKeyRef}
           defaultFiles={[{ s3Key: singleImgKey }]}
-          onFileSuccess={(files) => {
+          onUploadSuccess={(files) => {
             let value = files?.[0]?.s3Key;
             if (onChange) {
               const modelFields = {

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -653,7 +653,7 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toMatchSnapshot();
     });
 
-    it.only('should render a update form with StorageField on non-array field', () => {
+    it('should render a update form with StorageField on non-array field', () => {
       const { componentText } = generateWithAmplifyFormRenderer(
         'forms/product-datastore-update-non-array',
         'datastore/product-non-array',

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
@@ -267,7 +267,7 @@ export const buildOverrideOnChangeStatement = (
 function getOnValueChangeProp(fieldType: string): string {
   const map: { [key: string]: string } = {
     StepperField: 'onStepChange',
-    StorageField: 'onFileSuccess',
+    StorageField: 'onUploadSuccess',
   };
 
   return map[fieldType] ?? 'onChange';

--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -34,7 +34,7 @@ export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<
       },
       {
         dependencyName: '@aws-amplify/ui-react-storage',
-        supportedSemVerPattern: '^1.0.1',
+        supportedSemVerPattern: '^1.0.2',
         reason: 'Required to leverage StorageManager.',
       },
     ];


### PR DESCRIPTION
## Problem
The rendered StorageManager component is using incorrect prop name. 
onFileSuccess -> onUploadSuccess

## Solution
Updating the prop name to onUploadSuccess

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [X] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.