### PR TITLE
fix: parse operand value when field is number type

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -1094,7 +1094,7 @@ export default function CollectionOfCustomButtons(
   } = props;
   const itemsFilterObj = {
     and: [
-      { field: \\"age\\", operand: \\"10\\", operator: \\"gt\\" },
+      { field: \\"age\\", operand: 10, operator: \\"eq\\" },
       { field: \\"lastName\\", operand: \\"L\\", operator: \\"beginsWith\\" },
     ],
   };

--- a/packages/codegen-ui-react/lib/__tests__/__utils__/mock-data-schemas.ts
+++ b/packages/codegen-ui-react/lib/__tests__/__utils__/mock-data-schemas.ts
@@ -480,3 +480,90 @@ export const compositePersonSchema: GenericDataSchema = getGenericFromDataStore(
   codegenVersion: '3.3.2',
   version: 'accea0d7a2f24829740c710ceb3264a8',
 });
+
+export const userSchema: GenericDataSchema = getGenericFromDataStore({
+  models: {
+    User: {
+      name: 'User',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
+        },
+        firstName: {
+          name: 'firstName',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        lastName: {
+          name: 'lastName',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        age: {
+          name: 'age',
+          isArray: false,
+          type: 'Int',
+          isRequired: false,
+          attributes: [],
+        },
+        isLoggedIn: {
+          name: 'isLoggedIn',
+          isArray: false,
+          type: 'Boolean',
+          isRequired: false,
+          attributes: [],
+        },
+        loggedInColor: {
+          name: 'loggedInColor',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        loggedOutColor: {
+          name: 'loggedOutColor',
+          isArray: false,
+          type: 'String',
+          isRequired: false,
+          attributes: [],
+        },
+        createdAt: {
+          name: 'createdAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+        updatedAt: {
+          name: 'updatedAt',
+          isArray: false,
+          type: 'AWSDateTime',
+          isRequired: false,
+          attributes: [],
+          isReadOnly: true,
+        },
+      },
+      syncable: true,
+      pluralName: 'Users',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+      ],
+    },
+  },
+  enums: {},
+  nonModels: {},
+  codegenVersion: '3.3.2',
+  version: 'accea0d7a2f24829740c710ceb3264a8',
+});

--- a/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-component-render-helper.test.ts
@@ -35,6 +35,7 @@ import {
   buildConditionalExpression,
   hasChildrenProp,
   buildConcatExpression,
+  parseNumberOperand,
 } from '../react-component-render-helper';
 
 import { assertASTMatchesSnapshot } from './__utils__';
@@ -343,6 +344,17 @@ describe('react-component-render-helper', () => {
 
       const exp = buildConcatExpression(concatProp);
       assertASTMatchesSnapshot(exp);
+    });
+  });
+
+  describe('parseNumberOperand', () => {
+    test('should parse int if field data type is Int', () => {
+      expect(parseNumberOperand('10', { dataType: 'Int', readOnly: false, required: false, isArray: false })).toBe(10);
+    });
+    test('should parse int if field data type is Int', () => {
+      expect(parseNumberOperand('10.01', { dataType: 'Float', readOnly: false, required: false, isArray: false })).toBe(
+        10.01,
+      );
     });
   });
 });

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 import { ModuleKind, ScriptTarget, ScriptKind } from '..';
-import { authorHasManySchema, compositePersonSchema, generateWithAmplifyRenderer } from './__utils__';
+import { authorHasManySchema, compositePersonSchema, generateWithAmplifyRenderer, userSchema } from './__utils__';
 
 describe('amplify render tests', () => {
   describe('basic component tests', () => {
@@ -121,7 +121,12 @@ describe('amplify render tests', () => {
     });
 
     it('should render collection with data binding if binding name is items', () => {
-      const generatedCode = generateWithAmplifyRenderer('collectionWithBindingItemsName');
+      const generatedCode = generateWithAmplifyRenderer(
+        'collectionWithBindingItemsName',
+        undefined,
+        undefined,
+        userSchema,
+      );
       expect(generatedCode.componentText).toMatchSnapshot();
     });
 

--- a/packages/codegen-ui-react/lib/react-component-render-helper.ts
+++ b/packages/codegen-ui-react/lib/react-component-render-helper.ts
@@ -52,7 +52,13 @@ import {
   ArrayLiteralExpression,
 } from 'typescript';
 
-import { FormMetadata, FormStyleConfig, StudioFormInputFieldProperty } from '@aws-amplify/codegen-ui/lib/types';
+import {
+  DataFieldDataType,
+  FormMetadata,
+  FormStyleConfig,
+  GenericDataField,
+  StudioFormInputFieldProperty,
+} from '@aws-amplify/codegen-ui/lib/types';
 import { ImportCollection, ImportSource } from './imports';
 import { json, jsonToLiteral } from './react-studio-template-renderer-helper';
 import { getChildPropMappingForComponentName } from './workflow/utils';
@@ -456,6 +462,19 @@ export function getSyntaxKindToken(operator: RelationalOperator): BinaryOperator
     default:
       return undefined;
   }
+}
+
+export function parseNumberOperand(operand: string | number | boolean, dataField: GenericDataField | undefined) {
+  if (dataField) {
+    const numberOperandType: DataFieldDataType[] = ['Int', 'Float'];
+    if (numberOperandType.includes(dataField.dataType)) {
+      const parsedOperand = parseFloat(`${operand}`);
+      if (!Number.isNaN(parsedOperand) && Number.isFinite(parsedOperand)) {
+        return parsedOperand;
+      }
+    }
+  }
+  return operand;
 }
 
 export function getConditionalOperandExpression(

--- a/packages/codegen-ui/example-schemas/collectionWithBindingItemsName.json
+++ b/packages/codegen-ui/example-schemas/collectionWithBindingItemsName.json
@@ -45,7 +45,7 @@
           {
             "field": "age",
             "operand": "10",
-            "operator": "gt"
+            "operator": "eq"
           },
           {
             "field": "lastName",


### PR DESCRIPTION
## Problem
comparing equality with filter operand as string returns false. 0 == '0'

## Solution
Parse operand value when field type is a number

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.