### PR TITLE
chore: export processFile from lib/index

### DIFF
--- a/packages/codegen-ui-react/lib/index.ts
+++ b/packages/codegen-ui-react/lib/index.ts
@@ -31,3 +31,4 @@ export * from './react-utils-studio-template-renderer';
 export * from './react-required-dependency-provider';
 export * from './utils/forms/validation';
 export { fetchByPath } from './utils/json-path-fetch';
+export { processFile } from './utils/storage-manager';


### PR DESCRIPTION
## Problem
export processFile at `lib/index` to be used by consumers

## Solution
export processFile at `lib/index` to be used by consumers

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.