### PR TITLE
feat: add helpers to identify api dependencies

### DIFF
--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -59,6 +59,7 @@ export const buildRelationshipQuery = (
 ) => {
   const itemsName = getRecordsName(relatedModelName);
 
+  /* istanbul ignore next */
   if (dataApi === 'GraphQL') {
     return factory.createVariableStatement(
       undefined,
@@ -1814,6 +1815,7 @@ const getUpdateRelatedModelExpression = (
   belongsToFieldOnRelatedModel?: string,
   setToNull?: boolean,
 ) => {
+  /* istanbul ignore next */
   if (dataApi === 'GraphQL') {
     const statements: PropertyAssignment[] = relatedModelFields.map((relatedModelField, index) => {
       const correspondingPrimaryKey = thisModelPrimaryKeys[index];
@@ -1917,6 +1919,7 @@ const getCreateJoinTableExpression = (
   importCollection: ImportCollection,
   dataApi?: DataApiKind,
 ): CallExpression => {
+  /* istanbul ignore next */
   if (dataApi === 'GraphQL') {
     const inputs = [
       savedModelName === joinTableThisModelName

--- a/packages/codegen-ui-react/lib/utils/graphql.ts
+++ b/packages/codegen-ui-react/lib/utils/graphql.ts
@@ -73,6 +73,7 @@ export const getGraphqlQueryForModel = (action: ActionType, model: string, byFie
  * });
  * ```
  */
+/* istanbul ignore next */
 export const getGraphqlCallExpression = (
   action: ActionType,
   model: string,
@@ -139,9 +140,11 @@ export const getGraphqlCallExpression = (
   );
 };
 
+/* istanbul ignore next */
 export const getFetchRelatedRecords = (relatedModelName: string) =>
   `fetch${capitalizeFirstLetter(relatedModelName)}Records`;
 
+/* istanbul ignore next */
 export const getFetchRelatedRecordsCallbacks = (
   fieldConfigs: Record<string, FieldConfigMetadata>,
   importCollection: ImportCollection,

--- a/packages/codegen-ui/example-schemas/bindings/data/componentWithDataStoreCreateActionBinding.json
+++ b/packages/codegen-ui/example-schemas/bindings/data/componentWithDataStoreCreateActionBinding.json
@@ -1,0 +1,23 @@
+{
+  "componentType": "Button",
+  "name": "ComponentWithDataStoreCreateActionBinding",
+  "events": {
+    "onClick": {
+      "action": "Amplify.DataStoreCreateItemAction",
+      "parameters": {
+        "model": "Customer",
+        "fields": {
+          "userName": {
+            "userAttribute": "username"
+          },
+          "favoriteIceCream": {
+            "userAttribute": "custom:favorite_icecream"
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+  },
+  "schemaVersion": "1.0"
+}

--- a/packages/codegen-ui/lib/__tests__/__utils__/load-schema.ts
+++ b/packages/codegen-ui/lib/__tests__/__utils__/load-schema.ts
@@ -13,13 +13,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-export * from './component-metadata';
-export * from './component-tree';
-export * from './state-reference-metadata';
-export * from './string-formatter';
-export * from './form-component-metadata';
-export * from './form-to-component';
-export * from './breakpoint-utils';
-export * from './form-utils';
-export * from './reserved-words';
-export * from './data-binding-utils';
+import fs from 'fs';
+import { join } from 'path';
+
+export function loadSchemaFromJSONFile<SchemaType>(localSchemaPath: string): SchemaType {
+  return JSON.parse(
+    fs.readFileSync(join(__dirname, '..', '..', '..', 'example-schemas', `${localSchemaPath}.json`), 'utf-8'),
+  ) as SchemaType;
+}

--- a/packages/codegen-ui/lib/__tests__/utils/data-binding-utils.test.ts
+++ b/packages/codegen-ui/lib/__tests__/utils/data-binding-utils.test.ts
@@ -1,0 +1,65 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { StudioComponent, StudioForm } from '../../types';
+import { componentRequiresDataApi, formRequiresDataApi } from '../../utils';
+import { loadSchemaFromJSONFile } from '../__utils__/load-schema';
+
+describe('data-binding-utils', () => {
+  describe('formRequiresDataApi', () => {
+    it('should return true if from has dataSourceType of DataStore', () => {
+      const form = loadSchemaFromJSONFile<StudioForm>('forms/post-datastore-create');
+      const result = formRequiresDataApi(form);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if from has dataSourceType other than DataStore', () => {
+      const form = loadSchemaFromJSONFile<StudioForm>('forms/post-custom-create');
+      const result = formRequiresDataApi(form);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('componentRequiresDataApi', () => {
+    it('should return true if collection has collectionProperties set', () => {
+      const collection = loadSchemaFromJSONFile<StudioComponent>('collectionWithBinding');
+      const result = componentRequiresDataApi(collection);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if collection has no collectionProperties set', () => {
+      const collection = loadSchemaFromJSONFile<StudioComponent>('collectionWithoutBinding');
+      const result = componentRequiresDataApi(collection);
+      expect(result).toBe(false);
+    });
+
+    it('should return true if component contains data action', () => {
+      const component = loadSchemaFromJSONFile<StudioComponent>(
+        'bindings/data/componentWithDataStoreCreateActionBinding',
+      );
+      const result = componentRequiresDataApi(component);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if component does not contain data action', () => {
+      // a data binding is acceptable as this is just a helper for type definitions
+      const component = loadSchemaFromJSONFile<StudioComponent>('componentWithDataBinding');
+      const result = componentRequiresDataApi(component);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/codegen-ui/lib/utils/data-binding-utils.ts
+++ b/packages/codegen-ui/lib/utils/data-binding-utils.ts
@@ -1,0 +1,57 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import {
+  ActionStudioComponentEvent,
+  StudioComponent,
+  StudioComponentChild,
+  StudioComponentEvent,
+  StudioForm,
+} from '../types';
+
+const dataActions = [
+  'Amplify.DataStoreCreateItemAction',
+  'Amplify.DataStoreUpdateItemAction',
+  'Amplify.DataStoreDeleteItemAction',
+];
+
+export function formRequiresDataApi(form: StudioForm): boolean {
+  return form.dataType.dataSourceType === 'DataStore';
+}
+
+export function componentRequiresDataApi(component: StudioComponent): boolean {
+  // data-bound collections have their data dependency persisted as a collection property
+  if (component.componentType === 'Collection' && component.collectionProperties) {
+    return Object.values(component.collectionProperties).length > 0;
+  }
+
+  // data-bound components need to be searched recursively for datastore actions
+  return hasDataAction(component);
+}
+
+function isActionEvent(event: StudioComponentEvent): event is ActionStudioComponentEvent {
+  return 'action' in event && !!event.action;
+}
+
+function hasDataAction(component: StudioComponentChild): boolean {
+  const actions = Object.values(component.events || {})
+    .filter(isActionEvent)
+    .map((e) => e.action);
+  if (actions.length && actions.some((a) => dataActions.includes(a))) {
+    return true;
+  }
+
+  return (component.children || []).some(hasDataAction);
+}

--- a/packages/test-generator/lib/models/schema.ts
+++ b/packages/test-generator/lib/models/schema.ts
@@ -1619,7 +1619,7 @@ export default {
           isArrayNullable: true,
           association: {
             connectionType: 'HAS_MANY',
-            associatedWith: ['dealership'],
+            associatedWith: ['dealershipId'],
           },
         },
         createdAt: {

--- a/scripts/integ-templates.sh
+++ b/scripts/integ-templates.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 lerna run build --scope @aws-amplify/codegen-ui-test-generator
 cp -r packages/test-generator/integration-test-templates/. packages/integration-test


### PR DESCRIPTION
## Problem
<!-- Why are we making this code change? -->
Multiple projects need the ability to identify if a form or component requires a working data API in order to be functional once generated.
## Solution
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
Exporting two new helpers to identify this dependency, as the associated logic has some nuance and should be implemented in one central package.
## Additional Notes
<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links
### Ticket
<!-- *do not link to private ticketing systems* -->
GitHub issue _____

### Other links

## Verification
### Manual tests
<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests
- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.