### PR TITLE
chore: add housekeeping items to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,27 +1,41 @@
 ## Problem
+
 <!-- Why are we making this code change? -->
 
 ## Solution
+
 <!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
 
 ## Additional Notes
+
 <!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->
 
 ## Links
+
 ### Ticket
+
 <!-- *do not link to private ticketing systems* -->
-GitHub issue _____
+
+GitHub issue:
 
 ### Other links
 
 ## Verification
+
 ### Manual tests
+
 <!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->
 
 ### Automated tests
+
 - [ ] Unit tests added/updated
 - [ ] E2E tests added/updated
 - [ ] N/A - (provide a reason)
 - [ ] deferred - (provide GitHub issue for tracking)
+
+### Housekeeping
+
+- [ ] No non-essential console logs
+- [ ] All new files contain license notice
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
## Problem
<!-- Why are we making this code change? -->
some minor items that we can't/don't lint for can go through PR unnoticed.

## Solution
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
add new PR tasks as a reminder to devs and reviewers to confirm that submitted changes are compliant.
## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - updates PR template only
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.