### PR TITLE
fix: change handlers and props for StorageField

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -24936,20 +24936,33 @@ export default function CreateProductForm(props) {
         isReadOnly={false}
       >
         <StorageManager
-          onUploadSuccess={(files) => {
-            let value = files.map(({ key }) => key);
-            if (onChange) {
-              const modelFields = {
-                name,
-                imgKeys: value,
-              };
-              const result = onChange(modelFields);
-              value = result?.imgKeys ?? value;
-            }
-            if (errors.imgKeys?.hasError) {
-              runValidationTasks(\\"imgKeys\\", value);
-            }
-            setImgKeys(value);
+          onUploadSuccess={({ key }) => {
+            setImgKeys((prev) => {
+              let value = [...prev, key];
+              if (onChange) {
+                const modelFields = {
+                  name,
+                  imgKeys: value,
+                };
+                const result = onChange(modelFields);
+                value = result?.imgKeys ?? value;
+              }
+              return value;
+            });
+          }}
+          onFileRemove={({ key }) => {
+            setImgKeys((prev) => {
+              let value = prev.filter((f) => f !== key);
+              if (onChange) {
+                const modelFields = {
+                  name,
+                  imgKeys: value,
+                };
+                const result = onChange(modelFields);
+                value = result?.imgKeys ?? value;
+              }
+              return value;
+            });
           }}
           accessLevel={\\"protected\\"}
           acceptedFileTypes={[\\".txt\\", \\".pdf\\"]}
@@ -25150,20 +25163,33 @@ export default function UpdateProductForm(props) {
       >
         <StorageManager
           defaultFiles={imgKeys.map((key) => ({ key }))}
-          onUploadSuccess={(files) => {
-            let value = files.map(({ key }) => key);
-            if (onChange) {
-              const modelFields = {
-                name,
-                imgKeys: value,
-              };
-              const result = onChange(modelFields);
-              value = result?.imgKeys ?? value;
-            }
-            if (errors.imgKeys?.hasError) {
-              runValidationTasks(\\"imgKeys\\", value);
-            }
-            setImgKeys(value);
+          onUploadSuccess={({ key }) => {
+            setImgKeys((prev) => {
+              let value = [...prev, key];
+              if (onChange) {
+                const modelFields = {
+                  name,
+                  imgKeys: value,
+                };
+                const result = onChange(modelFields);
+                value = result?.imgKeys ?? value;
+              }
+              return value;
+            });
+          }}
+          onFileRemove={({ key }) => {
+            setImgKeys((prev) => {
+              let value = prev.filter((f) => f !== key);
+              if (onChange) {
+                const modelFields = {
+                  name,
+                  imgKeys: value,
+                };
+                const result = onChange(modelFields);
+                value = result?.imgKeys ?? value;
+              }
+              return value;
+            });
           }}
           accessLevel={\\"private\\"}
           acceptedFileTypes={[\\".doc\\", \\".pdf\\"]}
@@ -25367,21 +25393,34 @@ export default function UpdateProductForm(props) {
         isReadOnly={false}
       >
         <StorageManager
-          defaultFiles={[{ key: singleImgKey }]}
-          onUploadSuccess={(files) => {
-            let value = files?.[0]?.key;
-            if (onChange) {
-              const modelFields = {
-                name,
-                singleImgKey: value,
-              };
-              const result = onChange(modelFields);
-              value = result?.singleImgKey ?? value;
-            }
-            if (errors.singleImgKey?.hasError) {
-              runValidationTasks(\\"singleImgKey\\", value);
-            }
-            setSingleImgKey(value);
+          defaultFiles={singleImgKey ? [{ key: singleImgKey }] : undefined}
+          onUploadSuccess={({ key }) => {
+            setSingleImgKey((prev) => {
+              let value = key;
+              if (onChange) {
+                const modelFields = {
+                  name,
+                  singleImgKey: value,
+                };
+                const result = onChange(modelFields);
+                value = result?.singleImgKey ?? value;
+              }
+              return value;
+            });
+          }}
+          onFileRemove={({ key }) => {
+            setSingleImgKey((prev) => {
+              let value = initialValues?.singleImgKey;
+              if (onChange) {
+                const modelFields = {
+                  name,
+                  singleImgKey: value,
+                };
+                const result = onChange(modelFields);
+                value = result?.singleImgKey ?? value;
+              }
+              return value;
+            });
           }}
           accessLevel={\\"protected\\"}
           acceptedFileTypes={[\\".txt\\", \\".pdf\\"]}

--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -34,7 +34,7 @@ export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<
       },
       {
         dependencyName: '@aws-amplify/ui-react-storage',
-        supportedSemVerPattern: '^1.0.2',
+        supportedSemVerPattern: '^1.0.1',
         reason: 'Required to leverage StorageManager.',
       },
     ];

--- a/packages/codegen-ui-react/lib/utils/forms/storage-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/storage-field-component.ts
@@ -24,7 +24,7 @@ import {
 } from '@aws-amplify/codegen-ui';
 import { factory, JsxAttribute, JsxAttributeLike, JsxElement, JsxExpression, SyntaxKind } from 'typescript';
 import { getDecoratedLabel } from '../../forms/form-renderer-helper';
-import { buildOnChangeStatement } from '../../forms/form-renderer-helper/event-handler-props';
+import { buildStorageManagerOnChangeStatement } from '../../forms/form-renderer-helper/event-handler-props';
 import { propertyToExpression } from '../../react-component-render-helper';
 import { STORAGE_FILE_KEY } from '../constants';
 
@@ -78,7 +78,7 @@ export const renderStorageFieldComponent = (
             undefined,
             factory.createCallExpression(
               factory.createPropertyAccessExpression(
-                factory.createIdentifier('imgKeys'),
+                factory.createIdentifier(componentName),
                 factory.createIdentifier('map'),
               ),
               undefined,
@@ -118,19 +118,25 @@ export const renderStorageFieldComponent = (
           )
         : factory.createJsxExpression(
             undefined,
-            factory.createArrayLiteralExpression(
-              [
-                factory.createObjectLiteralExpression(
-                  [
-                    factory.createPropertyAssignment(
-                      factory.createIdentifier(STORAGE_FILE_KEY),
-                      factory.createIdentifier('singleImgKey'),
-                    ),
-                  ],
-                  false,
-                ),
-              ],
-              false,
+            factory.createConditionalExpression(
+              factory.createIdentifier(componentName),
+              factory.createToken(SyntaxKind.QuestionToken),
+              factory.createArrayLiteralExpression(
+                [
+                  factory.createObjectLiteralExpression(
+                    [
+                      factory.createPropertyAssignment(
+                        factory.createIdentifier('key'),
+                        factory.createIdentifier(componentName),
+                      ),
+                    ],
+                    false,
+                  ),
+                ],
+                false,
+              ),
+              factory.createToken(SyntaxKind.ColonToken),
+              factory.createIdentifier('undefined'),
             ),
           );
 
@@ -139,7 +145,8 @@ export const renderStorageFieldComponent = (
       );
     }
 
-    storageManagerAttributes.push(buildOnChangeStatement(component, fieldConfigs));
+    storageManagerAttributes.push(buildStorageManagerOnChangeStatement(component, fieldConfigs, 'onUploadSuccess'));
+    storageManagerAttributes.push(buildStorageManagerOnChangeStatement(component, fieldConfigs, 'onFileRemove'));
     fieldAttributes.push(
       factory.createJsxAttribute(
         factory.createIdentifier('errorMessage'),


### PR DESCRIPTION
## Problem
- onUploadSuccess was not working
- onFileRemove was missing
- defaultFiles was hard-coded and also throwing when value was null
- change ui-react-storage recommendation to 1.0.1 - we thought they would have to rev to 1.0.2 but don't.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.