### PR TITLE
feat: update GraphqlRenderConfig to use separate props for each file path

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
+++ b/packages/codegen-ui-react/lib/__tests__/__utils__/amplify-renderer-generator.ts
@@ -160,7 +160,10 @@ export const renderExpanderJsxElement = (
 export const rendererConfigWithGraphQL: ReactRenderConfig = {
   apiConfiguration: {
     dataApi: 'GraphQL',
-    operationsFilePath: '../graphql',
     typesFilePath: '../API',
+    queriesFilePath: '../graphql/queries',
+    mutationsFilePath: '../graphql/mutations',
+    subscriptionsFilePath: '../graphql/subscriptions',
+    fragmentsFilePath: '../graphql/fragments',
   },
 };

--- a/packages/codegen-ui-react/lib/imports/import-collection.ts
+++ b/packages/codegen-ui-react/lib/imports/import-collection.ts
@@ -48,9 +48,20 @@ export class ImportCollection {
     }
   }
 
-  private getOperationsPath() {
+  private getOperationsPath(operation: 'mutation' | 'query' | 'subscription' | 'fragment') {
     if (this.rendererConfig?.apiConfiguration?.dataApi === 'GraphQL') {
-      return this.rendererConfig.apiConfiguration.operationsFilePath;
+      switch (operation) {
+        case 'mutation':
+          return this.rendererConfig.apiConfiguration.mutationsFilePath;
+        case 'query':
+          return this.rendererConfig.apiConfiguration.queriesFilePath;
+        case 'subscription':
+          return this.rendererConfig.apiConfiguration.subscriptionsFilePath;
+        case 'fragment':
+          return this.rendererConfig.apiConfiguration.fragmentsFilePath;
+        default:
+          throw new InvalidInputError(`Unexpected GraphQL operation encountered: ${operation}`);
+      }
     }
     throw new InvalidInputError('Render is not configured to utilize GraphQL operations');
   }
@@ -61,15 +72,15 @@ export class ImportCollection {
   }
 
   addGraphqlMutationImport(importName: string) {
-    return this.addImport(`${this.getOperationsPath()}/mutations`, importName);
+    return this.addImport(this.getOperationsPath('mutation'), importName);
   }
 
   addGraphqlQueryImport(importName: string) {
-    return this.addImport(`${this.getOperationsPath()}/queries`, importName);
+    return this.addImport(this.getOperationsPath('query'), importName);
   }
 
   addGraphqlSubscriptionImport(importName: string) {
-    return this.addImport(`${this.getOperationsPath()}/subscriptions`, importName);
+    return this.addImport(this.getOperationsPath('subscription'), importName);
   }
 
   addModelImport(importName: string) {

--- a/packages/codegen-ui-react/lib/react-render-config.ts
+++ b/packages/codegen-ui-react/lib/react-render-config.ts
@@ -31,8 +31,11 @@ export type ReactRenderConfig = FrameworkRenderConfig & {
 
 export type GraphqlRenderConfig = {
   dataApi: 'GraphQL';
-  operationsFilePath: string;
   typesFilePath: string | undefined;
+  queriesFilePath: string;
+  mutationsFilePath: string;
+  subscriptionsFilePath: string;
+  fragmentsFilePath: string;
 };
 
 export type DataStoreRenderConfig = {


### PR DESCRIPTION
## Problem
<!-- Why are we making this code change? -->
the helper provided by `amplify-codegen` provides separate path values for each graphql operation type rather than just returning a common base path. This allows for additional flexibility in the future if there's ever a reason to allow operations to be located on different paths rather than always implied to be in neighboring files in the same directory, and also allows for file names to be customized in the future if required.
## Solution
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
Update the GraphQL config model to accept explicit file paths for each operation type rather than working off of naming conventions and concatenation based on a given base path.
## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.