### PR TITLE
fix: update form with storage field should render with existing files

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -25391,6 +25391,7 @@ export default function UpdateProductForm(props) {
         errorMessage={errors.singleImgKey?.errorMessage}
         hasError={errors.singleImgKey?.hasError}
         label={\\"Single Image\\"}
+        descriptiveText={\\"Limited to One Image\\"}
         isRequired={false}
         isReadOnly={false}
       >

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -25161,41 +25161,43 @@ export default function UpdateProductForm(props) {
         isRequired={false}
         isReadOnly={false}
       >
-        <StorageManager
-          defaultFiles={imgKeys.map((key) => ({ key }))}
-          onUploadSuccess={({ key }) => {
-            setImgKeys((prev) => {
-              let value = [...prev, key];
-              if (onChange) {
-                const modelFields = {
-                  name,
-                  imgKeys: value,
-                };
-                const result = onChange(modelFields);
-                value = result?.imgKeys ?? value;
-              }
-              return value;
-            });
-          }}
-          onFileRemove={({ key }) => {
-            setImgKeys((prev) => {
-              let value = prev.filter((f) => f !== key);
-              if (onChange) {
-                const modelFields = {
-                  name,
-                  imgKeys: value,
-                };
-                const result = onChange(modelFields);
-                value = result?.imgKeys ?? value;
-              }
-              return value;
-            });
-          }}
-          accessLevel={\\"private\\"}
-          acceptedFileTypes={[\\".doc\\", \\".pdf\\"]}
-          isResumable={false}
-          showThumbnails={true}
-        ></StorageManager>
+        {productRecord && (
+          <StorageManager
+            defaultFiles={productRecord.imgKeys.map((key) => ({ key }))}
+            onUploadSuccess={({ key }) => {
+              setImgKeys((prev) => {
+                let value = [...prev, key];
+                if (onChange) {
+                  const modelFields = {
+                    name,
+                    imgKeys: value,
+                  };
+                  const result = onChange(modelFields);
+                  value = result?.imgKeys ?? value;
+                }
+                return value;
+              });
+            }}
+            onFileRemove={({ key }) => {
+              setImgKeys((prev) => {
+                let value = prev.filter((f) => f !== key);
+                if (onChange) {
+                  const modelFields = {
+                    name,
+                    imgKeys: value,
+                  };
+                  const result = onChange(modelFields);
+                  value = result?.imgKeys ?? value;
+                }
+                return value;
+              });
+            }}
+            accessLevel={\\"private\\"}
+            acceptedFileTypes={[\\".doc\\", \\".pdf\\"]}
+            isResumable={false}
+            showThumbnails={true}
+          ></StorageManager>
+        )}
       </Field>
       <Flex
         justifyContent=\\"space-between\\"
@@ -25392,43 +25394,45 @@ export default function UpdateProductForm(props) {
         isRequired={false}
         isReadOnly={false}
       >
-        <StorageManager
-          defaultFiles={singleImgKey ? [{ key: singleImgKey }] : undefined}
-          onUploadSuccess={({ key }) => {
-            setSingleImgKey((prev) => {
-              let value = key;
-              if (onChange) {
-                const modelFields = {
-                  name,
-                  singleImgKey: value,
-                };
-                const result = onChange(modelFields);
-                value = result?.singleImgKey ?? value;
-              }
-              return value;
-            });
-          }}
-          onFileRemove={({ key }) => {
-            setSingleImgKey((prev) => {
-              let value = initialValues?.singleImgKey;
-              if (onChange) {
-                const modelFields = {
-                  name,
-                  singleImgKey: value,
-                };
-                const result = onChange(modelFields);
-                value = result?.singleImgKey ?? value;
-              }
-              return value;
-            });
-          }}
-          accessLevel={\\"protected\\"}
-          acceptedFileTypes={[\\".txt\\", \\".pdf\\"]}
-          isResumable={true}
-          showThumbnails={false}
-          maxFileCount={1}
-          maxSize={1024}
-        ></StorageManager>
+        {productRecord && (
+          <StorageManager
+            defaultFiles={[{ key: productRecord.singleImgKey }]}
+            onUploadSuccess={({ key }) => {
+              setSingleImgKey((prev) => {
+                let value = key;
+                if (onChange) {
+                  const modelFields = {
+                    name,
+                    singleImgKey: value,
+                  };
+                  const result = onChange(modelFields);
+                  value = result?.singleImgKey ?? value;
+                }
+                return value;
+              });
+            }}
+            onFileRemove={({ key }) => {
+              setSingleImgKey((prev) => {
+                let value = initialValues?.singleImgKey;
+                if (onChange) {
+                  const modelFields = {
+                    name,
+                    singleImgKey: value,
+                  };
+                  const result = onChange(modelFields);
+                  value = result?.singleImgKey ?? value;
+                }
+                return value;
+              });
+            }}
+            accessLevel={\\"protected\\"}
+            acceptedFileTypes={[\\".txt\\", \\".pdf\\"]}
+            isResumable={true}
+            showThumbnails={false}
+            maxFileCount={1}
+            maxSize={1024}
+          ></StorageManager>
+        )}
       </Field>
       <Flex
         justifyContent=\\"space-between\\"

--- a/packages/codegen-ui/example-schemas/forms/product-datastore-update-non-array.json
+++ b/packages/codegen-ui/example-schemas/forms/product-datastore-update-non-array.json
@@ -10,6 +10,7 @@
         "label": "Single Image",
         "inputType": {
           "type": "StorageField",
+          "descriptiveText": "Limited to One Image",
           "fileUploaderConfig": {
             "accessLevel": "protected",
             "acceptedFileTypes": [".txt", ".pdf"],


### PR DESCRIPTION
## Problem
Fixing update form with storage field where existing files are not rendered. StorageManager component does not update with `defaultFiles` prop update.

## Solution
Conditionally render after the record has been fetched.

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [X] Snapshot updated to match updated golden file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.