### PR TITLE
feat: handle parent relationship without belongsTo for GraphQL

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,6 +95,13 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 120
           config-file: cypress.config.js
+      - name: Upload Cypress videos
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          working-directory: e2e-test-app
+          name: cypress-videos
+          path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/e2e-test-app/cypress/videos
         env:
           REACT_APP_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
           REACT_APP_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
@@ -123,6 +130,12 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 210
           config-file: cypress.config.ts
+      - name: Upload Cypress videos
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-videos
+          path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/packages/integration-test/cypress/videos
       - name: Check Integ Test Coverage
         working-directory: packages/integration-test
         run: node cypress/scripts/generateCoverageSummary.mjs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,16 +95,15 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 120
           config-file: cypress.config.js
+        env:
+          REACT_APP_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+          REACT_APP_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
       - name: Upload Cypress videos
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          working-directory: e2e-test-app
           name: cypress-videos
           path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/e2e-test-app/cypress/videos
-        env:
-          REACT_APP_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
-          REACT_APP_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
 
   functional-tests:
     runs-on: ubuntu-latest

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -20552,9 +20552,9 @@ export default function UpdateOrgForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Org, idProp) : orgModelProp;
+      setOrgRecord(record);
       const linkedComments = record ? await record.comments.toArray() : [];
       setLinkedComments(linkedComments);
-      setOrgRecord(record);
     };
     queryData();
   }, [idProp, orgModelProp]);
@@ -21153,6 +21153,7 @@ export default function UpdateCompositeDogForm(props) {
       const record = idProp
         ? await DataStore.query(CompositeDog, idProp)
         : compositeDogModelProp;
+      setCompositeDogRecord(record);
       const CompositeBowlRecord = record
         ? await record.CompositeBowl
         : undefined;
@@ -21175,7 +21176,6 @@ export default function UpdateCompositeDogForm(props) {
           )
         : [];
       setLinkedCompositeVets(linkedCompositeVets);
-      setCompositeDogRecord(record);
     };
     queryData();
   }, [idProp, compositeDogModelProp]);
@@ -22267,6 +22267,7 @@ export default function UpdateCPKTeacherForm(props) {
       const record = specialTeacherIdProp
         ? await DataStore.query(CPKTeacher, specialTeacherIdProp)
         : cPKTeacherModelProp;
+      setCPKTeacherRecord(record);
       const CPKStudentRecord = record ? await record.CPKStudent : undefined;
       setCPKStudent(CPKStudentRecord);
       const linkedCPKClasses = record
@@ -22283,7 +22284,6 @@ export default function UpdateCPKTeacherForm(props) {
         ? await record.CPKProjects.toArray()
         : [];
       setLinkedCPKProjects(linkedCPKProjects);
-      setCPKTeacherRecord(record);
     };
     queryData();
   }, [specialTeacherIdProp, cPKTeacherModelProp]);
@@ -25573,6 +25573,7 @@ export default function UpdateCompositeDogForm(props) {
       const record = idProp
         ? await DataStore.query(CompositeDog, idProp)
         : compositeDogModelProp;
+      setCompositeDogRecord(record);
       const CompositeOwnerRecord = record
         ? await record.CompositeOwner
         : undefined;
@@ -25595,7 +25596,6 @@ export default function UpdateCompositeDogForm(props) {
         ? await record.compositeDogCompositeBowlShape
         : undefined;
       setCompositeDogCompositeBowlShape(compositeDogCompositeBowlShapeRecord);
-      setCompositeDogRecord(record);
     };
     queryData();
   }, [idProp, compositeDogModelProp]);
@@ -27342,9 +27342,9 @@ export default function UpdateDogForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Dog, idProp) : dogModelProp;
+      setDogRecord(record);
       const OwnerRecord = record ? await record.Owner : undefined;
       setOwner(OwnerRecord);
-      setDogRecord(record);
     };
     queryData();
   }, [idProp, dogModelProp]);
@@ -28379,9 +28379,9 @@ export default function UpdateOwnerForm(props) {
       const record = idProp
         ? await DataStore.query(Owner, idProp)
         : ownerModelProp;
+      setOwnerRecord(record);
       const DogRecord = record ? await record.Dog : undefined;
       setDog(DogRecord);
-      setOwnerRecord(record);
     };
     queryData();
   }, [idProp, ownerModelProp]);
@@ -33715,9 +33715,9 @@ export default function SchoolUpdateForm(props) {
       const record = idProp
         ? await DataStore.query(School, idProp)
         : schoolModelProp;
+      setSchoolRecord(record);
       const linkedStudents = record ? await record.Students.toArray() : [];
       setLinkedStudents(linkedStudents);
-      setSchoolRecord(record);
     };
     queryData();
   }, [idProp, schoolModelProp]);
@@ -34281,9 +34281,9 @@ export default function SchoolUpdateForm(props) {
       const record = idProp
         ? await DataStore.query(School, idProp)
         : schoolModelProp;
+      setSchoolRecord(record);
       const linkedStudent = record ? await record.Student.toArray() : [];
       setLinkedStudent(linkedStudent);
-      setSchoolRecord(record);
     };
     queryData();
   }, [idProp, schoolModelProp]);
@@ -34894,11 +34894,11 @@ export default function MyMemberForm(props) {
       const record = idProp
         ? await DataStore.query(Member, idProp)
         : memberModelProp;
+      setMemberRecord(record);
       const teamIDRecord = record ? await record.teamID : undefined;
       setTeamID(teamIDRecord);
       const TeamRecord = record ? await record.Team : undefined;
       setTeam(TeamRecord);
-      setMemberRecord(record);
     };
     queryData();
   }, [idProp, memberModelProp]);
@@ -35503,6 +35503,7 @@ export default function TagUpdateForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Tag, idProp) : tagModelProp;
+      setTagRecord(record);
       const linkedPosts = record
         ? await Promise.all(
             (
@@ -35513,7 +35514,6 @@ export default function TagUpdateForm(props) {
           )
         : [];
       setLinkedPosts(linkedPosts);
-      setTagRecord(record);
     };
     queryData();
   }, [idProp, tagModelProp]);
@@ -41896,9 +41896,9 @@ export default function UpdateCarForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Car, idProp) : carModelProp;
+      setCarRecord(record);
       const dealershipRecord = record ? await record.dealership : undefined;
       setDealership(dealershipRecord);
-      setCarRecord(record);
     };
     queryData();
   }, [idProp, carModelProp]);
@@ -42407,9 +42407,9 @@ export default function UpdateDealershipForm(props) {
       const record = idProp
         ? await DataStore.query(Dealership, idProp)
         : dealershipModelProp;
+      setDealershipRecord(record);
       const linkedCars = record ? await record.cars.toArray() : [];
       setLinkedCars(linkedCars);
-      setDealershipRecord(record);
     };
     queryData();
   }, [idProp, dealershipModelProp]);

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1476,9 +1476,7 @@ export default function MyMemberForm(props) {
           variables,
         })
       )?.data?.listTeams?.items;
-      var loaded = result.filter(
-        (item) => !teamIDIdSet.has(getIDValue.teamID?.(item))
-      );
+      var loaded = result.filter((item) => teamID !== item.id);
       newOptions.push(...loaded);
       newNext = result.nextToken;
     }
@@ -1667,13 +1665,15 @@ export default function MyMemberForm(props) {
         errorMessage={errors?.teamID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.teamID(teamRecords.find((r) => r.id === value))
+            ? getDisplayValue.teamID(teamIDRecords.find((r) => r.id === value))
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentTeamIDDisplayValue(
             value
-              ? getDisplayValue.teamID(teamRecords.find((r) => r.id === value))
+              ? getDisplayValue.teamID(
+                  teamIDRecords.find((r) => r.id === value)
+                )
               : \\"\\"
           );
           setCurrentTeamIDValue(value);
@@ -4444,9 +4444,9 @@ export default function PostUpdateForm(props) {
             })
           )?.data?.getPost
         : postModelProp;
-      setPostRecord(record);
       const linkedComments = record ? record.Comment?.items : [];
       setLinkedComments(linkedComments);
+      setPostRecord(record);
     };
     queryData();
   }, [idProp, postModelProp]);
@@ -5931,7 +5931,6 @@ export default function MovieUpdateForm(props) {
             })
           )?.data?.getMovie
         : movieModelProp;
-      setMovieRecord(record);
       const linkedTags = record
         ? (
             await API.graphql({
@@ -5947,6 +5946,7 @@ export default function MovieUpdateForm(props) {
           )
         : [];
       setLinkedTags(linkedTags);
+      setMovieRecord(record);
     };
     queryData();
   }, [idProp, movieModelProp]);
@@ -6483,7 +6483,7 @@ import {
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
-import { getComment, listPosts } from \\"../graphql/queries\\";
+import { getComment, getPost, listPosts } from \\"../graphql/queries\\";
 import { updateComment } from \\"../graphql/mutations\\";
 function ArrayField({
   items = [],
@@ -6696,11 +6696,20 @@ export default function CommentUpdateForm(props) {
             })
           )?.data?.getComment
         : commentModelProp;
-      setCommentRecord(record);
-      const postIDRecord = record ? await record.postID : undefined;
+      const postIDRecord = record ? record.postID : undefined;
+      const postRecord = postIDRecord
+        ? (
+            await API.graphql({
+              query: getPost,
+              variables: { id: postIDRecord },
+            })
+          )?.data?.getPost
+        : undefined;
       setPostID(postIDRecord);
+      setPostIDRecords([postRecord]);
       const PostRecord = record ? await record.Post : undefined;
       setPost(PostRecord);
+      setCommentRecord(record);
     };
     queryData();
   }, [idProp, commentModelProp]);
@@ -6768,9 +6777,7 @@ export default function CommentUpdateForm(props) {
           variables,
         })
       )?.data?.listPosts?.items;
-      var loaded = result.filter(
-        (item) => !postIDIdSet.has(getIDValue.postID?.(item))
-      );
+      var loaded = result.filter((item) => postID !== item.id);
       newOptions.push(...loaded);
       newNext = result.nextToken;
     }
@@ -6933,13 +6940,15 @@ export default function CommentUpdateForm(props) {
         errorMessage={errors?.postID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.postID(postRecords.find((r) => r.id === value))
+            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentPostIDDisplayValue(
             value
-              ? getDisplayValue.postID(postRecords.find((r) => r.id === value))
+              ? getDisplayValue.postID(
+                  postIDRecords.find((r) => r.id === value)
+                )
               : \\"\\"
           );
           setCurrentPostIDValue(value);
@@ -7190,7 +7199,7 @@ import {
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
-import { getComment, listPosts } from \\"../graphql/queries\\";
+import { getComment, getPost, listPosts } from \\"../graphql/queries\\";
 import { updateComment } from \\"../graphql/mutations\\";
 function ArrayField({
   items = [],
@@ -7403,11 +7412,20 @@ export default function CommentUpdateForm(props) {
             })
           )?.data?.getComment
         : commentModelProp;
-      setCommentRecord(record);
-      const postIDRecord = record ? await record.postID : undefined;
+      const postIDRecord = record ? record.postID : undefined;
+      const postRecord = postIDRecord
+        ? (
+            await API.graphql({
+              query: getPost,
+              variables: { id: postIDRecord },
+            })
+          )?.data?.getPost
+        : undefined;
       setPostID(postIDRecord);
+      setPostIDRecords([postRecord]);
       const PostRecord = record ? await record.Post : undefined;
       setPost(PostRecord);
+      setCommentRecord(record);
     };
     queryData();
   }, [idProp, commentModelProp]);
@@ -7475,9 +7493,7 @@ export default function CommentUpdateForm(props) {
           variables,
         })
       )?.data?.listPosts?.items;
-      var loaded = result.filter(
-        (item) => !postIDIdSet.has(getIDValue.postID?.(item))
-      );
+      var loaded = result.filter((item) => postID !== item.id);
       newOptions.push(...loaded);
       newNext = result.nextToken;
     }
@@ -7640,13 +7656,15 @@ export default function CommentUpdateForm(props) {
         errorMessage={errors?.postID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.postID(postRecords.find((r) => r.id === value))
+            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentPostIDDisplayValue(
             value
-              ? getDisplayValue.postID(postRecords.find((r) => r.id === value))
+              ? getDisplayValue.postID(
+                  postIDRecords.find((r) => r.id === value)
+                )
               : \\"\\"
           );
           setCurrentPostIDValue(value);
@@ -8106,7 +8124,6 @@ export default function ClassUpdateForm(props) {
             })
           )?.data?.getClass
         : classModelProp;
-      setClassRecord(record);
       const linkedStudents = record
         ? (
             await API.graphql({
@@ -8118,6 +8135,7 @@ export default function ClassUpdateForm(props) {
           ).data.studentClassByClassId.items.map((t) => t.student)
         : [];
       setLinkedStudents(linkedStudents);
+      setClassRecord(record);
     };
     queryData();
   }, [idProp, classModelProp]);
@@ -8750,7 +8768,6 @@ export default function UpdateCPKTeacherForm(props) {
             })
           )?.data?.getCPKTeacher
         : cPKTeacherModelProp;
-      setCPKTeacherRecord(record);
       const CPKStudentRecord = record ? await record.CPKStudent : undefined;
       setCPKStudent(CPKStudentRecord);
       const linkedCPKClasses = record
@@ -8768,6 +8785,7 @@ export default function UpdateCPKTeacherForm(props) {
       setLinkedCPKClasses(linkedCPKClasses);
       const linkedCPKProjects = record ? record.CPKProject?.items : [];
       setLinkedCPKProjects(linkedCPKProjects);
+      setCPKTeacherRecord(record);
     };
     queryData();
   }, [specialTeacherIdProp, cPKTeacherModelProp]);
@@ -9789,10 +9807,7 @@ export default function CreateCompositeToyForm(props) {
         })
       )?.data?.listCompositeDogs?.items;
       var loaded = result.filter(
-        (item) =>
-          !compositeDogCompositeToysNameIdSet.has(
-            getIDValue.compositeDogCompositeToysName?.(item)
-          )
+        (item) => compositeDogCompositeToysName !== item.id
       );
       newOptions.push(...loaded);
       newNext = result.nextToken;
@@ -9821,10 +9836,7 @@ export default function CreateCompositeToyForm(props) {
         })
       )?.data?.listCompositeDogs?.items;
       var loaded = result.filter(
-        (item) =>
-          !compositeDogCompositeToysDescriptionIdSet.has(
-            getIDValue.compositeDogCompositeToysDescription?.(item)
-          )
+        (item) => compositeDogCompositeToysDescription !== item.id
       );
       newOptions.push(...loaded);
       newNext = result.nextToken;
@@ -9980,7 +9992,9 @@ export default function CreateCompositeToyForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.compositeDogCompositeToysName(
-                compositeDogRecords.find((r) => r.name === value)
+                compositeDogCompositeToysNameRecords.find(
+                  (r) => r.name === value
+                )
               )
             : \\"\\"
         }
@@ -9988,7 +10002,9 @@ export default function CreateCompositeToyForm(props) {
           setCurrentCompositeDogCompositeToysNameDisplayValue(
             value
               ? getDisplayValue.compositeDogCompositeToysName(
-                  compositeDogRecords.find((r) => r.name === value)
+                  compositeDogCompositeToysNameRecords.find(
+                    (r) => r.name === value
+                  )
                 )
               : \\"\\"
           );
@@ -10074,7 +10090,9 @@ export default function CreateCompositeToyForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.compositeDogCompositeToysDescription(
-                compositeDogRecords.find((r) => r.description === value)
+                compositeDogCompositeToysDescriptionRecords.find(
+                  (r) => r.description === value
+                )
               )
             : \\"\\"
         }
@@ -10082,7 +10100,9 @@ export default function CreateCompositeToyForm(props) {
           setCurrentCompositeDogCompositeToysDescriptionDisplayValue(
             value
               ? getDisplayValue.compositeDogCompositeToysDescription(
-                  compositeDogRecords.find((r) => r.description === value)
+                  compositeDogCompositeToysDescriptionRecords.find(
+                    (r) => r.description === value
+                  )
                 )
               : \\"\\"
           );
@@ -10626,9 +10646,7 @@ export default function CreateCommentForm(props) {
           variables,
         })
       )?.data?.listPosts?.items;
-      var loaded = result.filter(
-        (item) => !postCommentsIdIdSet.has(getIDValue.postCommentsId?.(item))
-      );
+      var loaded = result.filter((item) => postCommentsId !== item.id);
       newOptions.push(...loaded);
       newNext = result.nextToken;
     }
@@ -10991,7 +11009,7 @@ export default function CreateCommentForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postCommentsId(
-                postRecords.find((r) => r.id === value)
+                postCommentsIdRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -10999,7 +11017,7 @@ export default function CreateCommentForm(props) {
           setCurrentPostCommentsIdDisplayValue(
             value
               ? getDisplayValue.postCommentsId(
-                  postRecords.find((r) => r.id === value)
+                  postCommentsIdRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
@@ -12976,9 +12994,9 @@ export default function UpdatePostForm(props) {
             })
           )?.data?.getPost
         : postModelProp;
-      setPostRecord(record);
       const linkedComments = record ? record.Comment?.items : [];
       setLinkedComments(linkedComments);
+      setPostRecord(record);
     };
     queryData();
   }, [idProp, postModelProp]);
@@ -14424,6 +14442,540 @@ export declare type CreateOwnerFormProps = React.PropsWithChildren<{
     onValidate?: CreateOwnerFormValidationValues;
 } & React.CSSProperties>;
 export default function CreateOwnerForm(props: CreateOwnerFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should treat relationship as bidirectional without belongsTo 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { API } from \\"aws-amplify\\";
+import { getComment, getPost, listPosts } from \\"../graphql/queries\\";
+import { updateComment } from \\"../graphql/mutations\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button
+            size=\\"small\\"
+            variation=\\"link\\"
+            isDisabled={hasError}
+            onClick={addItem}
+          >
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function CommentUpdateForm(props) {
+  const {
+    id: idProp,
+    comment: commentModelProp,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    content: \\"\\",
+    postID: undefined,
+  };
+  const [content, setContent] = React.useState(initialValues.content);
+  const [postID, setPostID] = React.useState(initialValues.postID);
+  const [postIDLoading, setPostIDLoading] = React.useState(false);
+  const [postIDRecords, setPostIDRecords] = React.useState([]);
+  const autocompleteLength = 10;
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    const cleanValues = commentRecord
+      ? { ...initialValues, ...commentRecord, postID }
+      : initialValues;
+    setContent(cleanValues.content);
+    setPostID(cleanValues.postID);
+    setCurrentPostIDValue(undefined);
+    setCurrentPostIDDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [commentRecord, setCommentRecord] = React.useState(commentModelProp);
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = idProp
+        ? (
+            await API.graphql({
+              query: getComment,
+              variables: { id: idProp },
+            })
+          )?.data?.getComment
+        : commentModelProp;
+      const postIDRecord = record ? record.postID : undefined;
+      const postRecord = postIDRecord
+        ? (
+            await API.graphql({
+              query: getPost,
+              variables: { id: postIDRecord },
+            })
+          )?.data?.getPost
+        : undefined;
+      setPostID(postIDRecord);
+      setPostIDRecords([postRecord]);
+      setCommentRecord(record);
+    };
+    queryData();
+  }, [idProp, commentModelProp]);
+  React.useEffect(resetStateValues, [commentRecord, postID]);
+  const [currentPostIDDisplayValue, setCurrentPostIDDisplayValue] =
+    React.useState(\\"\\");
+  const [currentPostIDValue, setCurrentPostIDValue] = React.useState(undefined);
+  const postIDRef = React.createRef();
+  const getDisplayValue = {
+    postID: (r) => \`\${r?.title ? r?.title + \\" - \\" : \\"\\"}\${r?.id}\`,
+  };
+  const validations = {
+    content: [],
+    postID: [{ type: \\"Required\\" }],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  const fetchPostIDRecords = async (value) => {
+    setPostIDLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [{ title: { contains: value } }, { id: { contains: value } }],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listPosts,
+          variables,
+        })
+      )?.data?.listPosts?.items;
+      var loaded = result.filter((item) => postID !== item.id);
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setPostIDRecords(newOptions.slice(0, autocompleteLength));
+    setPostIDLoading(false);
+  };
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          content,
+          postID,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(fieldName, item)
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(fieldName, modelFields[fieldName])
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value.trim() === \\"\\") {
+              modelFields[key] = undefined;
+            }
+          });
+          await API.graphql({
+            query: updateComment,
+            variables: {
+              input: {
+                id: commentRecord.id,
+                ...modelFields,
+              },
+            },
+          });
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+        } catch (err) {
+          if (onError) {
+            onError(modelFields, err.message);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"CommentUpdateForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Content\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={content}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              content: value,
+              postID,
+            };
+            const result = onChange(modelFields);
+            value = result?.content ?? value;
+          }
+          if (errors.content?.hasError) {
+            runValidationTasks(\\"content\\", value);
+          }
+          setContent(value);
+        }}
+        onBlur={() => runValidationTasks(\\"content\\", content)}
+        errorMessage={errors.content?.errorMessage}
+        hasError={errors.content?.hasError}
+        {...getOverrideProps(overrides, \\"content\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              content,
+              postID: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.postID ?? value;
+          }
+          setPostID(value);
+          setCurrentPostIDValue(undefined);
+        }}
+        currentFieldValue={currentPostIDValue}
+        label={\\"Post id\\"}
+        items={postID ? [postID] : []}
+        hasError={errors?.postID?.hasError}
+        errorMessage={errors?.postID?.errorMessage}
+        getBadgeText={(value) =>
+          value
+            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
+            : \\"\\"
+        }
+        setFieldValue={(value) => {
+          setCurrentPostIDDisplayValue(
+            value
+              ? getDisplayValue.postID(
+                  postIDRecords.find((r) => r.id === value)
+                )
+              : \\"\\"
+          );
+          setCurrentPostIDValue(value);
+        }}
+        inputFieldRef={postIDRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Post id\\"
+          isRequired={true}
+          isReadOnly={false}
+          placeholder=\\"Search Post\\"
+          value={currentPostIDDisplayValue}
+          options={postIDRecords
+            .filter(
+              (r, i, arr) =>
+                arr.findIndex((member) => member?.id === r?.id) === i
+            )
+            .map((r) => ({
+              id: r?.id,
+              label: getDisplayValue.postID?.(r),
+            }))}
+          isLoading={postIDLoading}
+          onSelect={({ id, label }) => {
+            setCurrentPostIDValue(id);
+            setCurrentPostIDDisplayValue(label);
+            runValidationTasks(\\"postID\\", label);
+          }}
+          onClear={() => {
+            setCurrentPostIDDisplayValue(\\"\\");
+          }}
+          defaultValue={postID}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchPostIDRecords(value);
+            if (errors.postID?.hasError) {
+              runValidationTasks(\\"postID\\", value);
+            }
+            setCurrentPostIDDisplayValue(value);
+            setCurrentPostIDValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"postID\\", currentPostIDValue)}
+          errorMessage={errors.postID?.errorMessage}
+          hasError={errors.postID?.hasError}
+          ref={postIDRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"postID\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          isDisabled={!(idProp || commentModelProp)}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={
+              !(idProp || commentModelProp) ||
+              Object.values(errors).some((e) => e?.hasError)
+            }
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should treat relationship as bidirectional without belongsTo 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Comment } from \\"../API\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type CommentUpdateFormInputValues = {
+    content?: string;
+    postID?: string;
+};
+export declare type CommentUpdateFormValidationValues = {
+    content?: ValidationFunction<string>;
+    postID?: ValidationFunction<string>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type CommentUpdateFormOverridesProps = {
+    CommentUpdateFormGrid?: PrimitiveOverrideProps<GridProps>;
+    content?: PrimitiveOverrideProps<TextFieldProps>;
+    postID?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type CommentUpdateFormProps = React.PropsWithChildren<{
+    overrides?: CommentUpdateFormOverridesProps | undefined | null;
+} & {
+    id?: string;
+    comment?: Comment;
+    onSubmit?: (fields: CommentUpdateFormInputValues) => CommentUpdateFormInputValues;
+    onSuccess?: (fields: CommentUpdateFormInputValues) => void;
+    onError?: (fields: CommentUpdateFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: CommentUpdateFormInputValues) => CommentUpdateFormInputValues;
+    onValidate?: CommentUpdateFormValidationValues;
+} & React.CSSProperties>;
+export default function CommentUpdateForm(props: CommentUpdateFormProps): React.ReactElement;
 "
 `;
 
@@ -20000,9 +20552,9 @@ export default function UpdateOrgForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Org, idProp) : orgModelProp;
-      setOrgRecord(record);
       const linkedComments = record ? await record.comments.toArray() : [];
       setLinkedComments(linkedComments);
+      setOrgRecord(record);
     };
     queryData();
   }, [idProp, orgModelProp]);
@@ -20601,7 +21153,6 @@ export default function UpdateCompositeDogForm(props) {
       const record = idProp
         ? await DataStore.query(CompositeDog, idProp)
         : compositeDogModelProp;
-      setCompositeDogRecord(record);
       const CompositeBowlRecord = record
         ? await record.CompositeBowl
         : undefined;
@@ -20624,6 +21175,7 @@ export default function UpdateCompositeDogForm(props) {
           )
         : [];
       setLinkedCompositeVets(linkedCompositeVets);
+      setCompositeDogRecord(record);
     };
     queryData();
   }, [idProp, compositeDogModelProp]);
@@ -21715,7 +22267,6 @@ export default function UpdateCPKTeacherForm(props) {
       const record = specialTeacherIdProp
         ? await DataStore.query(CPKTeacher, specialTeacherIdProp)
         : cPKTeacherModelProp;
-      setCPKTeacherRecord(record);
       const CPKStudentRecord = record ? await record.CPKStudent : undefined;
       setCPKStudent(CPKStudentRecord);
       const linkedCPKClasses = record
@@ -21732,6 +22283,7 @@ export default function UpdateCPKTeacherForm(props) {
         ? await record.CPKProjects.toArray()
         : [];
       setLinkedCPKProjects(linkedCPKProjects);
+      setCPKTeacherRecord(record);
     };
     queryData();
   }, [specialTeacherIdProp, cPKTeacherModelProp]);
@@ -25021,7 +25573,6 @@ export default function UpdateCompositeDogForm(props) {
       const record = idProp
         ? await DataStore.query(CompositeDog, idProp)
         : compositeDogModelProp;
-      setCompositeDogRecord(record);
       const CompositeOwnerRecord = record
         ? await record.CompositeOwner
         : undefined;
@@ -25044,6 +25595,7 @@ export default function UpdateCompositeDogForm(props) {
         ? await record.compositeDogCompositeBowlShape
         : undefined;
       setCompositeDogCompositeBowlShape(compositeDogCompositeBowlShapeRecord);
+      setCompositeDogRecord(record);
     };
     queryData();
   }, [idProp, compositeDogModelProp]);
@@ -26790,9 +27342,9 @@ export default function UpdateDogForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Dog, idProp) : dogModelProp;
-      setDogRecord(record);
       const OwnerRecord = record ? await record.Owner : undefined;
       setOwner(OwnerRecord);
+      setDogRecord(record);
     };
     queryData();
   }, [idProp, dogModelProp]);
@@ -27827,9 +28379,9 @@ export default function UpdateOwnerForm(props) {
       const record = idProp
         ? await DataStore.query(Owner, idProp)
         : ownerModelProp;
-      setOwnerRecord(record);
       const DogRecord = record ? await record.Dog : undefined;
       setDog(DogRecord);
+      setOwnerRecord(record);
     };
     queryData();
   }, [idProp, ownerModelProp]);
@@ -33163,9 +33715,9 @@ export default function SchoolUpdateForm(props) {
       const record = idProp
         ? await DataStore.query(School, idProp)
         : schoolModelProp;
-      setSchoolRecord(record);
       const linkedStudents = record ? await record.Students.toArray() : [];
       setLinkedStudents(linkedStudents);
+      setSchoolRecord(record);
     };
     queryData();
   }, [idProp, schoolModelProp]);
@@ -33729,9 +34281,9 @@ export default function SchoolUpdateForm(props) {
       const record = idProp
         ? await DataStore.query(School, idProp)
         : schoolModelProp;
-      setSchoolRecord(record);
       const linkedStudent = record ? await record.Student.toArray() : [];
       setLinkedStudent(linkedStudent);
+      setSchoolRecord(record);
     };
     queryData();
   }, [idProp, schoolModelProp]);
@@ -34342,11 +34894,11 @@ export default function MyMemberForm(props) {
       const record = idProp
         ? await DataStore.query(Member, idProp)
         : memberModelProp;
-      setMemberRecord(record);
       const teamIDRecord = record ? await record.teamID : undefined;
       setTeamID(teamIDRecord);
       const TeamRecord = record ? await record.Team : undefined;
       setTeam(TeamRecord);
+      setMemberRecord(record);
     };
     queryData();
   }, [idProp, memberModelProp]);
@@ -34951,7 +35503,6 @@ export default function TagUpdateForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Tag, idProp) : tagModelProp;
-      setTagRecord(record);
       const linkedPosts = record
         ? await Promise.all(
             (
@@ -34962,6 +35513,7 @@ export default function TagUpdateForm(props) {
           )
         : [];
       setLinkedPosts(linkedPosts);
+      setTagRecord(record);
     };
     queryData();
   }, [idProp, tagModelProp]);
@@ -41344,9 +41896,9 @@ export default function UpdateCarForm(props) {
   React.useEffect(() => {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Car, idProp) : carModelProp;
-      setCarRecord(record);
       const dealershipRecord = record ? await record.dealership : undefined;
       setDealership(dealershipRecord);
+      setCarRecord(record);
     };
     queryData();
   }, [idProp, carModelProp]);
@@ -41855,9 +42407,9 @@ export default function UpdateDealershipForm(props) {
       const record = idProp
         ? await DataStore.query(Dealership, idProp)
         : dealershipModelProp;
-      setDealershipRecord(record);
       const linkedCars = record ? await record.cars.toArray() : [];
       setLinkedCars(linkedCars);
+      setDealershipRecord(record);
     };
     queryData();
   }, [idProp, dealershipModelProp]);

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -1074,6 +1074,18 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });
+
+    it('should treat relationship as bidirectional without belongsTo', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/relationships/update-comment-no-belongsTo',
+        'datastore/relationships/has-many-comment-no-belongsTo',
+        { ...defaultCLIRenderConfig, ...rendererConfigWithGraphQL },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
   });
 
   describe('NoApi form tests', () => {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
@@ -707,6 +707,21 @@ export const buildUpdateDatastoreQuery = (
           ),
         );
 
+  const statements: Statement[] = [];
+  const setRecordStatement: ExpressionStatement = factory.createExpressionStatement(
+    factory.createCallExpression(getSetNameIdentifier(`${lowerCaseDataTypeName}Record`), undefined, [
+      factory.createIdentifier('record'),
+    ]),
+  );
+
+  if (dataApi === 'GraphQL') {
+    statements.push(...relatedModelStatements);
+    statements.push(setRecordStatement);
+  } else {
+    statements.push(setRecordStatement);
+    statements.push(...relatedModelStatements);
+  }
+
   return [
     factory.createVariableStatement(
       undefined,
@@ -744,13 +759,7 @@ export const buildUpdateDatastoreQuery = (
                       NodeFlags.Const,
                     ),
                   ),
-                  // Add logic to pull related relationship models off record
-                  ...relatedModelStatements,
-                  factory.createExpressionStatement(
-                    factory.createCallExpression(getSetNameIdentifier(`${lowerCaseDataTypeName}Record`), undefined, [
-                      factory.createIdentifier('record'),
-                    ]),
-                  ),
+                  ...statements,
                 ],
                 true,
               ),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
@@ -744,13 +744,13 @@ export const buildUpdateDatastoreQuery = (
                       NodeFlags.Const,
                     ),
                   ),
+                  // Add logic to pull related relationship models off record
+                  ...relatedModelStatements,
                   factory.createExpressionStatement(
                     factory.createCallExpression(getSetNameIdentifier(`${lowerCaseDataTypeName}Record`), undefined, [
                       factory.createIdentifier('record'),
                     ]),
                   ),
-                  // Add logic to pull related relationship models off record
-                  ...relatedModelStatements,
                 ],
                 true,
               ),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
@@ -30,6 +30,7 @@ import { extractModelAndKeys, getDisplayValueObjectName, getDisplayValueScalar }
 import { getElementAccessExpression } from './invalid-variable-helpers';
 import { getSetNameIdentifier, capitalizeFirstLetter } from '../../helpers';
 import { getDecoratedLabel } from './label-decorator';
+import { DataApiKind } from '../../react-render-config';
 
 function getOnChangeAttribute({
   setStateName,
@@ -130,6 +131,7 @@ export const renderArrayFieldComponent = (
   inputField: JsxChild,
   labelDecorator?: LabelDecorator,
   isRequired?: boolean,
+  dataApi: DataApiKind = 'DataStore',
 ) => {
   const fieldConfig = fieldConfigs[fieldName];
   const { sanitizedFieldName, dataType, componentType } = fieldConfig;
@@ -239,7 +241,9 @@ export const renderArrayFieldComponent = (
       ],
       undefined,
       factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-      getDisplayValueScalar(fieldName, scalarModel, scalarKey),
+      dataApi === 'GraphQL' && !isModelDataType(fieldConfig)
+        ? getDisplayValueScalar(fieldName, fieldName, scalarKey)
+        : getDisplayValueScalar(fieldName, scalarModel, scalarKey),
     );
   }
 
@@ -348,7 +352,9 @@ export const renderArrayFieldComponent = (
                 [
                   factory.createExpressionStatement(
                     factory.createCallExpression(setFieldValueIdentifier, undefined, [
-                      getDisplayValueScalar(fieldName, scalarModel, scalarKey),
+                      dataApi === 'GraphQL'
+                        ? getDisplayValueScalar(fieldName, fieldName, scalarKey)
+                        : getDisplayValueScalar(fieldName, scalarModel, scalarKey),
                     ]),
                   ),
                   factory.createExpressionStatement(

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -654,7 +654,6 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
       if (!(this.renderConfig.apiConfiguration?.dataApi === 'GraphQL')) {
         this.importCollection.addMappedImport(ImportValue.USE_DATA_STORE_BINDING);
 
-        // @rotp: check if this is needed for collection
         statements.push(
           ...[...relatedModelNames].map((relatedModelName) =>
             buildRelationshipQuery(relatedModelName, this.importCollection, dataApi),
@@ -690,7 +689,13 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
     }
 
     if (hasAutoComplete && dataApi === 'GraphQL') {
-      statements.push(...getFetchRelatedRecordsCallbacks(formMetadata.fieldConfigs, this.importCollection));
+      statements.push(
+        ...getFetchRelatedRecordsCallbacks(
+          formMetadata.fieldConfigs,
+          this.importCollection,
+          this.renderConfig.apiConfiguration?.dataApi,
+        ),
+      );
     }
 
     return statements;

--- a/packages/codegen-ui-react/lib/react-component-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-renderer.ts
@@ -110,7 +110,15 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
         this.importCollection.addImport(ImportSource.UI_REACT, 'Text');
         this.importCollection.addImport(ImportSource.UI_REACT, 'useTheme');
 
-        return renderArrayFieldComponent(this.component.name, label, fieldConfigs, element, labelDecorator, isRequired);
+        return renderArrayFieldComponent(
+          this.component.name,
+          label,
+          fieldConfigs,
+          element,
+          labelDecorator,
+          isRequired,
+          this.importCollection.rendererConfig?.apiConfiguration?.dataApi,
+        );
       }
     }
 

--- a/packages/codegen-ui/example-schemas/datastore/relationships/has-many-comment-no-belongsTo.json
+++ b/packages/codegen-ui/example-schemas/datastore/relationships/has-many-comment-no-belongsTo.json
@@ -1,0 +1,174 @@
+{
+    "models": {
+        "Comment": {
+            "name": "Comment",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "content": {
+                    "name": "content",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "postID": {
+                    "name": "postID",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Comments",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "allow": "public",
+                                "operations": [
+                                    "read"
+                                ]
+                            },
+                            {
+                                "provider": "userPools",
+                                "ownerField": "owner",
+                                "allow": "owner",
+                                "identityClaim": "cognito:username",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "Post": {
+            "name": "Post",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "title": {
+                    "name": "title",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "content": {
+                    "name": "content",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "Comments": {
+                    "name": "Comments",
+                    "isArray": true,
+                    "type": {
+                        "model": "Comment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": [
+                            "postID"
+                        ]
+                    }
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Posts",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "allow": "public",
+                                "operations": [
+                                    "read"
+                                ]
+                            },
+                            {
+                                "provider": "userPools",
+                                "ownerField": "owner",
+                                "allow": "owner",
+                                "identityClaim": "cognito:username",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "enums": {},
+    "nonModels": {},
+    "codegenVersion": "3.3.6",
+    "version": "0f95fb2e55520e7f5b5ee65562b0bb59"
+}

--- a/packages/codegen-ui/example-schemas/forms/relationships/update-comment-no-belongsTo.json
+++ b/packages/codegen-ui/example-schemas/forms/relationships/update-comment-no-belongsTo.json
@@ -1,0 +1,12 @@
+{
+    "name": "CommentUpdateForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "Comment"
+    },
+    "formActionType": "update",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+}


### PR DESCRIPTION
## Problem

The link from a child to a parent is always implemented with an id field on the child holding the id of its parent, customers can optionally annotate this field with `@belongsTo` to make the relationship bidirectional. For forms, we always want to behave as if the relationship is bidirectional, mainly to give us the ability to utilize the autocomplete control to update the parent id.

## Solution

Add conditional logic for GraphQL to add bidirectional abilities for forms.

## Additional Notes

Also adds a step to our Github actions to upload Cypress videos if Cypress tests fail in order to gather more insight when debugging failing tests.

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
