### PR TITLE
fix: fields with json type display 'null'

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -5141,12 +5141,13 @@ export default function MyPostForm(props) {
     setProfile_url(cleanValues.profile_url);
     setPost_url(cleanValues.post_url);
     setMetadata(
-      typeof cleanValues.metadata === \\"string\\"
+      typeof cleanValues.metadata === \\"string\\" || cleanValues.metadata === null
         ? cleanValues.metadata
         : JSON.stringify(cleanValues.metadata)
     );
     setNonModelField(
-      typeof cleanValues.nonModelField === \\"string\\"
+      typeof cleanValues.nonModelField === \\"string\\" ||
+        cleanValues.nonModelField === null
         ? cleanValues.nonModelField
         : JSON.stringify(cleanValues.nonModelField)
     );
@@ -30490,12 +30491,13 @@ export default function MyPostForm(props) {
     setProfile_url(cleanValues.profile_url);
     setPost_url(cleanValues.post_url);
     setMetadata(
-      typeof cleanValues.metadata === \\"string\\"
+      typeof cleanValues.metadata === \\"string\\" || cleanValues.metadata === null
         ? cleanValues.metadata
         : JSON.stringify(cleanValues.metadata)
     );
     setNonModelField(
-      typeof cleanValues.nonModelField === \\"string\\"
+      typeof cleanValues.nonModelField === \\"string\\" ||
+        cleanValues.nonModelField === null
         ? cleanValues.nonModelField
         : JSON.stringify(cleanValues.nonModelField)
     );
@@ -35858,7 +35860,8 @@ export default function InputGalleryUpdateForm(props) {
     setJsonArray(cleanValues.jsonArray ?? []);
     setCurrentJsonArrayValue(\\"\\");
     setJsonField(
-      typeof cleanValues.jsonField === \\"string\\"
+      typeof cleanValues.jsonField === \\"string\\" ||
+        cleanValues.jsonField === null
         ? cleanValues.jsonField
         : JSON.stringify(cleanValues.jsonField)
     );

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/form-state.ts
@@ -438,19 +438,29 @@ export const resetStateFunction = (fieldConfigs: Record<string, FieldConfigMetad
 
 /**
  * Datastore allows JSON strings and normal JSON so check for a string
- * before stringifying or else the string will return with escaped quotes
+ * before stringifying or else the string will return with escaped quotes.
+ * Also do not stringify null.
  *
  * Example output:
- * typeof cleanValues.metadata === 'string' ? cleanValues.metadata : JSON.stringify(cleanValues.metadata)
+ * typeof cleanValues.metadata === 'string' || cleanValues.metadata === null ?
+ * cleanValues.metadata : JSON.stringify(cleanValues.metadata)
  */
 const stringifyAWSJSONFieldValue = (
   value: PropertyAccessExpression | ElementAccessExpression,
 ): ConditionalExpression => {
   return factory.createConditionalExpression(
     factory.createBinaryExpression(
-      factory.createTypeOfExpression(value),
-      factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
-      factory.createStringLiteral('string'),
+      factory.createBinaryExpression(
+        factory.createTypeOfExpression(value),
+        factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+        factory.createStringLiteral('string'),
+      ),
+      factory.createToken(SyntaxKind.BarBarToken),
+      factory.createBinaryExpression(
+        value,
+        factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+        factory.createNull(),
+      ),
     ),
     factory.createToken(SyntaxKind.QuestionToken),
     value,


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->

In CMS, if the customer creates an empty record and then reopens the record, 'null' is displayed for JSON fields. 

<img width="1146" alt="json-null" src="https://github.com/aws-amplify/amplify-codegen-ui/assets/48109584/3101cbbf-4e53-4f1f-a7cc-e29fcca94672">

## Solution

Adds a condition to avoid stringifying `null`. This change also applies to `metadata` and `nonModelField` types as well as `json`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
