### PR TITLE
feat: implement graphql querying for join tables

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -5714,8 +5714,13 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
+import {
+  getMovie,
+  listMovieTags,
+  listTags,
+  movieTagsByMovieMovieKeyAndMovietitleAndMoviegenre,
+} from \\"../graphql/queries\\";
 import { API } from \\"aws-amplify\\";
-import { getMovie, listMovieTags, listTags } from \\"../graphql/queries\\";
 import {
   createMovieTags,
   deleteMovieTags,
@@ -5935,12 +5940,17 @@ export default function MovieUpdateForm(props) {
         : movieModelProp;
       setMovieRecord(record);
       const linkedTags = record
-        ? await Promise.all(
-            (
-              await record.tags.toArray()
-            ).map((r) => {
-              return r.tag;
+        ? (
+            await API.graphql({
+              query: movieTagsByMovieMovieKeyAndMovietitleAndMoviegenre,
+              variables: {
+                movieMovieKey: record.movieKey,
+                movietitle: record.title,
+                moviegenre: record.genre,
+              },
             })
+          ).data.movieTagsByMovieMovieKeyAndMovietitleAndMoviegenre.items.map(
+            (t) => t.tag
           )
         : [];
       setLinkedTags(linkedTags);
@@ -7891,8 +7901,13 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
+import {
+  getClass,
+  listStudentClasses,
+  listStudents,
+  studentClassByClassId,
+} from \\"../graphql/queries\\";
 import { API } from \\"aws-amplify\\";
-import { getClass, listStudentClasses, listStudents } from \\"../graphql/queries\\";
 import {
   createStudentClass,
   deleteStudentClass,
@@ -8100,13 +8115,14 @@ export default function ClassUpdateForm(props) {
         : classModelProp;
       setClassRecord(record);
       const linkedStudents = record
-        ? await Promise.all(
-            (
-              await record.students.toArray()
-            ).map((r) => {
-              return r.student;
+        ? (
+            await API.graphql({
+              query: studentClassByClassId,
+              variables: {
+                classId: record.id,
+              },
             })
-          )
+          ).data.studentClassByClassId.items.map((t) => t.student)
         : [];
       setLinkedStudents(linkedStudents);
     };
@@ -8496,15 +8512,16 @@ import {
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
-import { API } from \\"aws-amplify\\";
 import {
   cPKProjectsByCPKTeacherID,
+  cPKTeacherCPKClassByCPKTeacherSpecialTeacherId,
   getCPKTeacher,
   listCPKClasses,
   listCPKProjects,
   listCPKStudents,
   listCPKTeacherCPKClasses,
 } from \\"../graphql/queries\\";
+import { API } from \\"aws-amplify\\";
 import {
   createCPKTeacherCPKClass,
   deleteCPKTeacherCPKClass,
@@ -8745,12 +8762,15 @@ export default function UpdateCPKTeacherForm(props) {
       const CPKStudentRecord = record ? await record.CPKStudent : undefined;
       setCPKStudent(CPKStudentRecord);
       const linkedCPKClasses = record
-        ? await Promise.all(
-            (
-              await record.CPKClasses.toArray()
-            ).map((r) => {
-              return r.cpkClass;
+        ? (
+            await API.graphql({
+              query: cPKTeacherCPKClassByCPKTeacherSpecialTeacherId,
+              variables: {
+                cPKTeacherSpecialTeacherId: record.specialTeacherId,
+              },
             })
+          ).data.cPKTeacherCPKClassByCPKTeacherSpecialTeacherId.items.map(
+            (t) => t.cpkClass
           )
         : [];
       setLinkedCPKClasses(linkedCPKClasses);

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -863,6 +863,9 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toContain('moviegenre: movieRecord.genre,');
       expect(componentText).toContain('tagId: tagToLink.id,');
 
+      // query for join table records indexed by current model's ids
+      expect(componentText).toContain('query: movieTagsByMovieMovieKeyAndMovietitleAndMoviegenre');
+
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -524,7 +524,16 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
             linkedDataNames.push(fieldName);
           }
           // Flatten statments into 1d array
-          relatedModelStatements.push(...buildGetRelationshipModels(fieldName, value, this.importCollection, dataApi));
+          relatedModelStatements.push(
+            ...buildGetRelationshipModels(
+              fieldName,
+              value,
+              this.componentMetadata.dataSchemaMetadata,
+              this.primaryKeys!,
+              this.importCollection,
+              dataApi,
+            ),
+          );
         }
       });
 

--- a/packages/codegen-ui-react/lib/utils/graphql.ts
+++ b/packages/codegen-ui-react/lib/utils/graphql.ts
@@ -160,6 +160,28 @@ export const getGraphqlCallExpression = (
 };
 
 /* istanbul ignore next */
+export const mapFieldArraysToPropertyAssignments = (
+  joinTableFields: string[],
+  modelFields: string[],
+  modelRecord: string,
+) => {
+  return joinTableFields.map((key, i) => {
+    const recordKey = modelFields[i];
+    if (!recordKey) {
+      throw new InternalError(`Cannot find corresponding key for ${key}`);
+    }
+
+    return factory.createPropertyAssignment(
+      factory.createIdentifier(key),
+      factory.createPropertyAccessExpression(
+        factory.createIdentifier(modelRecord),
+        factory.createIdentifier(recordKey),
+      ),
+    );
+  });
+};
+
+/* istanbul ignore next */
 export const getGraphQLJoinTableCreateExpression = (
   relatedJoinTableName: string,
   thisModelRecord: string,
@@ -170,27 +192,6 @@ export const getGraphQLJoinTableCreateExpression = (
   joinTableRelatedModelFields: string[],
   importCollection: ImportCollection,
 ) => {
-  const mapFieldArraysToPropertyAssignments = (
-    joinTableFields: string[],
-    modelFields: string[],
-    modelRecord: string,
-  ) => {
-    return joinTableFields.map((key, i) => {
-      const recordKey = modelFields[i];
-      if (!recordKey) {
-        throw new InternalError(`Cannot find corresponding key for ${key}`);
-      }
-
-      return factory.createPropertyAssignment(
-        factory.createIdentifier(key),
-        factory.createPropertyAccessExpression(
-          factory.createIdentifier(modelRecord),
-          factory.createIdentifier(recordKey),
-        ),
-      );
-    });
-  };
-
   const thisModelAssignments = mapFieldArraysToPropertyAssignments(
     joinTableThisModelFields,
     thisModelPrimaryKeys,


### PR DESCRIPTION
## Problem
Form codegen does not properly query against join tables for many:many relationships when using GraphQL
<!-- Why are we making this code change? -->

## Solution
Implement proper querying using the indexed query assumed to be in the customer project
<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
