### PR TITLE
fix: address icon regression

### DIFF
--- a/packages/codegen-ui-react/lib/react-component-render-helper.ts
+++ b/packages/codegen-ui-react/lib/react-component-render-helper.ts
@@ -193,14 +193,12 @@ export function buildFixedLiteralExpression(
   const { value, type } = prop;
   switch (typeof value) {
     case 'number':
-      return factory.createNumericLiteral(value as number, undefined);
+      return factory.createNumericLiteral(value, undefined);
     case 'boolean':
       return value ? factory.createTrue() : factory.createFalse();
     case 'string':
+      return fixedPropertyWithTypeToLiteral(value, type);
     case 'object':
-      if (type !== 'object') {
-        return fixedPropertyWithTypeToLiteral(value as string, type);
-      }
       if (value instanceof Date) {
         throw new Error('Date object is not currently supported for fixed literal expression.');
       }

--- a/packages/codegen-ui-react/lib/utils/forms/storage-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/storage-field-component.ts
@@ -192,9 +192,6 @@ export const renderStorageFieldComponent = (
     if (isStorageManagerKey(key)) {
       let storageManagerValue = value;
 
-      if (key === 'acceptedFileTypes') {
-        storageManagerValue = { ...value, value: (value as any).value.split(',') };
-      }
       if (key === 'maxFileCount' && !fieldConfigs[componentName].isArray) {
         storageManagerValue = { ...value, value: 1 };
       }

--- a/packages/codegen-ui/lib/utils/form-to-component/map-form-definition-to-component.ts
+++ b/packages/codegen-ui/lib/utils/form-to-component/map-form-definition-to-component.ts
@@ -26,7 +26,11 @@ import { ctaButtonMapper, addCTAPosition } from './helpers/map-cta-buttons';
 const mapFormElementProps = (element: FormDefinitionElement) => {
   const props: StudioComponentProperties = {};
   Object.entries(element.props).forEach(([key, value]) => {
-    props[key] = { value: `${value}`, type: `${typeof value}` };
+    if (Array.isArray(value)) {
+      props[key] = { value: JSON.stringify(value), type: 'object' };
+    } else {
+      props[key] = { value: `${value}`, type: `${typeof value}` };
+    }
   });
   return props;
 };


### PR DESCRIPTION
## Problem
Icon processing is broken because the schemas are saved with lower-cased `"object"` as the value type. We had added a condition that starts rendering this type as a string instead of an actual array.

## Solution
Remove the condition and move it into the form-definition-to-component mapper instead. Testing added by the way of setting the type of that property to lower case "object"

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - (provide a reason) - the fact that no tests are updated is telling.
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.