### PR TITLE
fix: set conditional messaging for ui-react-storage

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/react-studio-dependency-provider.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-studio-dependency-provider.test.ts
@@ -17,7 +17,8 @@ import semver from 'semver';
 import { ReactRequiredDependencyProvider } from '..';
 
 describe('ReactStudioDependencyProvider', () => {
-  const requiredDependencies = new ReactRequiredDependencyProvider().getRequiredDependencies();
+  const requiredDependencies = new ReactRequiredDependencyProvider().getRequiredDependencies(false);
+  const requiredDependenciesWithStorageManager = new ReactRequiredDependencyProvider().getRequiredDependencies(true);
 
   describe('getRequiredDependencies', () => {
     it('has required dependencies', () => {
@@ -38,6 +39,16 @@ describe('ReactStudioDependencyProvider', () => {
       requiredDependencies.forEach((dep) => {
         expect(dep.reason.length).toBeGreaterThan(0);
       });
+    });
+
+    it('does not include ui-react-storage if user does not use StorageManager', () => {
+      expect(requiredDependencies.filter((dep) => dep.dependencyName !== '@aws-amplify/ui-react-storage')).toBeTruthy();
+    });
+
+    it('includes ui-react-storage if user is using StorageManager', () => {
+      expect(
+        requiredDependenciesWithStorageManager.filter((dep) => dep.dependencyName === '@aws-amplify/ui-react-storage'),
+      ).toBeTruthy();
     });
   });
 });

--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -20,8 +20,8 @@ type SemVerRequiredDependency = RequiredDependency & {
 };
 
 export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<SemVerRequiredDependency> {
-  getRequiredDependencies(): SemVerRequiredDependency[] {
-    return [
+  getRequiredDependencies(hasStorageManager?: boolean): SemVerRequiredDependency[] {
+    const dependencies = [
       {
         dependencyName: '@aws-amplify/ui-react',
         supportedSemVerPattern: '^4.6.0',
@@ -32,11 +32,16 @@ export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<
         supportedSemVerPattern: '^5.0.2',
         reason: 'Required to leverage DataStore.',
       },
-      {
+    ];
+
+    if (hasStorageManager) {
+      dependencies.push({
         dependencyName: '@aws-amplify/ui-react-storage',
         supportedSemVerPattern: '^1.1.0',
         reason: 'Required to leverage StorageManager.',
-      },
-    ];
+      });
+    }
+
+    return dependencies;
   }
 }

--- a/packages/codegen-ui/lib/required-dependency-provider.ts
+++ b/packages/codegen-ui/lib/required-dependency-provider.ts
@@ -19,5 +19,5 @@ export type RequiredDependency = {
 };
 
 export abstract class RequiredDependencyProvider<DependencyType extends RequiredDependency> {
-  abstract getRequiredDependencies(): DependencyType[];
+  abstract getRequiredDependencies(hasStorageManager?: boolean): DependencyType[];
 }


### PR DESCRIPTION
## Problem
Messaging for requiring ui-react-storage dependency was showing up even for users that are not using StorageManager.

## Solution
Make messaging conditional to only show for users who are using StorageManager.

Following up on CLI side to check if a user has StorageManager in their forms and pass the `hasStorageManager` boolean value.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.