### PR TITLE
chore: update cli check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Build amplify-cli
         working-directory: amplify-cli
         run: |
-          yarn policies set-version 1.18.0
-          yarn --network-concurrency 1
+          yarn install
           yarn setup-dev
       - name: Install updated codegen libraries
         working-directory: amplify-cli/packages/amplify-util-uibuilder
@@ -52,9 +51,9 @@ jobs:
       - name: Build amplify-cli with updated codegen libraries
         working-directory: amplify-cli
         run: |
-          yarn policies set-version 1.18.0
-          yarn --network-concurrency 1
-          yarn dev-build
+          yarn install
+          yarn build
+          echo "$HOME/work/amplify-codegen-ui/amplify-codegen-ui/amplify-cli/.bin" >> $GITHUB_PATH
       - name: Create a test react app
         run: npx create-react-app e2e-test-app
       - name: Install test app dependencies
@@ -112,7 +111,7 @@ jobs:
       - name: Install packages
         run: npm ci
       - name: Lerna bootstrap
-        run: lerna bootstrap
+        run: npm run bootstrap
       - name: Setup Integration Test
         run: npm run integ:setup
       - name: Cypress run

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "integ:test": "run-script-os",
     "integ:test:default": "./scripts/integ-test.sh",
     "integ:test:win32": "scripts\\integ-test.bat",
-    "integ:clean": "npx rimraf packages/integration-test"
+    "integ:clean": "npx rimraf packages/integration-test",
+    "bootstrap": "lerna bootstrap"
   },
   "files": [],
   "devDependencies": {


### PR DESCRIPTION
## Problem
Our `amplify-cli-tests` action is failing to build amplify-cli.

`lerna bootstrap` was using lerna v7.0.0 where `bootstrap` was deprecated, switched to running through an npm script so we can continue using lerna v6.4.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.