### PR TITLE
fix: change GraphQL unlink to use update action instead of delete

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -4232,7 +4232,7 @@ import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { commentsByPostID, getPost, listComments } from \\"../graphql/queries\\";
-import { deleteComment, updateComment, updatePost } from \\"../graphql/mutations\\";
+import { updateComment, updatePost } from \\"../graphql/mutations\\";
 function ArrayField({
   items = [],
   onChange,
@@ -4620,10 +4620,11 @@ export default function PostUpdateForm(props) {
             }
             promises.push(
               API.graphql({
-                query: deleteComment,
+                query: updateComment,
                 variables: {
                   input: {
                     id: original.id,
+                    postID: null,
                   },
                 },
               })
@@ -7739,7 +7740,6 @@ import {
 } from \\"../graphql/queries\\";
 import {
   createCPKTeacherCPKClass,
-  deleteCPKProject,
   deleteCPKTeacherCPKClass,
   updateCPKProject,
   updateCPKTeacher,
@@ -8321,10 +8321,11 @@ export default function UpdateCPKTeacherForm(props) {
             }
             promises.push(
               API.graphql({
-                query: deleteCPKProject,
+                query: updateCPKProject,
                 variables: {
                   input: {
                     specialProjectId: original.specialProjectId,
+                    cPKTeacherID: null,
                   },
                 },
               })

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -39,7 +39,7 @@ import {
   getRecordName,
 } from './form-state';
 import { buildBaseCollectionVariableStatement } from '../../react-studio-template-renderer-helper';
-import { ImportCollection, ImportSource } from '../../imports';
+import { ImportCollection } from '../../imports';
 import { lowerCaseFirst, getSetNameIdentifier, capitalizeFirstLetter } from '../../helpers';
 import { isManyToManyRelationship } from './map-from-fieldConfigs';
 import { extractModelAndKeys, getIDValueCallChain, getMatchEveryModelFieldCallExpression } from './model-values';
@@ -1233,7 +1233,7 @@ export const buildHasManyRelationshipStatements = (
   fieldName = fieldConfigMetaData.sanitizedFieldName || fieldName;
   const { relatedModelName, relatedModelFields, belongsToFieldOnRelatedModel } =
     fieldConfigMetaData.relationship as HasManyRelationshipType;
-  const relatedModelVariableName = importCollection.getMappedAlias(ImportSource.LOCAL_MODELS, relatedModelName);
+  const relatedModelVariableName = importCollection.getMappedModelAlias(relatedModelName);
   const linkedDataName = getLinkedDataName(fieldName);
   const dataToLink = `${lowerCaseFirst(fieldName)}ToLink`;
   const dataToUnLink = `${lowerCaseFirst(fieldName)}ToUnLink`;
@@ -1566,16 +1566,25 @@ export const buildHasManyRelationshipStatements = (
                       undefined,
                       [
                         dataApi === 'GraphQL'
-                          ? getGraphqlCallExpression(ActionType.DELETE, relatedModelName, importCollection, {
-                              inputs: keys.map((key) =>
-                                factory.createPropertyAssignment(
-                                  factory.createIdentifier(key),
-                                  factory.createPropertyAccessExpression(
-                                    factory.createIdentifier('original'),
+                          ? getGraphqlCallExpression(ActionType.UPDATE, relatedModelName, importCollection, {
+                              inputs: keys
+                                .map((key) =>
+                                  factory.createPropertyAssignment(
                                     factory.createIdentifier(key),
+                                    factory.createPropertyAccessExpression(
+                                      factory.createIdentifier('original'),
+                                      factory.createIdentifier(key),
+                                    ),
+                                  ),
+                                )
+                                .concat(
+                                  relatedModelFields.map((key) =>
+                                    factory.createPropertyAssignment(
+                                      factory.createIdentifier(key),
+                                      factory.createNull(),
+                                    ),
                                   ),
                                 ),
-                              ),
                             })
                           : getUpdateRelatedModelExpression(
                               thisModelRecord,


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->
Unlinking child records in a hasMany relationship is currently using the delete operation for GraphQL forms. This is a destructive action and does not align with what is done on DataStore forms. Furthermore the form validation suggests the intended action is an update as it checks if the parent id field is required on the child.
## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
Update codegen to generate requests using the update operation to clear the parent reference on a child record.
## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [ ] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
