### PR TITLE
chore: improve runtime safety of validation builder

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`form-render utils createValidationExpression handles undefined numValues 1`] = `
+"[
+    { type: \\"Contains\\", strValues: [\\"chard\\"] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles undefined strValues 1`] = `
+"[
+    { type: \\"GreaterThanNum\\", numValues: [9] }
+]"
+`;
+
 exports[`form-render utils should generate before & complete types if datastore config is set 1`] = `
 "{
     clearOnSuccess?: boolean;

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/__snapshots__/form-renderer-helper.test.ts.snap
@@ -1,14 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`form-render utils createValidationExpression handles undefined numValues 1`] = `
+exports[`form-render utils createValidationExpression handles BeAfter with undefined numValues 1`] = `
+"[
+    { type: \\"BeAfter\\", strValues: [\\"chard\\"] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles BeBefore with undefined numValues 1`] = `
+"[
+    { type: \\"BeBefore\\", strValues: [\\"chard\\"] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles Contains with undefined numValues 1`] = `
 "[
     { type: \\"Contains\\", strValues: [\\"chard\\"] }
 ]"
 `;
 
-exports[`form-render utils createValidationExpression handles undefined strValues 1`] = `
+exports[`form-render utils createValidationExpression handles EndWith with undefined numValues 1`] = `
+"[
+    { type: \\"EndWith\\", strValues: [\\"chard\\"] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles EqualTo with undefined strValues 1`] = `
+"[
+    { type: \\"EqualTo\\", numValues: [9] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles GreaterThanChar with undefined strValues 1`] = `
+"[
+    { type: \\"GreaterThanChar\\", numValues: [9] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles GreaterThanNum with undefined strValues 1`] = `
 "[
     { type: \\"GreaterThanNum\\", numValues: [9] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles LessThanChar with undefined strValues 1`] = `
+"[
+    { type: \\"LessThanChar\\", numValues: [9] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles LessThanNum with undefined strValues 1`] = `
+"[
+    { type: \\"LessThanNum\\", numValues: [9] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles NotContains with undefined numValues 1`] = `
+"[
+    { type: \\"NotContains\\", strValues: [\\"chard\\"] }
+]"
+`;
+
+exports[`form-render utils createValidationExpression handles StartWith with undefined numValues 1`] = `
+"[
+    { type: \\"StartWith\\", strValues: [\\"chard\\"] }
 ]"
 `;
 

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
@@ -13,10 +13,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { StudioForm } from '@aws-amplify/codegen-ui';
+import { StudioForm, ValidationTypes } from '@aws-amplify/codegen-ui';
 import { EmitHint, Node } from 'typescript';
 import { buildFormPropNode } from '../../forms';
 import { buildPrinter, defaultRenderConfig } from '../../react-studio-template-renderer-helper';
+import { createValidationExpression } from '../../forms/form-renderer-helper/validation';
 
 describe('form-render utils', () => {
   let printNode: (node: Node) => string;
@@ -103,6 +104,33 @@ describe('form-render utils', () => {
     expect(node).toContain('id?: {');
     expect(node).toContain('myKey: string;');
     expect(node).toContain('description: number;');
+    expect(node).toMatchSnapshot();
+  });
+
+  test.each([
+    [
+      'undefined strValues',
+      [
+        {
+          strValues: undefined,
+          numValues: [9],
+          type: ValidationTypes.GREATER_THAN_NUM,
+        } as any,
+      ],
+    ],
+    [
+      'undefined numValues',
+      [
+        {
+          strValues: ['chard'],
+          numValues: undefined,
+          type: ValidationTypes.CONTAINS,
+        } as any,
+      ],
+    ],
+  ])('createValidationExpression handles %s', (description, rules) => {
+    const expression = createValidationExpression(rules);
+    const node = printNode(expression);
     expect(node).toMatchSnapshot();
   });
 });

--- a/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-forms/form-renderer-helper.test.ts
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import { StudioForm, ValidationTypes } from '@aws-amplify/codegen-ui';
+import { StudioForm, ValidationTypeMapping } from '@aws-amplify/codegen-ui';
 import { EmitHint, Node } from 'typescript';
 import { buildFormPropNode } from '../../forms';
 import { buildPrinter, defaultRenderConfig } from '../../react-studio-template-renderer-helper';
@@ -107,28 +107,29 @@ describe('form-render utils', () => {
     expect(node).toMatchSnapshot();
   });
 
-  test.each([
-    [
-      'undefined strValues',
-      [
-        {
-          strValues: undefined,
-          numValues: [9],
-          type: ValidationTypes.GREATER_THAN_NUM,
-        } as any,
-      ],
-    ],
-    [
-      'undefined numValues',
+  test.each(
+    ValidationTypeMapping.StringType.map<[string, any[]]>((type) => [
+      `${type} with undefined numValues`,
       [
         {
           strValues: ['chard'],
           numValues: undefined,
-          type: ValidationTypes.CONTAINS,
+          type,
         } as any,
       ],
-    ],
-  ])('createValidationExpression handles %s', (description, rules) => {
+    ]).concat(
+      ValidationTypeMapping.NumberType.map<[string, any[]]>((type) => [
+        `${type} with undefined strValues`,
+        [
+          {
+            strValues: undefined,
+            numValues: [9],
+            type,
+          } as any,
+        ],
+      ]),
+    ),
+  )('createValidationExpression handles %s', (description, rules) => {
     const expression = createValidationExpression(rules);
     const node = printNode(expression);
     expect(node).toMatchSnapshot();

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/validation.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/validation.ts
@@ -22,14 +22,21 @@ import {
   ObjectLiteralExpression,
   PropertyAssignment,
 } from 'typescript';
-import { FieldValidationConfiguration, isValidVariableName } from '@aws-amplify/codegen-ui';
+import { FieldValidationConfiguration, ValidationTypes, isValidVariableName } from '@aws-amplify/codegen-ui';
 
 export const createValidationExpression = (validationRules: FieldValidationConfiguration[] = []): Expression => {
   const validateExpressions = validationRules.map<ObjectLiteralExpression>((rule) => {
     const elements: ObjectLiteralElementLike[] = [
       factory.createPropertyAssignment(factory.createIdentifier('type'), factory.createStringLiteral(rule.type)),
     ];
-    if ('strValues' in rule) {
+    if (
+      rule.type === ValidationTypes.CONTAINS ||
+      rule.type === ValidationTypes.NOT_CONTAINS ||
+      rule.type === ValidationTypes.END_WITH ||
+      rule.type === ValidationTypes.START_WITH ||
+      rule.type === ValidationTypes.BE_BEFORE ||
+      rule.type === ValidationTypes.BE_AFTER
+    ) {
       elements.push(
         factory.createPropertyAssignment(
           factory.createIdentifier('strValues'),
@@ -39,8 +46,13 @@ export const createValidationExpression = (validationRules: FieldValidationConfi
           ),
         ),
       );
-    }
-    if ('numValues' in rule) {
+    } else if (
+      rule.type === ValidationTypes.LESS_THAN_CHAR_LENGTH ||
+      rule.type === ValidationTypes.GREATER_THAN_CHAR_LENGTH ||
+      rule.type === ValidationTypes.LESS_THAN_NUM ||
+      rule.type === ValidationTypes.GREATER_THAN_NUM ||
+      rule.type === ValidationTypes.EQUAL_TO_NUM
+    ) {
       elements.push(
         factory.createPropertyAssignment(
           factory.createIdentifier('numValues'),


### PR DESCRIPTION
## Problem
True, typescript-wise, `strValues` and `numValues` should be defined if they exist as keys on  `FieldValidationConfiguration`, but we just had a regression where the UI was passing in values like `strValues: null`, causing rendering errors.

## Solution
Check that the value exists before further processing.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.