### PR TITLE
test: add coverage for icon regression fix

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -8839,6 +8839,51 @@ export default function IconPrimitive(
 "
 `;
 
+exports[`amplify render tests primitives Icon with lower-cased type \`object\` for values 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Icon, IconProps } from \\"@aws-amplify/ui-react\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type IconPrimitiveWithLowerCasedTypeOverridesProps = {
+  IconPrimitiveWithLowerCasedType?: PrimitiveOverrideProps<IconProps>;
+} & EscapeHatchProps;
+export type IconPrimitiveWithLowerCasedTypeProps = React.PropsWithChildren<
+  Partial<IconProps> & {
+    overrides?:
+      | IconPrimitiveWithLowerCasedTypeOverridesProps
+      | undefined
+      | null;
+  }
+>;
+export default function IconPrimitiveWithLowerCasedType(
+  props: IconPrimitiveWithLowerCasedTypeProps
+): React.ReactElement {
+  const { overrides, ...rest } = props;
+  return (
+    /* @ts-ignore: TS2322 */
+    <Icon
+      ariaLabel=\\"Favorite\\"
+      viewBox={{ width: 24, height: 24 }}
+      paths={[
+        {
+          d: \\"M18 6V4h2V2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h14v-2h-4.03c1.23-.91 2.03-2.36 2.03-4v-5H8v5c0 1.64.81 3.09 2.03 4H6V4h2v2c0 .55.45 1 1 1h8c.55 0 1-.45 1-1z\\",
+          fill: \\"black\\",
+        },
+      ]}
+      {...getOverrideProps(overrides, \\"IconPrimitiveWithLowerCasedType\\")}
+      {...rest}
+    ></Icon>
+  );
+}
+"
+`;
+
 exports[`amplify render tests primitives Menu 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -608,6 +608,10 @@ describe('amplify render tests', () => {
     test('Icon', () => {
       expect(generateWithAmplifyRenderer('primitives/IconPrimitive').componentText).toMatchSnapshot();
     });
+
+    test('Icon with lower-cased type `object` for values', () => {
+      expect(generateWithAmplifyRenderer('primitives/IconPrimitiveWithLowerCasedType').componentText).toMatchSnapshot();
+    });
   });
 
   describe('icon-indices', () => {

--- a/packages/codegen-ui/example-schemas/primitives/IconPrimitiveWithLowerCasedType.json
+++ b/packages/codegen-ui/example-schemas/primitives/IconPrimitiveWithLowerCasedType.json
@@ -1,0 +1,20 @@
+{
+    "id": "1234-5678-9010",
+    "componentType": "Icon",
+    "name": "IconPrimitiveWithLowerCasedType",
+    "properties": {
+      "ariaLabel": {
+        "value": "Favorite"
+      },
+      "viewBox": {
+        "type": "object",
+        "value": "{\"width\": 24, \"height\": 24}"
+      },
+      "paths": {
+        "type": "object",
+        "value": "[{\"d\":\"M18 6V4h2V2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h14v-2h-4.03c1.23-.91 2.03-2.36 2.03-4v-5H8v5c0 1.64.81 3.09 2.03 4H6V4h2v2c0 .55.45 1 1 1h8c.55 0 1-.45 1-1z\",\"fill\":\"black\"}]"
+      }
+    },
+    "schemaVersion": "1.0"
+  }
+  


### PR DESCRIPTION
## Change
The PR fixing icon regression did not have enough coverage: https://github.com/aws-amplify/amplify-codegen-ui/commit/d913b932b0edda5c148299d6ffe8d6dadbe72ac7
This adds coverage.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.