### PR TITLE
fix(codegen-ui): fix multiple has one relationships

### DIFF
--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:ci": "jest --ci --maxWorkers=30%",
+    "test:ci": "jest --ci -i",
     "test:update": "jest --updateSnapshot",
     "build": "tsc -p tsconfig.build.json",
     "build:watch": "npm run build -- --watch"

--- a/packages/codegen-ui/lib/__tests__/__utils__/introspection-schemas/schema-with-2-has-one.json
+++ b/packages/codegen-ui/lib/__tests__/__utils__/introspection-schemas/schema-with-2-has-one.json
@@ -1,0 +1,226 @@
+{
+  "version": "1",
+  "models": {
+    "Foo": {
+      "name": "Foo",
+      "fields": {
+        "id": {
+          "name": "id",
+          "isArray": false,
+          "type": "ID",
+          "isRequired": true,
+          "attributes": []
+        },
+        "User1": {
+          "name": "User1",
+          "isArray": false,
+          "type": {
+            "model": "User"
+          },
+          "isRequired": false,
+          "attributes": [],
+          "association": {
+            "connectionType": "HAS_ONE",
+            "associatedWith": [
+              "id"
+            ],
+            "targetNames": [
+              "fooUser1Id"
+            ]
+          }
+        },
+        "User2": {
+          "name": "User2",
+          "isArray": false,
+          "type": {
+            "model": "User"
+          },
+          "isRequired": false,
+          "attributes": [],
+          "association": {
+            "connectionType": "HAS_ONE",
+            "associatedWith": [
+              "id"
+            ],
+            "targetNames": [
+              "fooUser2Id"
+            ]
+          }
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "isArray": false,
+          "type": "AWSDateTime",
+          "isRequired": false,
+          "attributes": [],
+          "isReadOnly": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "isArray": false,
+          "type": "AWSDateTime",
+          "isRequired": false,
+          "attributes": [],
+          "isReadOnly": true
+        },
+        "fooUser1Id": {
+          "name": "fooUser1Id",
+          "isArray": false,
+          "type": "ID",
+          "isRequired": false,
+          "attributes": []
+        },
+        "fooUser2Id": {
+          "name": "fooUser2Id",
+          "isArray": false,
+          "type": "ID",
+          "isRequired": false,
+          "attributes": []
+        }
+      },
+      "syncable": true,
+      "pluralName": "Foos",
+      "attributes": [
+        {
+          "type": "model",
+          "properties": {}
+        },
+        {
+          "type": "auth",
+          "properties": {
+            "rules": [
+              {
+                "allow": "public",
+                "operations": [
+                  "create",
+                  "update",
+                  "delete",
+                  "read"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "primaryKeyInfo": {
+        "isCustomPrimaryKey": false,
+        "primaryKeyFieldName": "id",
+        "sortKeyFieldNames": []
+      }
+    },
+    "User": {
+      "name": "User",
+      "fields": {
+        "id": {
+          "name": "id",
+          "isArray": false,
+          "type": "ID",
+          "isRequired": true,
+          "attributes": []
+        },
+        "name": {
+          "name": "name",
+          "isArray": false,
+          "type": "String",
+          "isRequired": true,
+          "attributes": []
+        },
+        "image": {
+          "name": "image",
+          "isArray": false,
+          "type": "String",
+          "isRequired": false,
+          "attributes": []
+        },
+        "bio": {
+          "name": "bio",
+          "isArray": false,
+          "type": "String",
+          "isRequired": true,
+          "attributes": []
+        },
+        "gender": {
+          "name": "gender",
+          "isArray": false,
+          "type": {
+            "enum": "Genders"
+          },
+          "isRequired": true,
+          "attributes": []
+        },
+        "lookingFor": {
+          "name": "lookingFor",
+          "isArray": false,
+          "type": {
+            "enum": "Genders"
+          },
+          "isRequired": true,
+          "attributes": []
+        },
+        "sub": {
+          "name": "sub",
+          "isArray": false,
+          "type": "String",
+          "isRequired": true,
+          "attributes": []
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "isArray": false,
+          "type": "AWSDateTime",
+          "isRequired": false,
+          "attributes": [],
+          "isReadOnly": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "isArray": false,
+          "type": "AWSDateTime",
+          "isRequired": false,
+          "attributes": [],
+          "isReadOnly": true
+        }
+      },
+      "syncable": true,
+      "pluralName": "Users",
+      "attributes": [
+        {
+          "type": "model",
+          "properties": {}
+        },
+        {
+          "type": "auth",
+          "properties": {
+            "rules": [
+              {
+                "allow": "public",
+                "operations": [
+                  "create",
+                  "update",
+                  "delete",
+                  "read"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "primaryKeyInfo": {
+        "isCustomPrimaryKey": false,
+        "primaryKeyFieldName": "id",
+        "sortKeyFieldNames": []
+      }
+    }
+  },
+  "enums": {
+    "Genders": {
+      "name": "Genders",
+      "values": [
+        "MALE",
+        "FEMALE",
+        "OTHER"
+      ]
+    }
+  },
+  "nonModels": {}
+}

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "test:ci": "jest --ci --maxWorkers=30%",
+    "test:ci": "jest -i --ci",
     "test:update": "jest --updateSnapshot",
     "build": "tsc -p tsconfig.build.json",
     "build:watch": "npm run build -- --watch"


### PR DESCRIPTION
## Problem
If a customer has multiple hasOne relationships for the same model, we currently default to the first field. 

## Solution
This adds an additional check to ensure that the field selected also uses the same key.

## Additional Notes
No

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue: N/A

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.