### PR TITLE
feat: graphql support for collections

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -864,6 +864,805 @@ export default function DataBindingNamedClass(
 "
 `;
 
+exports[`amplify render tests collection GraphQL should not render nested query if the data schema is not provided 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { listAuthors } from \\"../graphql/queries\\";
+import AuthorProfile, { AuthorProfileProps } from \\"./AuthorProfile\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import {
+  Collection,
+  CollectionProps,
+  Pagination,
+  Placeholder,
+} from \\"@aws-amplify/ui-react\\";
+import { API } from \\"aws-amplify\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type AuthorProfileCollectionOverridesProps = {
+  AuthorProfileCollection?: PrimitiveOverrideProps<CollectionProps>;
+  AuthorProfile?: AuthorProfileProps;
+} & EscapeHatchProps;
+export type AuthorProfileCollectionProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    items?: any[];
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => AuthorProfileProps;
+  } & {
+    overrides?: AuthorProfileCollectionOverridesProps | undefined | null;
+  }
+>;
+
+const nextToken = {};
+const apiCache = {};
+export default function AuthorProfileCollection(
+  props: AuthorProfileCollectionProps
+): React.ReactElement {
+  const { items: itemsProp, overrideItems, overrides, ...rest } = props;
+  const [pageIndex, setPageIndex] = React.useState(1);
+  const [hasMorePages, setHasMorePages] = React.useState(true);
+  const [items, setItems] = React.useState([]);
+  const [isApiPagination, setIsApiPagination] = React.useState(false);
+  const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
+  const [loading, setLoading] = React.useState(true);
+  const [maxViewed, setMaxViewed] = React.useState(1);
+  const pageSize = 4;
+  React.useEffect(() => {
+    nextToken[instanceKey] = \\"\\";
+    apiCache[instanceKey] = [];
+  }, [instanceKey]);
+  React.useEffect(() => {
+    setIsApiPagination(!!!itemsProp);
+  }, [itemsProp]);
+  const handlePreviousPage = () => {
+    setPageIndex(pageIndex - 1);
+  };
+  const handleNextPage = () => {
+    setPageIndex(pageIndex + 1);
+  };
+  const jumpToPage = (pageNum?: number) => {
+    setPageIndex(pageNum!);
+  };
+  const loadPage = async (page: number) => {
+    const cacheUntil = page * pageSize + 1;
+    const newCache = apiCache[instanceKey].slice();
+    let newNext = nextToken[instanceKey];
+    while (newCache.length < cacheUntil && newNext != null) {
+      setLoading(true);
+      const variables: any = {
+        limit: pageSize,
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listAuthors,
+          variables,
+        })
+      ).data.listAuthors;
+      var loaded = await Promise.all(
+        result.items.map(async (item) => {
+          return {
+            ...item,
+          };
+        })
+      );
+      newCache.push(...loaded);
+      newNext = result.nextToken;
+    }
+    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    setItems(cacheSlice);
+    setHasMorePages(!!newNext);
+    setLoading(false);
+    apiCache[instanceKey] = newCache;
+    nextToken[instanceKey] = newNext;
+  };
+  React.useEffect(() => {
+    loadPage(pageIndex);
+  }, [pageIndex]);
+  React.useEffect(() => {
+    setMaxViewed(Math.max(maxViewed, pageIndex));
+  }, [pageIndex, maxViewed, setMaxViewed]);
+  return (
+    /* @ts-ignore: TS2322 */
+    <div>
+      <Collection
+        type=\\"list\\"
+        itemsPerPage={6}
+        templateColumns=\\"1fr 1fr\\"
+        autoFlow=\\"row\\"
+        alignItems=\\"stretch\\"
+        justifyContent=\\"stretch\\"
+        itemsPerPage={pageSize}
+        items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
+        {...getOverrideProps(overrides, \\"AuthorProfileCollection\\")}
+        {...rest}
+      >
+        {(item, index) => {
+          if (loading) {
+            return <Placeholder key={index} size=\\"large\\" />;
+          }
+          return (
+            <AuthorProfile
+              author={item}
+              key={item.id}
+              {...(overrideItems && overrideItems({ item, index }))}
+            ></AuthorProfile>
+          );
+        }}
+      </Collection>
+      {isApiPagination && (
+        <Pagination
+          currentPage={pageIndex}
+          totalPages={maxViewed}
+          hasMorePages={hasMorePages}
+          onNext={handleNextPage}
+          onPrevious={handlePreviousPage}
+          onChange={jumpToPage}
+        />
+      )}
+    </div>
+  );
+}
+"
+`;
+
+exports[`amplify render tests collection GraphQL should render collection with data binding 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { UserPreferences } from \\"../API\\";
+import { listUserPreferences, listUsers } from \\"../graphql/queries\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { API } from \\"aws-amplify\\";
+import {
+  Button,
+  ButtonProps,
+  Collection,
+  CollectionProps,
+  Flex,
+  FlexProps,
+  Pagination,
+  Placeholder,
+} from \\"@aws-amplify/ui-react\\";
+import { MyFlexProps } from \\"./MyFlex\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type CollectionOfCustomButtonsOverridesProps = {
+  CollectionOfCustomButtons?: PrimitiveOverrideProps<CollectionProps>;
+  MyFlex?: PrimitiveOverrideProps<FlexProps>;
+  MyButton?: PrimitiveOverrideProps<ButtonProps>;
+} & EscapeHatchProps;
+export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    width?: Number;
+    backgroundColor?: String;
+    buttonColor?: UserPreferences;
+    buttonEnabled?: UserPreferences;
+    items?: any[];
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => MyFlexProps;
+  } & {
+    overrides?: CollectionOfCustomButtonsOverridesProps | undefined | null;
+  }
+>;
+
+const nextToken = {};
+const apiCache = {};
+export default function CollectionOfCustomButtons(
+  props: CollectionOfCustomButtonsProps
+): React.ReactElement {
+  const {
+    width,
+    backgroundColor,
+    buttonColor: buttonColorProp,
+    buttonEnabled: buttonEnabledProp,
+    items: itemsProp,
+    overrideItems,
+    overrides,
+    ...rest
+  } = props;
+  const [pageIndex, setPageIndex] = React.useState(1);
+  const [hasMorePages, setHasMorePages] = React.useState(true);
+  const [items, setItems] = React.useState([]);
+  const [isApiPagination, setIsApiPagination] = React.useState(false);
+  const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
+  const [loading, setLoading] = React.useState(true);
+  const [maxViewed, setMaxViewed] = React.useState(1);
+  const pageSize = 4;
+  React.useEffect(() => {
+    nextToken[instanceKey] = \\"\\";
+    apiCache[instanceKey] = [];
+  }, [instanceKey]);
+  React.useEffect(() => {
+    setIsApiPagination(!!!itemsProp);
+  }, [itemsProp]);
+  const handlePreviousPage = () => {
+    setPageIndex(pageIndex - 1);
+  };
+  const handleNextPage = () => {
+    setPageIndex(pageIndex + 1);
+  };
+  const jumpToPage = (pageNum?: number) => {
+    setPageIndex(pageNum!);
+  };
+  const loadPage = async (page: number) => {
+    const cacheUntil = page * pageSize + 1;
+    const newCache = apiCache[instanceKey].slice();
+    let newNext = nextToken[instanceKey];
+    while (newCache.length < cacheUntil && newNext != null) {
+      setLoading(true);
+      const variables: any = {
+        limit: pageSize,
+        filter: {
+          and: [
+            { age: { gt: \\"10\\" } },
+            { lastName: { beginsWith: \\"L\\" } },
+            {
+              and: [
+                { date: { ge: \\"2022-03-10\\" } },
+                { date: { le: \\"2023-03-11\\" } },
+              ],
+            },
+          ],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listUsers,
+          variables,
+        })
+      ).data.listUsers;
+      var loaded = await Promise.all(
+        result.items.map(async (item) => {
+          return {
+            ...item,
+          };
+        })
+      );
+      newCache.push(...loaded);
+      newNext = result.nextToken;
+    }
+    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    setItems(cacheSlice);
+    setHasMorePages(!!newNext);
+    setLoading(false);
+    apiCache[instanceKey] = newCache;
+    nextToken[instanceKey] = newNext;
+  };
+  React.useEffect(() => {
+    loadPage(pageIndex);
+  }, [pageIndex]);
+  React.useEffect(() => {
+    setMaxViewed(Math.max(maxViewed, pageIndex));
+  }, [pageIndex, maxViewed, setMaxViewed]);
+  const buttonColorFilterObj = { userID: { eq: \\"user@email.com\\" } };
+  const buttonColorDataStore = API.graphql({
+    query: listUserPreferences,
+    variables: {
+      input: {
+        ...buttonColorFilterObj,
+      },
+    },
+  }).items[0];
+  const buttonColor =
+    buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;
+  const buttonEnabledFilterObj = {
+    and: [{ date: { ge: \\"2022-03-10\\" } }, { date: { le: \\"2023-03-11\\" } }],
+  };
+  const buttonEnabledDataStore = API.graphql({
+    query: listUserPreferences,
+    variables: {
+      input: {
+        ...buttonEnabledFilterObj,
+      },
+    },
+  }).items[0];
+  const buttonEnabled =
+    buttonEnabledProp !== undefined
+      ? buttonEnabledProp
+      : buttonEnabledDataStore;
+  return (
+    /* @ts-ignore: TS2322 */
+    <div>
+      <Collection
+        type=\\"list\\"
+        isPaginated={!isApiPagination}
+        gap=\\"1.5rem\\"
+        backgroundColor={backgroundColor}
+        itemsPerPage={pageSize}
+        items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
+        {...getOverrideProps(overrides, \\"CollectionOfCustomButtons\\")}
+        {...rest}
+      >
+        {(item, index) => {
+          if (loading) {
+            return <Placeholder key={index} size=\\"large\\" />;
+          }
+          return (
+            <Flex
+              key={item.id}
+              {...(overrideItems && overrideItems({ item, index }))}
+            >
+              <Button
+                labelWidth={width}
+                backgroundColor={buttonColor?.favoriteColor}
+                disabled={isDisabled}
+                children={item.username || \\"hspain@gmail.com\\"}
+                {...(overrideItems && overrideItems({ item, index }))}
+              ></Button>
+            </Flex>
+          );
+        }}
+      </Collection>
+      {isApiPagination && (
+        <Pagination
+          currentPage={pageIndex}
+          totalPages={maxViewed}
+          hasMorePages={hasMorePages}
+          onNext={handleNextPage}
+          onPrevious={handlePreviousPage}
+          onChange={jumpToPage}
+        />
+      )}
+    </div>
+  );
+}
+"
+`;
+
+exports[`amplify render tests collection GraphQL should render collection with data binding with no predicate 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { listUntitledModels } from \\"../graphql/queries\\";
+import ListingCard, { ListingCardProps } from \\"./ListingCard\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import {
+  Collection,
+  CollectionProps,
+  Pagination,
+  Placeholder,
+} from \\"@aws-amplify/ui-react\\";
+import { API } from \\"aws-amplify\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type ListingCardCollectionOverridesProps = {
+  ListingCardCollection?: PrimitiveOverrideProps<CollectionProps>;
+  ListingCard?: ListingCardProps;
+} & EscapeHatchProps;
+export type ListingCardCollectionProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    items?: any[];
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => ListingCardProps;
+  } & {
+    overrides?: ListingCardCollectionOverridesProps | undefined | null;
+  }
+>;
+
+const nextToken = {};
+const apiCache = {};
+export default function ListingCardCollection(
+  props: ListingCardCollectionProps
+): React.ReactElement {
+  const { items: itemsProp, overrideItems, overrides, ...rest } = props;
+  const [pageIndex, setPageIndex] = React.useState(1);
+  const [hasMorePages, setHasMorePages] = React.useState(true);
+  const [items, setItems] = React.useState([]);
+  const [isApiPagination, setIsApiPagination] = React.useState(false);
+  const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
+  const [loading, setLoading] = React.useState(true);
+  const [maxViewed, setMaxViewed] = React.useState(1);
+  const pageSize = 4;
+  React.useEffect(() => {
+    nextToken[instanceKey] = \\"\\";
+    apiCache[instanceKey] = [];
+  }, [instanceKey]);
+  React.useEffect(() => {
+    setIsApiPagination(!!!itemsProp);
+  }, [itemsProp]);
+  const handlePreviousPage = () => {
+    setPageIndex(pageIndex - 1);
+  };
+  const handleNextPage = () => {
+    setPageIndex(pageIndex + 1);
+  };
+  const jumpToPage = (pageNum?: number) => {
+    setPageIndex(pageNum!);
+  };
+  const loadPage = async (page: number) => {
+    const cacheUntil = page * pageSize + 1;
+    const newCache = apiCache[instanceKey].slice();
+    let newNext = nextToken[instanceKey];
+    while (newCache.length < cacheUntil && newNext != null) {
+      setLoading(true);
+      const variables: any = {
+        limit: pageSize,
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listUntitledModels,
+          variables,
+        })
+      ).data.listUntitledModels;
+      var loaded = await Promise.all(
+        result.items.map(async (item) => {
+          return {
+            ...item,
+          };
+        })
+      );
+      newCache.push(...loaded);
+      newNext = result.nextToken;
+    }
+    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    setItems(cacheSlice);
+    setHasMorePages(!!newNext);
+    setLoading(false);
+    apiCache[instanceKey] = newCache;
+    nextToken[instanceKey] = newNext;
+  };
+  React.useEffect(() => {
+    loadPage(pageIndex);
+  }, [pageIndex]);
+  React.useEffect(() => {
+    setMaxViewed(Math.max(maxViewed, pageIndex));
+  }, [pageIndex, maxViewed, setMaxViewed]);
+  return (
+    /* @ts-ignore: TS2322 */
+    <div>
+      <Collection
+        isPaginated={!isApiPagination}
+        collectionType=\\"grid\\"
+        type=\\"list\\"
+        columns=\\"2\\"
+        order=\\"left-to-right\\"
+        itemsPerPage={pageSize}
+        items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
+        {...getOverrideProps(overrides, \\"ListingCardCollection\\")}
+        {...rest}
+      >
+        {(item, index) => {
+          if (loading) {
+            return <Placeholder key={index} size=\\"large\\" />;
+          }
+          return (
+            <ListingCard
+              marginRight=\\"0\\"
+              marginBottom=\\"0\\"
+              marginTop=\\"0\\"
+              marginLeft=\\"0\\"
+              key={item.id}
+              {...(overrideItems && overrideItems({ item, index }))}
+            ></ListingCard>
+          );
+        }}
+      </Collection>
+      {isApiPagination && (
+        <Pagination
+          currentPage={pageIndex}
+          totalPages={maxViewed}
+          hasMorePages={hasMorePages}
+          onNext={handleNextPage}
+          onPrevious={handlePreviousPage}
+          onChange={jumpToPage}
+        />
+      )}
+    </div>
+  );
+}
+"
+`;
+
+exports[`amplify render tests collection GraphQL should render collection without data binding 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import ListingCard, { ListingCardProps } from \\"./ListingCard\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import {
+  Collection,
+  CollectionProps,
+  Pagination,
+  Placeholder,
+} from \\"@aws-amplify/ui-react\\";
+import { API } from \\"aws-amplify\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type ListingCardCollectionOverridesProps = {
+  ListingCardCollection?: PrimitiveOverrideProps<CollectionProps>;
+  ListingCard?: ListingCardProps;
+} & EscapeHatchProps;
+export type ListingCardCollectionProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    items?: any[];
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => ListingCardProps;
+  } & {
+    overrides?: ListingCardCollectionOverridesProps | undefined | null;
+  }
+>;
+
+const nextToken = {};
+const apiCache = {};
+export default function ListingCardCollection(
+  props: ListingCardCollectionProps
+): React.ReactElement {
+  const { items: itemsProp, overrideItems, overrides, ...rest } = props;
+  const [pageIndex, setPageIndex] = React.useState(1);
+  const [hasMorePages, setHasMorePages] = React.useState(true);
+  const [items, setItems] = React.useState([]);
+  const [isApiPagination, setIsApiPagination] = React.useState(false);
+  const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
+  const [loading, setLoading] = React.useState(true);
+  const [maxViewed, setMaxViewed] = React.useState(1);
+  const pageSize = 4;
+  React.useEffect(() => {
+    nextToken[instanceKey] = \\"\\";
+    apiCache[instanceKey] = [];
+  }, [instanceKey]);
+  React.useEffect(() => {
+    setIsApiPagination(!!!itemsProp);
+  }, [itemsProp]);
+  const handlePreviousPage = () => {
+    setPageIndex(pageIndex - 1);
+  };
+  const handleNextPage = () => {
+    setPageIndex(pageIndex + 1);
+  };
+  const jumpToPage = (pageNum?: number) => {
+    setPageIndex(pageNum!);
+  };
+  const loadPage = async (page: number) => {
+    const cacheUntil = page * pageSize + 1;
+    const newCache = apiCache[instanceKey].slice();
+    let newNext = nextToken[instanceKey];
+    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    setItems(cacheSlice);
+    setHasMorePages(!!newNext);
+    setLoading(false);
+    apiCache[instanceKey] = newCache;
+    nextToken[instanceKey] = newNext;
+  };
+  React.useEffect(() => {
+    loadPage(pageIndex);
+  }, [pageIndex]);
+  React.useEffect(() => {
+    setMaxViewed(Math.max(maxViewed, pageIndex));
+  }, [pageIndex, maxViewed, setMaxViewed]);
+  return (
+    /* @ts-ignore: TS2322 */
+    <div>
+      <Collection
+        type=\\"list\\"
+        isPaginated={!isApiPagination}
+        itemsPerPage={pageSize}
+        items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
+        {...getOverrideProps(overrides, \\"ListingCardCollection\\")}
+        {...rest}
+      >
+        {(item, index) => {
+          if (loading) {
+            return <Placeholder key={index} size=\\"large\\" />;
+          }
+          return (
+            <ListingCard
+              key={item.id}
+              {...(overrideItems && overrideItems({ item, index }))}
+            ></ListingCard>
+          );
+        }}
+      </Collection>
+      {isApiPagination && (
+        <Pagination
+          currentPage={pageIndex}
+          totalPages={maxViewed}
+          hasMorePages={hasMorePages}
+          onNext={handleNextPage}
+          onPrevious={handlePreviousPage}
+          onChange={jumpToPage}
+        />
+      )}
+    </div>
+  );
+}
+"
+`;
+
+exports[`amplify render tests collection GraphQL should render nested query if model has a hasMany relationship 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { listAuthors } from \\"../graphql/queries\\";
+import AuthorProfile, { AuthorProfileProps } from \\"./AuthorProfile\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import {
+  Collection,
+  CollectionProps,
+  Pagination,
+  Placeholder,
+} from \\"@aws-amplify/ui-react\\";
+import { API } from \\"aws-amplify\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type AuthorProfileCollectionOverridesProps = {
+  AuthorProfileCollection?: PrimitiveOverrideProps<CollectionProps>;
+  AuthorProfile?: AuthorProfileProps;
+} & EscapeHatchProps;
+export type AuthorProfileCollectionProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    items?: any[];
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => AuthorProfileProps;
+  } & {
+    overrides?: AuthorProfileCollectionOverridesProps | undefined | null;
+  }
+>;
+
+const nextToken = {};
+const apiCache = {};
+export default function AuthorProfileCollection(
+  props: AuthorProfileCollectionProps
+): React.ReactElement {
+  const { items: itemsProp, overrideItems, overrides, ...rest } = props;
+  const [pageIndex, setPageIndex] = React.useState(1);
+  const [hasMorePages, setHasMorePages] = React.useState(true);
+  const [items, setItems] = React.useState([]);
+  const [isApiPagination, setIsApiPagination] = React.useState(false);
+  const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
+  const [loading, setLoading] = React.useState(true);
+  const [maxViewed, setMaxViewed] = React.useState(1);
+  const pageSize = 4;
+  React.useEffect(() => {
+    nextToken[instanceKey] = \\"\\";
+    apiCache[instanceKey] = [];
+  }, [instanceKey]);
+  React.useEffect(() => {
+    setIsApiPagination(!!!itemsProp);
+  }, [itemsProp]);
+  const handlePreviousPage = () => {
+    setPageIndex(pageIndex - 1);
+  };
+  const handleNextPage = () => {
+    setPageIndex(pageIndex + 1);
+  };
+  const jumpToPage = (pageNum?: number) => {
+    setPageIndex(pageNum!);
+  };
+  const loadPage = async (page: number) => {
+    const cacheUntil = page * pageSize + 1;
+    const newCache = apiCache[instanceKey].slice();
+    let newNext = nextToken[instanceKey];
+    while (newCache.length < cacheUntil && newNext != null) {
+      setLoading(true);
+      const variables: any = {
+        limit: pageSize,
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listAuthors,
+          variables,
+        })
+      ).data.listAuthors;
+      var loaded = await Promise.all(
+        result.items.map(async (item) => {
+          const Books = (
+            await API.graphql({
+              query: booksByAuthorID,
+              variables: { authorID: item.id },
+            })
+          ).data.booksByAuthorID.items;
+          const Publishers = (
+            await API.graphql({
+              query: publishersByAuthorID,
+              variables: { authorID: item.id },
+            })
+          ).data.publishersByAuthorID.items;
+          return {
+            ...item,
+            Books,
+            Publisher,
+          };
+        })
+      );
+      newCache.push(...loaded);
+      newNext = result.nextToken;
+    }
+    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    setItems(cacheSlice);
+    setHasMorePages(!!newNext);
+    setLoading(false);
+    apiCache[instanceKey] = newCache;
+    nextToken[instanceKey] = newNext;
+  };
+  React.useEffect(() => {
+    loadPage(pageIndex);
+  }, [pageIndex]);
+  React.useEffect(() => {
+    setMaxViewed(Math.max(maxViewed, pageIndex));
+  }, [pageIndex, maxViewed, setMaxViewed]);
+  return (
+    /* @ts-ignore: TS2322 */
+    <div>
+      <Collection
+        type=\\"list\\"
+        itemsPerPage={6}
+        templateColumns=\\"1fr 1fr\\"
+        autoFlow=\\"row\\"
+        alignItems=\\"stretch\\"
+        justifyContent=\\"stretch\\"
+        itemsPerPage={pageSize}
+        items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
+        {...getOverrideProps(overrides, \\"AuthorProfileCollection\\")}
+        {...rest}
+      >
+        {(item, index) => {
+          if (loading) {
+            return <Placeholder key={index} size=\\"large\\" />;
+          }
+          return (
+            <AuthorProfile
+              author={item}
+              key={item.id}
+              {...(overrideItems && overrideItems({ item, index }))}
+            ></AuthorProfile>
+          );
+        }}
+      </Collection>
+      {isApiPagination && (
+        <Pagination
+          currentPage={pageIndex}
+          totalPages={maxViewed}
+          hasMorePages={hasMorePages}
+          onNext={handleNextPage}
+          onPrevious={handlePreviousPage}
+          onChange={jumpToPage}
+        />
+      )}
+    </div>
+  );
+}
+"
+`;
+
 exports[`amplify render tests collection should not render nested query if the data schema is not provided 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -170,6 +170,41 @@ describe('amplify render tests', () => {
       expect(componentText).toContain(`key={\`\${item.name}\${item.description}\`}`);
       expect(componentText).toMatchSnapshot();
     });
+
+    describe('GraphQL', () => {
+      it('should render collection with data binding', () => {
+        const generatedCode = generateWithAmplifyRenderer('collectionWithBinding', rendererConfigWithGraphQL);
+        expect(generatedCode.componentText).toMatchSnapshot();
+      });
+
+      it('should render collection without data binding', () => {
+        const generatedCode = generateWithAmplifyRenderer('collectionWithoutBinding', rendererConfigWithGraphQL);
+        expect(generatedCode.componentText).toMatchSnapshot();
+      });
+
+      it('should render collection with data binding with no predicate', () => {
+        const generatedCode = generateWithAmplifyRenderer(
+          'collectionWithBindingWithoutPredicate',
+          rendererConfigWithGraphQL,
+        );
+        expect(generatedCode.componentText).toMatchSnapshot();
+      });
+
+      it('should render nested query if model has a hasMany relationship', () => {
+        const { componentText } = generateWithAmplifyRenderer(
+          'authorCollectionComponent',
+          rendererConfigWithGraphQL,
+          false,
+          authorHasManySchema,
+        );
+        expect(componentText).toMatchSnapshot();
+      });
+
+      it('should not render nested query if the data schema is not provided', () => {
+        const { componentText } = generateWithAmplifyRenderer('authorCollectionComponent', rendererConfigWithGraphQL);
+        expect(componentText).toMatchSnapshot();
+      });
+    });
   });
 
   describe('complex examples', () => {

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/amplify-renderer.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/amplify-renderer.ts
@@ -129,9 +129,13 @@ export class AmplifyRenderer extends ReactStudioTemplateRenderer {
         ).renderElement(renderChildren);
 
       case Primitive.Collection:
-        return new CollectionRenderer(component, this.componentMetadata, this.importCollection, parent).renderElement(
-          renderChildren,
-        );
+        return new CollectionRenderer(
+          component,
+          this.componentMetadata,
+          this.importCollection,
+          this.renderConfig,
+          parent,
+        ).renderElement(renderChildren);
 
       case Primitive.Divider:
         return new ReactComponentRenderer<DividerProps>(

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
@@ -16,47 +16,184 @@
 import { BaseComponentProps } from '@aws-amplify/ui-react';
 import {
   CollectionStudioComponentProperty,
+  ComponentMetadata,
   isStudioComponentWithCollectionProperties,
+  StudioComponent,
   StudioComponentChild,
+  StudioNode,
 } from '@aws-amplify/codegen-ui';
-import { factory, JsxChild, JsxElement, JsxExpression, JsxOpeningElement, SyntaxKind } from 'typescript';
+import ts, {
+  factory,
+  JsxAttribute,
+  JsxChild,
+  JsxElement,
+  JsxExpression,
+  JsxOpeningElement,
+  SyntaxKind,
+} from 'typescript';
 import { ReactComponentRenderer } from '../react-component-renderer';
 import { buildOpeningElementProperties } from '../react-component-render-helper';
+import { ImportCollection, ImportValue } from '../imports';
+import { ReactRenderConfig } from '../react-render-config';
+import { defaultRenderConfig } from '../react-studio-template-renderer-helper';
 
 export default class CollectionRenderer extends ReactComponentRenderer<BaseComponentProps> {
+  constructor(
+    component: StudioComponent | StudioComponentChild,
+    protected componentMetadata: ComponentMetadata,
+    protected importCollection: ImportCollection,
+    protected renderConfig: ReactRenderConfig & typeof defaultRenderConfig,
+    protected parent?: StudioNode,
+  ) {
+    super(component, componentMetadata, importCollection, parent);
+  }
+
   renderElement(renderChildren: (children: StudioComponentChild[]) => JsxChild[]): JsxElement {
     this.addKeyPropertyToChildren(this.component.children ?? []);
     const childrenJsx = this.component.children ? renderChildren(this.component.children ?? []) : [];
 
     const arrowFuncExpr = this.renderItemArrowFunctionExpr(childrenJsx);
     const itemsVariableName = this.findItemsVariableName();
-    const element = factory.createJsxElement(
-      this.renderCollectionOpeningElement(itemsVariableName),
-      [arrowFuncExpr],
-      factory.createJsxClosingElement(factory.createIdentifier(this.component.componentType)),
-    );
+    const element =
+      this.renderConfig.apiConfiguration?.dataApi === 'GraphQL'
+        ? factory.createJsxElement(
+            factory.createJsxOpeningElement(
+              factory.createIdentifier('div'),
+              undefined,
+              factory.createJsxAttributes([]),
+            ),
+            [
+              factory.createJsxElement(
+                this.renderCollectionOpeningElement(itemsVariableName),
+                [arrowFuncExpr],
+                factory.createJsxClosingElement(factory.createIdentifier(this.component.componentType)),
+              ),
+              factory.createJsxExpression(
+                undefined,
+                factory.createBinaryExpression(
+                  factory.createIdentifier('isApiPagination'),
+                  factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
+                  factory.createJsxSelfClosingElement(
+                    factory.createIdentifier('Pagination'),
+                    undefined,
+                    factory.createJsxAttributes([
+                      factory.createJsxAttribute(
+                        factory.createIdentifier('currentPage'),
+                        factory.createJsxExpression(undefined, factory.createIdentifier('pageIndex')),
+                      ),
+                      factory.createJsxAttribute(
+                        factory.createIdentifier('totalPages'),
+                        factory.createJsxExpression(undefined, factory.createIdentifier('maxViewed')),
+                      ),
+                      factory.createJsxAttribute(
+                        factory.createIdentifier('hasMorePages'),
+                        factory.createJsxExpression(undefined, factory.createIdentifier('hasMorePages')),
+                      ),
+                      factory.createJsxAttribute(
+                        factory.createIdentifier('onNext'),
+                        factory.createJsxExpression(undefined, factory.createIdentifier('handleNextPage')),
+                      ),
+                      factory.createJsxAttribute(
+                        factory.createIdentifier('onPrevious'),
+                        factory.createJsxExpression(undefined, factory.createIdentifier('handlePreviousPage')),
+                      ),
+                      factory.createJsxAttribute(
+                        factory.createIdentifier('onChange'),
+                        factory.createJsxExpression(undefined, factory.createIdentifier('jumpToPage')),
+                      ),
+                    ]),
+                  ),
+                ),
+              ),
+            ],
+            factory.createJsxClosingElement(factory.createIdentifier('div')),
+          )
+        : factory.createJsxElement(
+            this.renderCollectionOpeningElement(itemsVariableName),
+            [arrowFuncExpr],
+            factory.createJsxClosingElement(factory.createIdentifier(this.component.componentType)),
+          );
 
     this.importCollection.addImport('@aws-amplify/ui-react', this.component.componentType);
+
+    if (this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
+      this.importCollection.addMappedImport(ImportValue.API);
+      this.importCollection.addMappedImport(ImportValue.PAGINATION);
+      this.importCollection.addMappedImport(ImportValue.PLACEHOLDER);
+    }
 
     return element;
   }
 
   private renderCollectionOpeningElement(itemsVariableName?: string): JsxOpeningElement {
-    const propsArray = Object.entries(this.component.properties).map(([key, value]) =>
-      buildOpeningElementProperties(this.componentMetadata, value, key),
-    );
+    const propsArray = Object.entries(this.component.properties).map(([key, value]) => {
+      if (key === 'isPaginated' && this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
+        return factory.createJsxAttribute(
+          factory.createIdentifier('isPaginated'),
+          factory.createJsxExpression(
+            undefined,
+            factory.createPrefixUnaryExpression(
+              ts.SyntaxKind.ExclamationToken,
+              factory.createIdentifier('isApiPagination'),
+            ),
+          ),
+        );
+      }
+      return buildOpeningElementProperties(this.componentMetadata, value, key);
+    });
 
-    const itemsAttribute = factory.createJsxAttribute(
-      factory.createIdentifier('items'),
-      factory.createJsxExpression(
-        undefined,
-        factory.createBinaryExpression(
-          factory.createIdentifier(itemsVariableName || 'items'),
-          factory.createToken(SyntaxKind.BarBarToken),
-          factory.createArrayLiteralExpression([], false),
+    let itemsAttribute: JsxAttribute;
+
+    if (this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
+      propsArray.push(
+        factory.createJsxAttribute(
+          factory.createIdentifier('itemsPerPage'),
+          factory.createJsxExpression(undefined, factory.createIdentifier('pageSize')),
         ),
-      ),
-    );
+      );
+
+      itemsAttribute = factory.createJsxAttribute(
+        factory.createIdentifier('items'),
+        factory.createJsxExpression(
+          undefined,
+          factory.createBinaryExpression(
+            factory.createIdentifier('itemsProp'),
+            factory.createToken(ts.SyntaxKind.BarBarToken),
+            factory.createParenthesizedExpression(
+              factory.createConditionalExpression(
+                factory.createIdentifier('loading'),
+                factory.createToken(ts.SyntaxKind.QuestionToken),
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createNewExpression(factory.createIdentifier('Array'), undefined, [
+                      factory.createIdentifier('pageSize'),
+                    ]),
+                    factory.createIdentifier('fill'),
+                  ),
+                  undefined,
+                  [factory.createObjectLiteralExpression([], false)],
+                ),
+                factory.createToken(ts.SyntaxKind.ColonToken),
+                factory.createIdentifier('items'),
+              ),
+            ),
+          ),
+        ),
+      );
+    } else {
+      itemsAttribute = factory.createJsxAttribute(
+        factory.createIdentifier('items'),
+        factory.createJsxExpression(
+          undefined,
+          factory.createBinaryExpression(
+            factory.createIdentifier(itemsVariableName || 'items'),
+            factory.createToken(SyntaxKind.BarBarToken),
+            factory.createArrayLiteralExpression([], false),
+          ),
+        ),
+      );
+    }
+
     propsArray.push(itemsAttribute);
 
     this.addPropsSpreadAttributes(propsArray);
@@ -105,6 +242,72 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
   }
 
   private renderItemArrowFunctionExpr(childrenJsx: JsxChild[]): JsxExpression {
+    if (this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
+      return factory.createJsxExpression(
+        undefined,
+        factory.createArrowFunction(
+          undefined,
+          undefined,
+          [
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              undefined,
+              factory.createIdentifier('item'),
+              undefined,
+              undefined,
+              undefined,
+            ),
+            factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              undefined,
+
+              factory.createIdentifier('index'),
+              undefined,
+              undefined,
+              undefined,
+            ),
+          ],
+          undefined,
+          factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          factory.createBlock(
+            [
+              factory.createIfStatement(
+                factory.createIdentifier('loading'),
+                factory.createBlock(
+                  [
+                    factory.createReturnStatement(
+                      factory.createParenthesizedExpression(
+                        factory.createJsxSelfClosingElement(
+                          factory.createIdentifier('Placeholder'),
+                          undefined,
+                          factory.createJsxAttributes([
+                            factory.createJsxAttribute(
+                              factory.createIdentifier('key'),
+                              factory.createJsxExpression(undefined, factory.createIdentifier('index')),
+                            ),
+                            factory.createJsxAttribute(
+                              factory.createIdentifier('size'),
+                              factory.createStringLiteral('large'),
+                            ),
+                          ]),
+                        ),
+                      ),
+                    ),
+                  ],
+                  true,
+                ),
+                undefined,
+              ),
+              factory.createReturnStatement(factory.createParenthesizedExpression(childrenJsx[0] as JsxExpression)),
+            ],
+            true,
+          ),
+        ),
+      );
+    }
+
     return factory.createJsxExpression(
       undefined,
       factory.createArrowFunction(

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -394,8 +394,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     if (!formMetadata) {
       throw new Error(`Form Metadata is missing from form: ${this.component.name}`);
     }
-    this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD);
-    this.importCollection.addMappedImport(ImportValue.FETCH_BY_PATH);
+    this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD, ImportValue.FETCH_BY_PATH);
 
     // add model import for datastore type
     if (dataSourceType === 'DataStore') {
@@ -535,8 +534,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
       statements.push(buildResetValuesOnRecordUpdate(defaultValueVariableName, linkedDataNames));
     }
 
-    this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD);
-    this.importCollection.addMappedImport(ImportValue.FETCH_BY_PATH);
+    this.importCollection.addMappedImport(ImportValue.VALIDATE_FIELD, ImportValue.FETCH_BY_PATH);
 
     if (dataSourceType === 'Custom' && formActionType === 'update') {
       statements.push(addUseEffectWrapper([buildSetStateFunction(formMetadata.fieldConfigs)], []));

--- a/packages/codegen-ui-react/lib/helpers/index.ts
+++ b/packages/codegen-ui-react/lib/helpers/index.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 import { GenericDataField, GenericDataSchema, StudioFormFields } from '@aws-amplify/codegen-ui/lib/types';
-import ts, { factory, Statement, Expression, NodeFlags, Identifier, ParameterDeclaration } from 'typescript';
+import { factory, Statement, Expression, NodeFlags, Identifier, ParameterDeclaration, SyntaxKind } from 'typescript';
 import { isPrimitive } from '../primitive';
 
 export const lowerCaseFirst = (input: string) => input.charAt(0).toLowerCase() + input.slice(1);
@@ -150,7 +150,7 @@ export const buildArrowFunctionStatement = (
             undefined,
             parameterDeclarations ?? [],
             undefined,
-            factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            factory.createToken(SyntaxKind.EqualsGreaterThanToken),
             factory.createBlock(
               [
                 factory.createExpressionStatement(
@@ -162,7 +162,7 @@ export const buildArrowFunctionStatement = (
           ),
         ),
       ],
-      ts.NodeFlags.Const,
+      NodeFlags.Const,
     ),
   );
 };

--- a/packages/codegen-ui-react/lib/helpers/index.ts
+++ b/packages/codegen-ui-react/lib/helpers/index.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  */
 import { GenericDataField, GenericDataSchema, StudioFormFields } from '@aws-amplify/codegen-ui/lib/types';
-import { factory, Statement, Expression, NodeFlags, Identifier } from 'typescript';
+import ts, { factory, Statement, Expression, NodeFlags, Identifier, ParameterDeclaration } from 'typescript';
 import { isPrimitive } from '../primitive';
 
 export const lowerCaseFirst = (input: string) => input.charAt(0).toLowerCase() + input.slice(1);
@@ -117,6 +117,52 @@ export const buildInitConstVariableExpression = (name: string, value: Expression
     factory.createVariableDeclarationList(
       [factory.createVariableDeclaration(factory.createIdentifier(name), undefined, undefined, value)],
       NodeFlags.Const,
+    ),
+  );
+};
+
+/**
+ * Create statement to declare an arrow function to a const.
+ *
+ * @example
+ * ```
+ * const variableName = (parameterDeclaration) => {
+ *  functionName(expression);
+ * };
+ * ```
+ */
+export const buildArrowFunctionStatement = (
+  variableName: string,
+  functionName: string,
+  expression: Expression,
+  parameterDeclarations?: ParameterDeclaration[],
+): Statement => {
+  return factory.createVariableStatement(
+    undefined,
+    factory.createVariableDeclarationList(
+      [
+        factory.createVariableDeclaration(
+          factory.createIdentifier(variableName),
+          undefined,
+          undefined,
+          factory.createArrowFunction(
+            undefined,
+            undefined,
+            parameterDeclarations ?? [],
+            undefined,
+            factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            factory.createBlock(
+              [
+                factory.createExpressionStatement(
+                  factory.createCallExpression(factory.createIdentifier(functionName), undefined, [expression]),
+                ),
+              ],
+              true,
+            ),
+          ),
+        ),
+      ],
+      ts.NodeFlags.Const,
     ),
   );
 };

--- a/packages/codegen-ui-react/lib/imports/import-collection.ts
+++ b/packages/codegen-ui-react/lib/imports/import-collection.ts
@@ -66,9 +66,11 @@ export class ImportCollection {
     throw new InvalidInputError('Render is not configured to utilize GraphQL operations');
   }
 
-  addMappedImport(importValue: ImportValue) {
-    const importPackage = ImportMapping[importValue];
-    this.addImport(importPackage, importValue);
+  addMappedImport(...importValue: ImportValue[]) {
+    importValue.forEach((value) => {
+      const importPackage = ImportMapping[value];
+      this.addImport(importPackage, value);
+    });
   }
 
   addGraphqlMutationImport(importName: string) {

--- a/packages/codegen-ui-react/lib/imports/import-mapping.ts
+++ b/packages/codegen-ui-react/lib/imports/import-mapping.ts
@@ -53,6 +53,8 @@ export enum ImportValue {
   DEFAULT_THEME = 'defaultTheme',
   USE_STATE = 'useState',
   API = 'API',
+  PAGINATION = 'Pagination',
+  PLACEHOLDER = 'Placeholder',
 }
 
 export const ImportMapping: Record<ImportValue, ImportSource> = {
@@ -82,4 +84,6 @@ export const ImportMapping: Record<ImportValue, ImportSource> = {
   [ImportValue.PROCESS_FILE]: ImportSource.UTILS,
   [ImportValue.USE_STATE]: ImportSource.REACT,
   [ImportValue.API]: ImportSource.AMPLIFY,
+  [ImportValue.PAGINATION]: ImportSource.UI_REACT,
+  [ImportValue.PLACEHOLDER]: ImportSource.UI_REACT,
 };

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -63,7 +63,11 @@ import ts, {
   PropertyAssignment,
   ObjectLiteralElementLike,
   Identifier,
+  Expression,
+  ParameterDeclaration,
+  ShorthandPropertyAssignment,
 } from 'typescript';
+import pluralize from 'pluralize';
 import { ImportCollection, ImportSource, ImportValue } from './imports';
 import { ReactOutputManager } from './react-output-manager';
 import { ReactRenderConfig, ScriptKind, scriptKindToFileExtension } from './react-render-config';
@@ -110,7 +114,11 @@ import {
   fieldNeedsRelationshipLoadedForCollection,
   isAliased,
   removeAlias,
+  buildInitConstVariableExpression,
+  buildArrowFunctionStatement,
 } from './helpers';
+import { addUseEffectWrapper } from './utils/generate-react-hooks';
+import { ActionType, getGraphqlCallExpression, getGraphqlQueryForModel } from './utils/graphql';
 
 export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer<
   string,
@@ -233,6 +241,46 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     });
 
     componentText += EOL;
+
+    if (this.component.componentType === 'Collection' && this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
+      componentText += EOL;
+
+      const graphqlVariableDeclarations = [
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier('nextToken'),
+                undefined,
+                undefined,
+                factory.createObjectLiteralExpression([], false),
+              ),
+            ],
+            ts.NodeFlags.Const,
+          ),
+        ),
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier('apiCache'),
+                undefined,
+                undefined,
+                factory.createObjectLiteralExpression([], false),
+              ),
+            ],
+            ts.NodeFlags.Const,
+          ),
+        ),
+      ];
+
+      graphqlVariableDeclarations.forEach((variableDeclaration) => {
+        const result = printer.printNode(EmitHint.Unspecified, variableDeclaration, file);
+        componentText += result + EOL;
+      });
+    }
 
     const result = printer.printNode(EmitHint.Unspecified, wrappedFunction, file);
     componentText += result;
@@ -637,14 +685,15 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     }
 
     if (component.componentType === 'Collection') {
-      const bindingElement = this.hasCollectionPropertyNamedItems(component)
-        ? factory.createBindingElement(
-            undefined,
-            factory.createIdentifier('items'),
-            factory.createIdentifier('itemsProp'),
-            undefined,
-          )
-        : factory.createBindingElement(undefined, undefined, factory.createIdentifier('items'), undefined);
+      const bindingElement =
+        this.hasCollectionPropertyNamedItems(component) || this.renderConfig.apiConfiguration?.dataApi === 'GraphQL'
+          ? factory.createBindingElement(
+              undefined,
+              factory.createIdentifier('items'),
+              factory.createIdentifier('itemsProp'),
+              undefined,
+            )
+          : factory.createBindingElement(undefined, undefined, factory.createIdentifier('items'), undefined);
       elements.push(bindingElement);
       elements.push(
         factory.createBindingElement(undefined, undefined, factory.createIdentifier('overrideItems'), undefined),
@@ -705,12 +754,19 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       statements.push(authStatement);
     }
 
-    const collectionBindingStatements = this.buildCollectionBindingStatements(component);
-    collectionBindingStatements.forEach((entry) => {
-      statements.push(entry);
-    });
+    if (component.componentType === 'Collection' && this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
+      const paginationStatements = this.buildGraphqlPaginationStatements(component);
+      paginationStatements.forEach((entry) => {
+        statements.push(entry);
+      });
+    } else {
+      const collectionBindingStatements = this.buildCollectionBindingStatements(component);
+      collectionBindingStatements.forEach((entry) => {
+        statements.push(entry);
+      });
+    }
 
-    const useStoreBindingStatements = this.buildUseDataStoreBindingStatements(component);
+    const useStoreBindingStatements = this.buildUseBindingStatements(component);
     useStoreBindingStatements.forEach((entry) => {
       statements.push(entry);
     });
@@ -1239,7 +1295,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     );
   }
 
-  private buildUseDataStoreBindingStatements(component: StudioComponent): Statement[] {
+  private buildUseBindingStatements(component: StudioComponent): Statement[] {
     const statements: Statement[] = [];
 
     // generate for single record binding
@@ -1261,7 +1317,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
             statements.push(
               this.buildPredicateDeclaration(propName, bindingProperties.predicate, bindingProperties.model),
             );
-            statements.push(this.buildCreateDataStorePredicateCall(modelName, propName));
+
+            if (this.renderConfig.apiConfiguration?.dataApi !== 'GraphQL') {
+              statements.push(this.buildCreateDataStorePredicateCall(modelName, propName));
+            }
+
             /**
              * const buttonColorDataStore = useDataStoreBinding({
              *   type: "collection"
@@ -1279,7 +1339,13 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                       undefined,
                       factory.createElementAccessExpression(
                         factory.createPropertyAccessExpression(
-                          this.buildUseDataStoreBindingCall('collection', modelName, this.getFilterName(propName)),
+                          this.renderConfig.apiConfiguration?.dataApi === 'GraphQL'
+                            ? getGraphqlCallExpression(ActionType.LIST, modelName, this.importCollection, [
+                                factory.createSpreadAssignment(
+                                  factory.createIdentifier(this.getFilterObjName(propName)),
+                                ),
+                              ])
+                            : this.buildUseDataStoreBindingCall('collection', modelName, this.getFilterName(propName)),
                           factory.createIdentifier('items'),
                         ),
                         factory.createNumericLiteral('0'),
@@ -1451,35 +1517,65 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       return this.predicateToObjectLiteralExpression(resolveBetweenPredicateToMultiplePredicates(predicate), model);
     }
 
-    const objectAssignments = Object.entries(filteredPredicate).map(([key, value]) => {
-      if (key === 'and' || key === 'or') {
+    let objectAssignments: PropertyAssignment[];
+
+    if (
+      this.renderConfig.apiConfiguration?.dataApi === 'GraphQL' &&
+      filteredPredicate.field &&
+      filteredPredicate.operand &&
+      filteredPredicate.operator
+    ) {
+      objectAssignments = [
+        factory.createPropertyAssignment(
+          factory.createIdentifier(filteredPredicate.field),
+          factory.createObjectLiteralExpression(
+            [
+              factory.createPropertyAssignment(
+                factory.createIdentifier(filteredPredicate.operator),
+                getConditionalOperandExpression(
+                  parseNumberOperand(
+                    filteredPredicate.operand,
+                    this.componentMetadata.dataSchemaMetadata?.models[model]?.fields[predicate.field || ''],
+                  ),
+                  operandType,
+                ),
+              ),
+            ],
+            false,
+          ),
+        ),
+      ];
+    } else {
+      objectAssignments = Object.entries(filteredPredicate).map(([key, value]) => {
+        if (key === 'and' || key === 'or' || key === 'not') {
+          return factory.createPropertyAssignment(
+            factory.createIdentifier(key),
+            factory.createArrayLiteralExpression(
+              (predicate[key] as StudioComponentPredicate[]).map(
+                (pred: StudioComponentPredicate) => this.predicateToObjectLiteralExpression(pred, model),
+                false,
+              ),
+            ),
+          );
+        }
+        if (key === 'operand' && typeof value === 'string') {
+          return factory.createPropertyAssignment(
+            factory.createIdentifier(key),
+            getConditionalOperandExpression(
+              parseNumberOperand(
+                value,
+                this.componentMetadata.dataSchemaMetadata?.models[model]?.fields[predicate.field || ''],
+              ),
+              operandType,
+            ),
+          );
+        }
         return factory.createPropertyAssignment(
           factory.createIdentifier(key),
-          factory.createArrayLiteralExpression(
-            (predicate[key] as StudioComponentPredicate[]).map(
-              (pred: StudioComponentPredicate) => this.predicateToObjectLiteralExpression(pred, model),
-              false,
-            ),
-          ),
+          typeof value === 'string' ? factory.createStringLiteral(value) : factory.createIdentifier('undefined'),
         );
-      }
-      if (key === 'operand' && typeof value === 'string') {
-        return factory.createPropertyAssignment(
-          factory.createIdentifier(key),
-          getConditionalOperandExpression(
-            parseNumberOperand(
-              value,
-              this.componentMetadata.dataSchemaMetadata?.models[model]?.fields[predicate.field || ''],
-            ),
-            operandType,
-          ),
-        );
-      }
-      return factory.createPropertyAssignment(
-        factory.createIdentifier(key),
-        typeof value === 'string' ? factory.createStringLiteral(value) : factory.createIdentifier('undefined'),
-      );
-    });
+      });
+    }
 
     return factory.createObjectLiteralExpression(objectAssignments);
   }
@@ -1521,6 +1617,695 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     );
   }
 
+  private buildGraphqlPaginationStatements(component: StudioComponent): Statement[] {
+    const statements: Statement[] = [];
+
+    const stateVariables: { name: string; default: Expression }[] = [
+      { name: 'pageIndex', default: factory.createNumericLiteral('1') },
+      { name: 'hasMorePages', default: factory.createTrue() },
+      { name: 'items', default: factory.createArrayLiteralExpression([]) },
+      { name: 'isApiPagination', default: factory.createFalse() },
+      { name: 'instanceKey', default: factory.createStringLiteral('newGuid') },
+      { name: 'loading', default: factory.createTrue() },
+      { name: 'maxViewed', default: factory.createNumericLiteral(1) },
+    ];
+
+    /*
+        const [pageIndex, setPageIndex] = React.useState(1);
+        const [hasMorePages, setHasMorePages] = React.useState(true);
+        const [items, setItems] = React.useState([]);
+        const [isApiPagination, setIsApiPagination] = React.useState(false);
+        const [instanceKey] = React.useState('newGuid');
+        const [loading, setLoading] = React.useState(true);
+        const [maxViewed, setMaxViewed] = React.useState(1);
+     */
+    stateVariables.forEach((state) => {
+      statements.push(buildUseStateExpression(state.name, state.default));
+    });
+
+    // const pageSize = 4;
+    statements.push(buildInitConstVariableExpression('pageSize', factory.createNumericLiteral('4')));
+
+    /*
+      React.useEffect(() => {
+        nextToken[instanceKey] = '';
+        apiCache[instanceKey] = [];
+      },[instanceKey]);
+
+      React.useEffect(() => {
+        setIsApiPagination(!!!itemsProp);
+      }, [itemsProp]);
+    */
+    const instanceKeyStatements = [
+      factory.createExpressionStatement(
+        factory.createBinaryExpression(
+          factory.createElementAccessExpression(
+            factory.createIdentifier('nextToken'),
+            factory.createIdentifier('instanceKey'),
+          ),
+          factory.createToken(ts.SyntaxKind.EqualsToken),
+          factory.createStringLiteral(''),
+        ),
+      ),
+      factory.createExpressionStatement(
+        factory.createBinaryExpression(
+          factory.createElementAccessExpression(
+            factory.createIdentifier('apiCache'),
+            factory.createIdentifier('instanceKey'),
+          ),
+          factory.createToken(ts.SyntaxKind.EqualsToken),
+          factory.createArrayLiteralExpression([], false),
+        ),
+      ),
+    ];
+    statements.push(addUseEffectWrapper(instanceKeyStatements, ['instanceKey']));
+    statements.push(
+      addUseEffectWrapper(
+        [
+          factory.createExpressionStatement(
+            factory.createCallExpression(factory.createIdentifier('setIsApiPagination'), undefined, [
+              factory.createPrefixUnaryExpression(
+                ts.SyntaxKind.ExclamationToken,
+                factory.createPrefixUnaryExpression(
+                  ts.SyntaxKind.ExclamationToken,
+                  factory.createPrefixUnaryExpression(
+                    ts.SyntaxKind.ExclamationToken,
+                    factory.createIdentifier('itemsProp'),
+                  ),
+                ),
+              ),
+            ]),
+          ),
+        ],
+        ['itemsProp'],
+      ),
+    );
+
+    /*
+      const handlePreviousPage = () => {
+        setPageIndex(pageIndex-1);
+      };
+
+      const handleNextPage = () => {
+          setPageIndex(pageIndex+1);
+      };
+
+      const jumpToPage = (pageNum?: number) => {
+          setPageIndex(pageNum!);
+      };
+    */
+    const arrowFunctionVariables: {
+      variableName: string;
+      functionName: string;
+      expression: Expression;
+      parameterDeclarations?: ParameterDeclaration[];
+    }[] = [
+      {
+        variableName: 'handlePreviousPage',
+        functionName: 'setPageIndex',
+        expression: factory.createBinaryExpression(
+          factory.createIdentifier('pageIndex'),
+          factory.createToken(ts.SyntaxKind.MinusToken),
+          factory.createNumericLiteral('1'),
+        ),
+      },
+      {
+        variableName: 'handleNextPage',
+        functionName: 'setPageIndex',
+        expression: factory.createBinaryExpression(
+          factory.createIdentifier('pageIndex'),
+          factory.createToken(ts.SyntaxKind.PlusToken),
+          factory.createNumericLiteral('1'),
+        ),
+      },
+      {
+        variableName: 'jumpToPage',
+        functionName: 'setPageIndex',
+        expression: factory.createNonNullExpression(factory.createIdentifier('pageNum')),
+        parameterDeclarations: [
+          factory.createParameterDeclaration(
+            undefined,
+            undefined,
+            undefined,
+            factory.createIdentifier('pageNum'),
+            factory.createToken(ts.SyntaxKind.QuestionToken),
+            factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+            undefined,
+          ),
+        ],
+      },
+    ];
+    arrowFunctionVariables.forEach((entry) => {
+      statements.push(
+        buildArrowFunctionStatement(
+          entry.variableName,
+          entry.functionName,
+          entry.expression,
+          entry.parameterDeclarations,
+        ),
+      );
+    });
+
+    statements.push(this.buildLoadPageStatement(component));
+
+    /*
+      React.useEffect(() => {
+        loadPage(pageIndex);
+      }, [pageIndex]);
+
+      React.useEffect(() => {
+        setMaxViewed(Math.max(maxViewed, pageIndex));
+      }, [pageIndex, maxViewed, setMaxViewed]);
+    */
+    statements.push(
+      addUseEffectWrapper(
+        [
+          factory.createExpressionStatement(
+            factory.createCallExpression(factory.createIdentifier('loadPage'), undefined, [
+              factory.createIdentifier('pageIndex'),
+            ]),
+          ),
+        ],
+        ['pageIndex'],
+      ),
+    );
+    statements.push(
+      addUseEffectWrapper(
+        [
+          factory.createExpressionStatement(
+            factory.createCallExpression(factory.createIdentifier('setMaxViewed'), undefined, [
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('Math'),
+                  factory.createIdentifier('max'),
+                ),
+                undefined,
+                [factory.createIdentifier('maxViewed'), factory.createIdentifier('pageIndex')],
+              ),
+            ]),
+          ),
+        ],
+        ['pageIndex', 'maxViewed', 'setMaxViewed'],
+      ),
+    );
+
+    return statements;
+  }
+
+  private buildLoadPageStatement(component: StudioComponent): Statement {
+    const statements: Statement[] = [];
+
+    /*
+      const cacheUntil = (page*pageSize)+1; 
+      const newCache = apiCache[instanceKey].slice();
+      let newNext = nextToken[instanceKey];
+    */
+    statements.push(
+      buildInitConstVariableExpression(
+        'cacheUntil',
+        factory.createBinaryExpression(
+          factory.createParenthesizedExpression(
+            factory.createBinaryExpression(
+              factory.createIdentifier('page'),
+              factory.createToken(ts.SyntaxKind.AsteriskToken),
+              factory.createIdentifier('pageSize'),
+            ),
+          ),
+          factory.createToken(ts.SyntaxKind.PlusToken),
+          factory.createNumericLiteral('1'),
+        ),
+      ),
+    );
+    statements.push(
+      buildInitConstVariableExpression(
+        'newCache',
+        factory.createCallExpression(
+          factory.createPropertyAccessExpression(
+            factory.createElementAccessExpression(
+              factory.createIdentifier('apiCache'),
+              factory.createIdentifier('instanceKey'),
+            ),
+            factory.createIdentifier('slice'),
+          ),
+          undefined,
+          [],
+        ),
+      ),
+    );
+    statements.push(
+      factory.createVariableStatement(
+        undefined,
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              factory.createIdentifier('newNext'),
+              undefined,
+              undefined,
+              factory.createElementAccessExpression(
+                factory.createIdentifier('nextToken'),
+                factory.createIdentifier('instanceKey'),
+              ),
+            ),
+          ],
+          ts.NodeFlags.Let,
+        ),
+      ),
+    );
+
+    if (isStudioComponentWithCollectionProperties(component)) {
+      let filter: ObjectLiteralExpression | undefined;
+      let modelQuery = '';
+      const { dataSchemaMetadata: dataSchema } = this.componentMetadata;
+      const loadedFields: ShorthandPropertyAssignment[] = [];
+      const loadedFieldNames: string[] = [];
+      const loadedFieldStatements: Statement[] = [];
+
+      Object.entries(component.collectionProperties).forEach((collectionProp) => {
+        const [, { model: modelName, predicate }] = collectionProp;
+        modelQuery = getGraphqlQueryForModel(ActionType.LIST, modelName);
+        this.importCollection.addGraphqlQueryImport(modelQuery);
+        if (predicate) {
+          filter = this.predicateToObjectLiteralExpression(predicate, modelName);
+        }
+
+        const model = dataSchema?.models[modelName];
+
+        if (model !== undefined) {
+          Object.entries(model.fields).forEach(([fieldName, fieldSchema]) => {
+            if (fieldNeedsRelationshipLoadedForCollection(fieldSchema, dataSchema as GenericDataSchema)) {
+              const { relationship } = fieldSchema;
+              loadedFieldNames.push(fieldName);
+              const relatedFieldQueryName = this.getQueryRelationshipName(
+                modelName,
+                relationship?.relatedModelName ?? '',
+              );
+
+              /*
+                const Comments = (await API.graphql({query: commentsByPostID, variables: { post: item.id }}))
+                  .data.commentsByPostID.items;
+              */
+              loadedFieldStatements.push(
+                factory.createVariableStatement(
+                  undefined,
+                  factory.createVariableDeclarationList(
+                    [
+                      factory.createVariableDeclaration(
+                        factory.createIdentifier(pluralize(fieldName)),
+                        undefined,
+                        undefined,
+                        factory.createPropertyAccessExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createParenthesizedExpression(
+                                factory.createAwaitExpression(
+                                  factory.createCallExpression(
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier('API'),
+                                      factory.createIdentifier('graphql'),
+                                    ),
+                                    undefined,
+                                    [
+                                      factory.createObjectLiteralExpression(
+                                        [
+                                          factory.createPropertyAssignment(
+                                            factory.createIdentifier('query'),
+                                            factory.createIdentifier(relatedFieldQueryName),
+                                          ),
+                                          factory.createPropertyAssignment(
+                                            factory.createIdentifier('variables'),
+                                            factory.createObjectLiteralExpression(
+                                              [
+                                                factory.createPropertyAssignment(
+                                                  factory.createIdentifier(`${modelName.toLowerCase()}ID`),
+                                                  factory.createPropertyAccessExpression(
+                                                    factory.createIdentifier('item'),
+                                                    factory.createIdentifier('id'),
+                                                  ),
+                                                ),
+                                              ],
+                                              false,
+                                            ),
+                                          ),
+                                        ],
+                                        false,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                              factory.createIdentifier('data'),
+                            ),
+                            factory.createIdentifier(relatedFieldQueryName),
+                          ),
+                          factory.createIdentifier('items'),
+                        ),
+                      ),
+                    ],
+                    ts.NodeFlags.Const,
+                  ),
+                ),
+              );
+
+              loadedFields.push(
+                factory.createShorthandPropertyAssignment(factory.createIdentifier(fieldName), undefined),
+              );
+            }
+          });
+        }
+      });
+
+      statements.push(
+        factory.createWhileStatement(
+          factory.createBinaryExpression(
+            factory.createBinaryExpression(
+              factory.createPropertyAccessExpression(
+                factory.createIdentifier('newCache'),
+                factory.createIdentifier('length'),
+              ),
+              factory.createToken(ts.SyntaxKind.LessThanToken),
+              factory.createIdentifier('cacheUntil'),
+            ),
+            factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
+            factory.createParenthesizedExpression(
+              factory.createBinaryExpression(
+                factory.createIdentifier('newNext'),
+                factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),
+                factory.createNull(),
+              ),
+            ),
+          ),
+          factory.createBlock(
+            [
+              factory.createExpressionStatement(
+                factory.createCallExpression(factory.createIdentifier('setLoading'), undefined, [factory.createTrue()]),
+              ),
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createIdentifier('variables'),
+                      undefined,
+                      factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+                      factory.createObjectLiteralExpression(
+                        filter !== undefined
+                          ? [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('limit'),
+                                factory.createIdentifier('pageSize'),
+                              ),
+                              factory.createPropertyAssignment(factory.createIdentifier('filter'), filter),
+                            ]
+                          : [
+                              factory.createPropertyAssignment(
+                                factory.createIdentifier('limit'),
+                                factory.createIdentifier('pageSize'),
+                              ),
+                            ],
+                        true,
+                      ),
+                    ),
+                  ],
+                  ts.NodeFlags.Const,
+                ),
+              ),
+              factory.createIfStatement(
+                factory.createIdentifier('newNext'),
+                factory.createBlock(
+                  [
+                    factory.createExpressionStatement(
+                      factory.createBinaryExpression(
+                        factory.createElementAccessExpression(
+                          factory.createIdentifier('variables'),
+                          factory.createStringLiteral('nextToken'),
+                        ),
+                        factory.createToken(ts.SyntaxKind.EqualsToken),
+                        factory.createIdentifier('newNext'),
+                      ),
+                    ),
+                  ],
+                  true,
+                ),
+                undefined,
+              ),
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createIdentifier('result'),
+                      undefined,
+                      undefined,
+                      factory.createPropertyAccessExpression(
+                        factory.createPropertyAccessExpression(
+                          factory.createParenthesizedExpression(
+                            factory.createAwaitExpression(
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('API'),
+                                  factory.createIdentifier('graphql'),
+                                ),
+                                undefined,
+                                [
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('query'),
+                                        factory.createIdentifier(modelQuery),
+                                      ),
+                                      factory.createShorthandPropertyAssignment(
+                                        factory.createIdentifier('variables'),
+                                        undefined,
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          factory.createIdentifier('data'),
+                        ),
+                        factory.createIdentifier(modelQuery),
+                      ),
+                    ),
+                  ],
+                  ts.NodeFlags.Const,
+                ),
+              ),
+              factory.createVariableStatement(
+                undefined,
+                factory.createVariableDeclarationList(
+                  [
+                    factory.createVariableDeclaration(
+                      factory.createIdentifier('loaded'),
+                      undefined,
+                      undefined,
+                      factory.createAwaitExpression(
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('Promise'),
+                            factory.createIdentifier('all'),
+                          ),
+                          undefined,
+                          [
+                            factory.createCallExpression(
+                              factory.createPropertyAccessExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('result'),
+                                  factory.createIdentifier('items'),
+                                ),
+                                factory.createIdentifier('map'),
+                              ),
+                              undefined,
+                              [
+                                factory.createArrowFunction(
+                                  [factory.createToken(ts.SyntaxKind.AsyncKeyword)],
+                                  undefined,
+                                  [
+                                    factory.createParameterDeclaration(
+                                      undefined,
+                                      undefined,
+                                      undefined,
+                                      factory.createIdentifier('item'),
+                                      undefined,
+                                      undefined,
+                                      undefined,
+                                    ),
+                                  ],
+                                  undefined,
+                                  factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                                  factory.createBlock(
+                                    [
+                                      ...loadedFieldStatements,
+                                      factory.createReturnStatement(
+                                        factory.createObjectLiteralExpression(
+                                          [
+                                            factory.createSpreadAssignment(factory.createIdentifier('item')),
+                                            ...loadedFields,
+                                          ],
+                                          true,
+                                        ),
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                  ts.NodeFlags.AwaitContext,
+                ),
+              ),
+              factory.createExpressionStatement(
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('newCache'),
+                    factory.createIdentifier('push'),
+                  ),
+                  undefined,
+                  [factory.createSpreadElement(factory.createIdentifier('loaded'))],
+                ),
+              ),
+              factory.createExpressionStatement(
+                factory.createBinaryExpression(
+                  factory.createIdentifier('newNext'),
+                  factory.createToken(ts.SyntaxKind.EqualsToken),
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier('result'),
+                    factory.createIdentifier('nextToken'),
+                  ),
+                ),
+              ),
+            ],
+            true,
+          ),
+        ),
+      );
+    }
+
+    /*
+      const cacheSlice = newCache.slice((page-1)*pageSize, page*pageSize);
+      setItems(cacheSlice);
+      setHasMorePages(!!newNext);
+      setLoading(false);
+      apiCache[instanceKey] = newCache;
+      nextToken[instanceKey] = newNext;
+    */
+    statements.push(
+      buildInitConstVariableExpression(
+        'cacheSlice',
+        factory.createCallExpression(
+          factory.createPropertyAccessExpression(
+            factory.createIdentifier('newCache'),
+            factory.createIdentifier('slice'),
+          ),
+          undefined,
+          [
+            factory.createBinaryExpression(
+              factory.createParenthesizedExpression(
+                factory.createBinaryExpression(
+                  factory.createIdentifier('page'),
+                  factory.createToken(ts.SyntaxKind.MinusToken),
+                  factory.createNumericLiteral('1'),
+                ),
+              ),
+              factory.createToken(ts.SyntaxKind.AsteriskToken),
+              factory.createIdentifier('pageSize'),
+            ),
+            factory.createBinaryExpression(
+              factory.createIdentifier('page'),
+              factory.createToken(ts.SyntaxKind.AsteriskToken),
+              factory.createIdentifier('pageSize'),
+            ),
+          ],
+        ),
+      ),
+    );
+    statements.push(
+      factory.createExpressionStatement(
+        factory.createCallExpression(factory.createIdentifier('setItems'), undefined, [
+          factory.createIdentifier('cacheSlice'),
+        ]),
+      ),
+    );
+    statements.push(
+      factory.createExpressionStatement(
+        factory.createCallExpression(factory.createIdentifier('setHasMorePages'), undefined, [
+          factory.createPrefixUnaryExpression(
+            ts.SyntaxKind.ExclamationToken,
+            factory.createPrefixUnaryExpression(ts.SyntaxKind.ExclamationToken, factory.createIdentifier('newNext')),
+          ),
+        ]),
+      ),
+    );
+    statements.push(
+      factory.createExpressionStatement(
+        factory.createCallExpression(factory.createIdentifier('setLoading'), undefined, [factory.createFalse()]),
+      ),
+    );
+    statements.push(
+      factory.createExpressionStatement(
+        factory.createBinaryExpression(
+          factory.createElementAccessExpression(
+            factory.createIdentifier('apiCache'),
+            factory.createIdentifier('instanceKey'),
+          ),
+          factory.createToken(ts.SyntaxKind.EqualsToken),
+          factory.createIdentifier('newCache'),
+        ),
+      ),
+    );
+    statements.push(
+      factory.createExpressionStatement(
+        factory.createBinaryExpression(
+          factory.createElementAccessExpression(
+            factory.createIdentifier('nextToken'),
+            factory.createIdentifier('instanceKey'),
+          ),
+          factory.createToken(ts.SyntaxKind.EqualsToken),
+          factory.createIdentifier('newNext'),
+        ),
+      ),
+    );
+
+    return factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('loadPage'),
+            undefined,
+            undefined,
+            factory.createArrowFunction(
+              [factory.createToken(ts.SyntaxKind.AsyncKeyword)],
+              undefined,
+              [
+                factory.createParameterDeclaration(
+                  undefined,
+                  undefined,
+                  undefined,
+                  factory.createIdentifier('page'),
+                  undefined,
+                  factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+                  undefined,
+                ),
+              ],
+              undefined,
+              factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+              factory.createBlock(statements, true),
+            ),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    );
+  }
+
   private hasCollectionPropertyNamedItems(component: StudioComponent): boolean {
     if (component.collectionProperties === undefined) {
       return false;
@@ -1550,6 +2335,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       return 'ButtonProps';
     }
     return `${component.componentType}Props`;
+  }
+
+  private getQueryRelationshipName(modelName: string, relatedModelName: string): string {
+    const relatedModel = pluralize(relatedModelName.toLowerCase());
+    return `${relatedModel}By${modelName}ID`;
   }
 
   private dropMissingListElements<T>(elements: (T | null | undefined)[]): T[] {

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -945,8 +945,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
    * );
    */
   private buildOverridesFromVariantsAndProp(hasBreakpoint: boolean) {
-    this.importCollection.addMappedImport(ImportValue.GET_OVERRIDES_FROM_VARIANTS);
-    this.importCollection.addMappedImport(ImportValue.VARIANT);
+    this.importCollection.addMappedImport(ImportValue.GET_OVERRIDES_FROM_VARIANTS, ImportValue.VARIANT);
 
     return factory.createVariableStatement(
       undefined,
@@ -997,8 +996,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
           statements.push(this.buildCreateDataStorePredicateCall(modelName, propName));
         }
         if (sort) {
-          this.importCollection.addMappedImport(ImportValue.SORT_DIRECTION);
-          this.importCollection.addMappedImport(ImportValue.SORT_PREDICATE);
+          this.importCollection.addMappedImport(ImportValue.SORT_DIRECTION, ImportValue.SORT_PREDICATE);
           statements.push(this.buildPaginationStatement(propName, modelName, sort));
         }
 

--- a/packages/codegen-ui-react/lib/views/react-view-renderer.ts
+++ b/packages/codegen-ui-react/lib/views/react-view-renderer.ts
@@ -359,8 +359,7 @@ export abstract class ReactViewTemplateRenderer extends StudioTemplateRenderer<
        * builds sort function
        */
       if (sort) {
-        this.importCollection.addMappedImport(ImportValue.SORT_DIRECTION);
-        this.importCollection.addMappedImport(ImportValue.SORT_PREDICATE);
+        this.importCollection.addMappedImport(ImportValue.SORT_DIRECTION, ImportValue.SORT_PREDICATE);
         statements.push(
           factory.createVariableStatement(
             undefined,
@@ -476,8 +475,7 @@ export abstract class ReactViewTemplateRenderer extends StudioTemplateRenderer<
     ]);
     const formPropType = getComponentPropName(this.component.name);
 
-    this.importCollection.addMappedImport(ImportValue.ESCAPE_HATCH_PROPS);
-    this.importCollection.addMappedImport(ImportValue.CREATE_DATA_STORE_PREDICATE);
+    this.importCollection.addMappedImport(ImportValue.ESCAPE_HATCH_PROPS, ImportValue.CREATE_DATA_STORE_PREDICATE);
 
     return [
       factory.createTypeAliasDeclaration(

--- a/packages/codegen-ui/lib/types/bindings.ts
+++ b/packages/codegen-ui/lib/types/bindings.ts
@@ -106,6 +106,7 @@ export type StudioComponentDataBindingProperty = {
 export type StudioComponentPredicate = {
   and?: StudioComponentPredicate[];
   or?: StudioComponentPredicate[];
+  not?: StudioComponentPredicate[];
   field?: string;
   operand?: string;
   operator?: string;


### PR DESCRIPTION
## Problem
Customers who do not use DataStore are not able to create collections with GraphQL APIs.
## Solution
Conditionally generate needed code for GraphQL APIs rather than using the DataStore library for collections.

## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.