### PR TITLE
chore: increasing unit test timeout to 30m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
       - run:
           name: Unit Test
           command: npm run test:ci
+          no_output_timeout: 30m
       - run:
           name: Codecov
           command: npx codecov


### PR DESCRIPTION
## Problem
The unit test is failing in CircleCI due to timeout.

## Solution
Override the default 10 min timeout to 30 min.

## Links
https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-Hit-Timeout-Limit#:~:text=CircleCI%20has%20a%20built%2Din,will%20be%20canceled%20and%20stopped.

### Automated tests
- [ ] N/A - (provide a reason)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.