### PR TITLE
chore: add specific cypress version to fix 12.15.0 bug

### DIFF
--- a/scripts/integ-setup.bat
+++ b/scripts/integ-setup.bat
@@ -20,7 +20,7 @@ call lerna add --scope integration-test @aws-amplify/codegen-ui-react
 call lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator
 call lerna add --no-ci --scope integration-test react-router-dom
 call lerna add --no-ci --scope integration-test @types/react-router-dom
-call lerna add --no-ci --dev --scope integration-test cypress
+call lerna add --no-ci --dev --scope integration-test cypress@12.14.0
 call lerna add --no-ci --dev --scope integration-test wait-on
 call lerna add --no-ci --scope integration-test os-browserify
 call lerna add --no-ci --scope integration-test path-browserify

--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -25,7 +25,7 @@ lerna add --scope integration-test @aws-amplify/codegen-ui-react
 lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator
 lerna add --no-ci --scope integration-test react-router-dom
 lerna add --no-ci --scope integration-test @types/react-router-dom
-lerna add --no-ci --dev --scope integration-test cypress
+lerna add --no-ci --dev --scope integration-test cypress@12.14.0
 lerna add --no-ci --dev --scope integration-test @cypress/code-coverage
 lerna add --no-ci --dev --scope integration-test wait-on
 lerna add --no-ci --dev --scope integration-test istanbul-lib-report


### PR DESCRIPTION
## Problem
Seems like a regression was introduced in Cypress v12.15.0, `functional-tests` are failing with the following error message for all specs:
```
CypressError: `cy.task()` must only be invoked from the spec file or support file.
```

## Solution
Set Cypress version to v12.14.0.

## Additional Notes
Once Cypress addresses the issue this can be removed to ensure we are using the latest Cypress for integration tests.

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - (small script change)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.