### PR TITLE
fix: plural items property in autocomplete data query

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -262,7 +262,7 @@ export default function CreateOwnerForm(props) {
           query: listDogs,
           variables,
         })
-      ).data.listDogs.item;
+      ).data.listDogs.items;
       var loaded = result.filter(
         (item) => !DogIdSet.has(getIDValue.Dog?.(item))
       );
@@ -1475,7 +1475,7 @@ export default function MyMemberForm(props) {
           query: listTeams,
           variables,
         })
-      ).data.listTeamIDS.item;
+      ).data.listTeamIDS.items;
       var loaded = result.filter(
         (item) => !teamIDIdSet.has(getIDValue.teamID?.(item))
       );
@@ -1502,7 +1502,7 @@ export default function MyMemberForm(props) {
           query: listTeams,
           variables,
         })
-      ).data.listTeams.item;
+      ).data.listTeams.items;
       var loaded = result.filter(
         (item) => !TeamIdSet.has(getIDValue.Team?.(item))
       );
@@ -2106,7 +2106,7 @@ export default function SchoolCreateForm(props) {
           query: listStudents,
           variables,
         })
-      ).data.listStudents.item;
+      ).data.listStudents.items;
       var loaded = result.filter(
         (item) => !StudentsIdSet.has(getIDValue.Students?.(item))
       );
@@ -2656,7 +2656,7 @@ export default function BookCreateForm(props) {
           query: listAuthors,
           variables,
         })
-      ).data.listPrimaryAuthors.item;
+      ).data.listPrimaryAuthors.items;
       var loaded = result.filter(
         (item) => !primaryAuthorIdSet.has(getIDValue.primaryAuthor?.(item))
       );
@@ -3200,7 +3200,7 @@ export default function TagCreateForm(props) {
           query: listPosts,
           variables,
         })
-      ).data.listPosts.item;
+      ).data.listPosts.items;
       var loaded = result.filter(
         (item) => !PostsIdSet.has(getIDValue.Posts?.(item))
       );
@@ -3834,7 +3834,7 @@ export default function BookCreateForm(props) {
           query: listAuthors,
           variables,
         })
-      ).data.listPrimaryAuthors.item;
+      ).data.listPrimaryAuthors.items;
       var loaded = result.filter(
         (item) => !primaryAuthorIdSet.has(getIDValue.primaryAuthor?.(item))
       );
@@ -3861,7 +3861,7 @@ export default function BookCreateForm(props) {
           query: listTitles,
           variables,
         })
-      ).data.listPrimaryTitles.item;
+      ).data.listPrimaryTitles.items;
       var loaded = result.filter(
         (item) => !primaryTitleIdSet.has(getIDValue.primaryTitle?.(item))
       );
@@ -4541,7 +4541,7 @@ export default function PostUpdateForm(props) {
           query: listComments,
           variables,
         })
-      ).data.listComments.item;
+      ).data.listComments.items;
       var loaded = result.filter(
         (item) => !CommentsIdSet.has(getIDValue.Comments?.(item))
       );
@@ -6013,7 +6013,7 @@ export default function CommentUpdateForm(props) {
           query: listPosts,
           variables,
         })
-      ).data.listPostIDS.item;
+      ).data.listPostIDS.items;
       var loaded = result.filter(
         (item) => !postIDIdSet.has(getIDValue.postID?.(item))
       );
@@ -6042,7 +6042,7 @@ export default function CommentUpdateForm(props) {
           query: listPosts,
           variables,
         })
-      ).data.listPosts.item;
+      ).data.listPosts.items;
       var loaded = result.filter(
         (item) => !PostIdSet.has(getIDValue.Post?.(item))
       );
@@ -6724,7 +6724,7 @@ export default function CommentUpdateForm(props) {
           query: listPosts,
           variables,
         })
-      ).data.listPostIDS.item;
+      ).data.listPostIDS.items;
       var loaded = result.filter(
         (item) => !postIDIdSet.has(getIDValue.postID?.(item))
       );
@@ -6753,7 +6753,7 @@ export default function CommentUpdateForm(props) {
           query: listPosts,
           variables,
         })
-      ).data.listPosts.item;
+      ).data.listPosts.items;
       var loaded = result.filter(
         (item) => !PostIdSet.has(getIDValue.Post?.(item))
       );
@@ -7423,7 +7423,7 @@ export default function ClassUpdateForm(props) {
           query: listStudents,
           variables,
         })
-      ).data.listStudents.item;
+      ).data.listStudents.items;
       var loaded = result.filter(
         (item) => !studentsIdSet.has(getIDValue.students?.(item))
       );
@@ -8119,7 +8119,7 @@ export default function UpdateCPKTeacherForm(props) {
           query: listCPKStudents,
           variables,
         })
-      ).data.listCPKStudents.item;
+      ).data.listCPKStudents.items;
       var loaded = result.filter(
         (item) => !CPKStudentIdSet.has(getIDValue.CPKStudent?.(item))
       );
@@ -8146,7 +8146,7 @@ export default function UpdateCPKTeacherForm(props) {
           query: listCPKClasses,
           variables,
         })
-      ).data.listCPKClasses.item;
+      ).data.listCPKClasses.items;
       var loaded = result.filter(
         (item) => !CPKClassesIdSet.has(getIDValue.CPKClasses?.(item))
       );
@@ -8173,7 +8173,7 @@ export default function UpdateCPKTeacherForm(props) {
           query: listCPKProjects,
           variables,
         })
-      ).data.listCPKProjects.item;
+      ).data.listCPKProjects.items;
       var loaded = result.filter(
         (item) => !CPKProjectsIdSet.has(getIDValue.CPKProjects?.(item))
       );
@@ -9044,7 +9044,7 @@ export default function CreateCompositeToyForm(props) {
           query: listCompositeDogs,
           variables,
         })
-      ).data.listCompositeDogCompositeToysNames.item;
+      ).data.listCompositeDogCompositeToysNames.items;
       var loaded = result.filter(
         (item) =>
           !compositeDogCompositeToysNameIdSet.has(
@@ -9076,7 +9076,7 @@ export default function CreateCompositeToyForm(props) {
           query: listCompositeDogs,
           variables,
         })
-      ).data.listCompositeDogCompositeToysDescriptions.item;
+      ).data.listCompositeDogCompositeToysDescriptions.items;
       var loaded = result.filter(
         (item) =>
           !compositeDogCompositeToysDescriptionIdSet.has(
@@ -9795,7 +9795,7 @@ export default function CreateCommentForm(props) {
           query: listPosts,
           variables,
         })
-      ).data.listPosts.item;
+      ).data.listPosts.items;
       var loaded = result.filter(
         (item) => !postIdSet.has(getIDValue.post?.(item))
       );
@@ -9824,7 +9824,7 @@ export default function CreateCommentForm(props) {
           query: listUsers,
           variables,
         })
-      ).data.listUsers.item;
+      ).data.listUsers.items;
       var loaded = result.filter(
         (item) => !UserIdSet.has(getIDValue.User?.(item))
       );
@@ -9853,7 +9853,7 @@ export default function CreateCommentForm(props) {
           query: listOrgs,
           variables,
         })
-      ).data.listOrgs.item;
+      ).data.listOrgs.items;
       var loaded = result.filter(
         (item) => !OrgIdSet.has(getIDValue.Org?.(item))
       );
@@ -9882,7 +9882,7 @@ export default function CreateCommentForm(props) {
           query: listPosts,
           variables,
         })
-      ).data.listPostCommentsIds.item;
+      ).data.listPostCommentsIds.items;
       var loaded = result.filter(
         (item) => !postCommentsIdIdSet.has(getIDValue.postCommentsId?.(item))
       );
@@ -10745,7 +10745,7 @@ export default function CreateCompositeDogForm(props) {
           query: listCompositeBowls,
           variables,
         })
-      ).data.listCompositeBowls.item;
+      ).data.listCompositeBowls.items;
       var loaded = result.filter(
         (item) => !CompositeBowlIdSet.has(getIDValue.CompositeBowl?.(item))
       );
@@ -10777,7 +10777,7 @@ export default function CreateCompositeDogForm(props) {
           query: listCompositeOwners,
           variables,
         })
-      ).data.listCompositeOwners.item;
+      ).data.listCompositeOwners.items;
       var loaded = result.filter(
         (item) => !CompositeOwnerIdSet.has(getIDValue.CompositeOwner?.(item))
       );
@@ -10806,7 +10806,7 @@ export default function CreateCompositeDogForm(props) {
           query: listCompositeToys,
           variables,
         })
-      ).data.listCompositeToys.item;
+      ).data.listCompositeToys.items;
       var loaded = result.filter(
         (item) => !CompositeToysIdSet.has(getIDValue.CompositeToys?.(item))
       );
@@ -10838,7 +10838,7 @@ export default function CreateCompositeDogForm(props) {
           query: listCompositeVets,
           variables,
         })
-      ).data.listCompositeVets.item;
+      ).data.listCompositeVets.items;
       var loaded = result.filter(
         (item) => !CompositeVetsIdSet.has(getIDValue.CompositeVets?.(item))
       );
@@ -11736,7 +11736,7 @@ export default function CreateDogForm(props) {
           query: listOwners,
           variables,
         })
-      ).data.listOwners.item;
+      ).data.listOwners.items;
       var loaded = result.filter(
         (item) => !OwnerIdSet.has(getIDValue.Owner?.(item))
       );
@@ -12273,7 +12273,7 @@ export default function CreateOwnerForm(props) {
           query: listDogs,
           variables,
         })
-      ).data.listDogs.item;
+      ).data.listDogs.items;
       var loaded = result.filter(
         (item) => !DogIdSet.has(getIDValue.Dog?.(item))
       );

--- a/packages/codegen-ui-react/lib/utils/graphql.ts
+++ b/packages/codegen-ui-react/lib/utils/graphql.ts
@@ -371,7 +371,7 @@ export const getFetchRelatedRecordsCallbacks = (
                                             ActionType.LIST,
                                             capitalizeFirstLetter(renderedFieldName),
                                           ),
-                                          'item',
+                                          'items',
                                         ],
                                       ),
                                     ),


### PR DESCRIPTION
## Problem

missing plural items in autocomplete data fetch

## Solution

add 's'

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
