### PR TITLE
fix: address yarn failures during check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,7 @@ jobs:
         working-directory: amplify-cli
         run: |
           yarn --network-concurrency 1 --cache-folder ~/.cache/yarn
+          yarn policies set-version 1.18.0
           yarn setup-dev
       - name: Install updated codegen libraries
         working-directory: amplify-cli/packages/amplify-util-uibuilder
@@ -52,6 +53,7 @@ jobs:
         working-directory: amplify-cli
         run: |
           yarn --network-concurrency 1 --cache-folder ~/.cache/yarn
+          yarn policies set-version 1.18.0
           yarn dev-build
       - name: Create a test react app
         run: npx create-react-app e2e-test-app

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build amplify-cli
         working-directory: amplify-cli
         run: |
-          yarn --network-concurrency 1 --cache-folder ~/.cache/yarn
+          yarn --network-concurrency 1
           yarn policies set-version 1.18.0
           yarn setup-dev
       - name: Install updated codegen libraries
@@ -52,7 +52,7 @@ jobs:
       - name: Build amplify-cli with updated codegen libraries
         working-directory: amplify-cli
         run: |
-          yarn --network-concurrency 1 --cache-folder ~/.cache/yarn
+          yarn --network-concurrency 1
           yarn policies set-version 1.18.0
           yarn dev-build
       - name: Create a test react app

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Build amplify-cli
         working-directory: amplify-cli
         run: |
+          yarn policies set-version 1.18.0
           yarn --network-concurrency 1
-          # yarn policies set-version 1.18.0
           yarn setup-dev
       - name: Install updated codegen libraries
         working-directory: amplify-cli/packages/amplify-util-uibuilder
@@ -52,8 +52,8 @@ jobs:
       - name: Build amplify-cli with updated codegen libraries
         working-directory: amplify-cli
         run: |
+          yarn policies set-version 1.18.0
           yarn --network-concurrency 1
-          # yarn policies set-version 1.18.0
           yarn dev-build
       - name: Create a test react app
         run: npx create-react-app e2e-test-app

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: amplify-cli
         run: |
           yarn --network-concurrency 1
-          yarn policies set-version 1.18.0
+          # yarn policies set-version 1.18.0
           yarn setup-dev
       - name: Install updated codegen libraries
         working-directory: amplify-cli/packages/amplify-util-uibuilder
@@ -53,7 +53,7 @@ jobs:
         working-directory: amplify-cli
         run: |
           yarn --network-concurrency 1
-          yarn policies set-version 1.18.0
+          # yarn policies set-version 1.18.0
           yarn dev-build
       - name: Create a test react app
         run: npx create-react-app e2e-test-app

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build amplify-cli
         working-directory: amplify-cli
         run: |
-          yarn policies set-version 1.18.0
+          yarn --network-concurrency 1 --cache-folder ~/.cache/yarn
           yarn setup-dev
       - name: Install updated codegen libraries
         working-directory: amplify-cli/packages/amplify-util-uibuilder
@@ -51,7 +51,7 @@ jobs:
       - name: Build amplify-cli with updated codegen libraries
         working-directory: amplify-cli
         run: |
-          yarn policies set-version 1.18.0
+          yarn --network-concurrency 1 --cache-folder ~/.cache/yarn
           yarn dev-build
       - name: Create a test react app
         run: npx create-react-app e2e-test-app


### PR DESCRIPTION
## Problem
we run integration tests that call yarn setup-dev. It's been failing at this step ([see example log](https://github.com/aws-amplify/amplify-codegen-ui/actions/runs/4619674637/jobs/8168733246)).

## Solution
See this PR for context - https://github.com/aws-amplify/amplify-cli/pull/12389

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.