### PR TITLE
fix(codegen-ui-react): prevent useless props forward to custom components

### DIFF
--- a/packages/codegen-ui-react/lib/react-component-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-renderer.ts
@@ -20,6 +20,7 @@ import {
   StudioComponentChild,
   ComponentMetadata,
   StudioGenericEvent,
+  StudioComponentProperty,
 } from '@aws-amplify/codegen-ui';
 import {
   JsxAttributeLike,
@@ -47,6 +48,7 @@ import { addFormAttributes } from './forms';
 import { shouldWrapInArrayField, renderArrayFieldComponent, getDecoratedLabel } from './forms/form-renderer-helper';
 import { getIsRequiredValue } from './forms/form-renderer-helper/label-decorator';
 import { renderStorageFieldComponent } from './utils/forms/storage-field-component';
+import { Primitive } from './primitive';
 
 export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
   TPropIn,
@@ -123,38 +125,56 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
       this.componentMetadata.stateReferences,
     );
 
-    const propertyAttributes = Object.entries(this.component.properties).map(([key, value]) => {
-      if (key in localStateReferences) {
-        const stateName = getStateName({ componentName: this.component.name, property: key });
-        return buildOpeningElementProperties(
-          this.componentMetadata,
-          { bindingProperties: { property: stateName } },
-          key,
-        );
-      }
-      if (
-        this.componentMetadata.formMetadata &&
-        this.componentMetadata.formMetadata.fieldConfigs[this.component.name]
-      ) {
-        const {
-          labelDecorator,
-          fieldConfigs: {
-            [this.component.name]: { isArray },
-          },
-        } = this.componentMetadata.formMetadata;
-        const isRequired = getIsRequiredValue(this.component.properties.isRequired);
-        if (
-          ((key === 'children' && this.component.componentType === 'ToggleButton') || key === 'label') &&
-          ((labelDecorator && labelDecorator === 'required' && isRequired) ||
-            (labelDecorator === 'optional' && !isRequired)) &&
-          'value' in value &&
-          !isArray
-        ) {
-          return getDecoratedLabel(key, value.value.toString(), labelDecorator);
+    const primitivesTypes = Object.values(Primitive);
+
+    const isPrimitive = primitivesTypes.includes(this.component.componentType as Primitive);
+    const isHTML = this.component.componentType[0].match(/[a-z]/);
+
+    const shouldForwardProperty = ([key, value]: [string, StudioComponentProperty]) => {
+      return (
+        isPrimitive ||
+        isHTML ||
+        key in localStateReferences ||
+        'collectionBindingProperties' in value ||
+        'concat' in value ||
+        value.configured
+      );
+    };
+
+    const propertyAttributes = Object.entries(this.component.properties)
+      .filter(shouldForwardProperty)
+      .map(([key, value]) => {
+        if (key in localStateReferences) {
+          const stateName = getStateName({ componentName: this.component.name, property: key });
+          return buildOpeningElementProperties(
+            this.componentMetadata,
+            { bindingProperties: { property: stateName } },
+            key,
+          );
         }
-      }
-      return buildOpeningElementProperties(this.componentMetadata, value, key);
-    });
+        if (
+          this.componentMetadata.formMetadata &&
+          this.componentMetadata.formMetadata.fieldConfigs[this.component.name]
+        ) {
+          const {
+            labelDecorator,
+            fieldConfigs: {
+              [this.component.name]: { isArray },
+            },
+          } = this.componentMetadata.formMetadata;
+          const isRequired = getIsRequiredValue(this.component.properties.isRequired);
+          if (
+            ((key === 'children' && this.component.componentType === 'ToggleButton') || key === 'label') &&
+            ((labelDecorator && labelDecorator === 'required' && isRequired) ||
+              (labelDecorator === 'optional' && !isRequired)) &&
+            'value' in value &&
+            !isArray
+          ) {
+            return getDecoratedLabel(key, value.value.toString(), labelDecorator);
+          }
+        }
+        return buildOpeningElementProperties(this.componentMetadata, value, key);
+      });
 
     // Reverse, and create element properties for localStateReferences which are not yet defined props
     const unmodeledPropertyAttributes = Object.entries(localStateReferences)

--- a/packages/codegen-ui/example-schemas/collectionWithBindingWithoutPredicate.json
+++ b/packages/codegen-ui/example-schemas/collectionWithBindingWithoutPredicate.json
@@ -7,16 +7,20 @@
       "componentType": "ListingCard",
       "properties": {
         "marginRight": {
-          "value": "0"
+          "value": "0",
+          "configured": true
         },
         "marginBottom": {
-          "value": "0"
+          "value": "0",
+          "configured": true
         },
         "marginTop": {
-          "value": "0"
+          "value": "0",
+          "configured": true
         },
         "marginLeft": {
-          "value": "0"
+          "value": "0",
+          "configured": true
         }
       },
       "overrides": {},

--- a/packages/codegen-ui/example-schemas/complexTest3.json
+++ b/packages/codegen-ui/example-schemas/complexTest3.json
@@ -73,10 +73,12 @@
       "name": "ReneButton",
       "properties": {
         "width": {
-          "value": "293px"
+          "value": "293px",
+          "configured": true
         },
         "height": {
-          "value": "45px"
+          "value": "45px",
+          "configured": true
         }
       }
     },

--- a/packages/codegen-ui/example-schemas/customChild.json
+++ b/packages/codegen-ui/example-schemas/customChild.json
@@ -10,10 +10,12 @@
       "name": "MyCustomButton",
       "properties": {
         "color": {
-          "value": "#ff0000"
+          "value": "#ff0000",
+          "configured": true
         },
         "width": {
-          "value": "20px"
+          "value": "20px",
+          "configured": true
         }
       }
     }

--- a/packages/codegen-ui/example-schemas/customChildMalformedProperty.json
+++ b/packages/codegen-ui/example-schemas/customChildMalformedProperty.json
@@ -18,7 +18,8 @@
             {
               "value": "Value!"
             }
-          ]
+          ],
+          "configured": true
         }
       }
     }

--- a/packages/codegen-ui/example-schemas/parsedFixedValues.json
+++ b/packages/codegen-ui/example-schemas/parsedFixedValues.json
@@ -13,10 +13,12 @@
       "name": "MyInputString",
       "properties": {
         "id": {
-          "value": "string-value"
+          "value": "string-value",
+          "configured": true
         },
         "value": {
-          "value": "raw string value"
+          "value": "raw string value",
+          "configured": true
         }
       }
     },
@@ -25,10 +27,12 @@
       "name": "MyInputNumber",
       "properties": {
         "id": {
-          "value": "number-value"
+          "value": "number-value",
+          "configured": true
         },
         "value": {
-          "value": "67548"
+          "value": "67548",
+          "configured": true
         }
       }
     },
@@ -37,11 +41,13 @@
       "name": "MyInputParsedNumber",
       "properties": {
         "id": {
-          "value": "parsed-number-value"
+          "value": "parsed-number-value",
+          "configured": true
         },
         "value": {
           "value": "67548",
-          "type": "Number"
+          "type": "Number",
+          "configured": true
         }
       }
     },
@@ -50,10 +56,12 @@
       "name": "MyInputBoolean",
       "properties": {
         "id": {
-          "value": "boolean-value"
+          "value": "boolean-value",
+          "configured": true
         },
         "value": {
-          "value": "true"
+          "value": "true",
+          "configured": true
         }
       }
     },
@@ -62,11 +70,13 @@
       "name": "MyInputPrasedBoolean",
       "properties": {
         "id": {
-          "value": "parsed-boolean-value"
+          "value": "parsed-boolean-value",
+          "configured": true
         },
         "value": {
           "value": "true",
-          "type": "Boolean"
+          "type": "Boolean",
+          "configured": true
         }
       }
     },
@@ -75,10 +85,12 @@
       "name": "MyInputJson",
       "properties": {
         "id": {
-          "value": "json-value"
+          "value": "json-value",
+          "configured": true
         },
         "value": {
-          "value": "{\"foo\": \"bar\"}"
+          "value": "{\"foo\": \"bar\"}",
+          "configured": true
         }
       }
     },
@@ -87,11 +99,13 @@
       "name": "MyInputParsedJson",
       "properties": {
         "id": {
-          "value": "parsed-json-value"
+          "value": "parsed-json-value",
+          "configured": true
         },
         "value": {
           "value": "{\"foo\": \"bar\"}",
-          "type": "Object"
+          "type": "Object",
+          "configured": true
         }
       }
     },
@@ -100,10 +114,12 @@
       "name": "MyInputArray",
       "properties": {
         "id": {
-          "value": "array-value"
+          "value": "array-value",
+          "configured": true
         },
         "value": {
-          "value": "[1,2,3]"
+          "value": "[1,2,3]",
+          "configured": true
         }
       }
     },
@@ -112,11 +128,13 @@
       "name": "MyInputParsedArray",
       "properties": {
         "id": {
-          "value": "parsed-array-value"
+          "value": "parsed-array-value",
+          "configured": true
         },
         "value": {
           "value": "[1,2,3]",
-          "type": "Object"
+          "type": "Object",
+          "configured": true
         }
       }
     },
@@ -125,10 +143,12 @@
       "name": "MyInputNull",
       "properties": {
         "id": {
-          "value": "null-value"
+          "value": "null-value",
+          "configured": true
         },
         "value": {
-          "value": "null"
+          "value": "null",
+          "configured": true
         }
       }
     },
@@ -137,11 +157,13 @@
       "name": "MyInputParsedNull",
       "properties": {
         "id": {
-          "value": "parsed-null-value"
+          "value": "parsed-null-value",
+          "configured": true
         },
         "value": {
           "value": "null",
-          "type": "Object"
+          "type": "Object",
+          "configured": true
         }
       }
     }

--- a/packages/codegen-ui/example-schemas/sampleCodeSnippet.json
+++ b/packages/codegen-ui/example-schemas/sampleCodeSnippet.json
@@ -14,14 +14,17 @@
       "name": "MyCustomButton",
       "properties": {
         "color": {
-          "value": "#ff0000"
+          "value": "#ff0000",
+          "configured": true
         },
         "width": {
-          "value": "20px"
+          "value": "20px",
+          "configured": true
         },
         "buttonText": {
           "exposedAs": "buttonText",
-          "value": "Click Me"
+          "value": "Click Me",
+          "configured": true
         }
       }
     }


### PR DESCRIPTION
## Problem
When we create composite components (components with nested components) in Figma and they go through the studio and amplify-codegen-ui, any props are forwarded to the nested component (including the defaults that were not configured in the studio).

When using variants with logic inside the components (breakpoint, displayMode, ...), this breaks the logic because the forwarded prop will always be the default variant.

Example:

GIVEN i created a NavBar component in Figma with 2 breakpoint variants (small, medium)
GIVEN i nested my NavBar component in a PageLayout component in Figma
WHEN codegen-amplify-ui generates my PageLayout component
THEN the nested NavBar component will receive a `breakpoint="small"` prop from PageLayout
THEN the forwarded prop overrides the breakpoint value generated inside the NavBar component

## Solution

Studio produced JSON includes a `configured` key for props added via the studio, so we can use it to filter custom components props. Implemented forwarding filter rule is the following:

- Component IS a Primitive => Because Primitives needs explicit props forwarding
- Component IS a HTML tag => Because HTML tags needs explicit props forwarding
- Prop value is dynamic (prop key is in `localStateReferences`)
- Prop value is a Collection binding
- Prop value is a concat
- Prop value has been configured in the studio

## Additional Notes
I fixed most of the specs by simply adding the `configured` prop to the dataset. It seems the best way to do, but pay attention so that doesn't change the nature of the test.

## Links
### Ticket
### Other links

## Verification
### Manual tests
### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.