### PR TITLE
fix: update variables to match local state

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -337,12 +337,12 @@ export default function CreateOwnerForm(props) {
                 variables: {
                   input: {
                     ...Dog,
-                    Owner: owner,
+                    owner: owner,
                   },
                 },
               })
             );
-            const ownerToUnlink = await dogToLink.Owner;
+            const ownerToUnlink = await dogToLink.owner;
             if (ownerToUnlink) {
               promises.push(
                 API.graphql({
@@ -13377,6 +13377,7 @@ import {
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Owner } from \\"../API\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { listOwners } from \\"../graphql/queries\\";
@@ -13552,17 +13553,17 @@ export default function CreateDogForm(props) {
   } = props;
   const initialValues = {
     name: \\"\\",
-    Owner: undefined,
+    owner: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
-  const [Owner, setOwner] = React.useState(initialValues.Owner);
-  const [OwnerLoading, setOwnerLoading] = React.useState(false);
-  const [OwnerRecords, setOwnerRecords] = React.useState([]);
+  const [owner, setOwner] = React.useState(initialValues.owner);
+  const [ownerLoading, setOwnerLoading] = React.useState(false);
+  const [ownerRecords, setOwnerRecords] = React.useState([]);
   const autocompleteLength = 10;
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     setName(initialValues.name);
-    setOwner(initialValues.Owner);
+    setOwner(initialValues.owner);
     setCurrentOwnerValue(undefined);
     setCurrentOwnerDisplayValue(\\"\\");
     setErrors({});
@@ -13570,21 +13571,21 @@ export default function CreateDogForm(props) {
   const [currentOwnerDisplayValue, setCurrentOwnerDisplayValue] =
     React.useState(\\"\\");
   const [currentOwnerValue, setCurrentOwnerValue] = React.useState(undefined);
-  const OwnerRef = React.createRef();
+  const ownerRef = React.createRef();
   const getIDValue = {
-    Owner: (r) => JSON.stringify({ id: r?.id }),
+    owner: (r) => JSON.stringify({ id: r?.id }),
   };
-  const OwnerIdSet = new Set(
-    Array.isArray(Owner)
-      ? Owner.map((r) => getIDValue.Owner?.(r))
-      : getIDValue.Owner?.(Owner)
+  const ownerIdSet = new Set(
+    Array.isArray(owner)
+      ? owner.map((r) => getIDValue.owner?.(r))
+      : getIDValue.owner?.(owner)
   );
   const getDisplayValue = {
-    Owner: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+    owner: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
   };
   const validations = {
     name: [],
-    Owner: [{ type: \\"Required\\", validationMessage: \\"Owner is required.\\" }],
+    owner: [{ type: \\"Required\\", validationMessage: \\"Owner is required.\\" }],
   };
   const runValidationTasks = async (
     fieldName,
@@ -13624,7 +13625,7 @@ export default function CreateDogForm(props) {
         })
       )?.data?.listOwners?.items;
       var loaded = result.filter(
-        (item) => !OwnerIdSet.has(getIDValue.Owner?.(item))
+        (item) => !ownerIdSet.has(getIDValue.owner?.(item))
       );
       newOptions.push(...loaded);
       newNext = result.nextToken;
@@ -13642,7 +13643,7 @@ export default function CreateDogForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
-          Owner,
+          owner,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -13689,7 +13690,7 @@ export default function CreateDogForm(props) {
             },
           });
           const promises = [];
-          const ownerToLink = modelFields.Owner;
+          const ownerToLink = modelFields.owner;
           if (ownerToLink) {
             promises.push(
               API.graphql({
@@ -13737,7 +13738,7 @@ export default function CreateDogForm(props) {
           if (onChange) {
             const modelFields = {
               name: value,
-              Owner,
+              owner,
             };
             const result = onChange(modelFields);
             value = result?.name ?? value;
@@ -13759,10 +13760,10 @@ export default function CreateDogForm(props) {
           if (onChange) {
             const modelFields = {
               name,
-              Owner: value,
+              owner: value,
             };
             const result = onChange(modelFields);
-            value = result?.Owner ?? value;
+            value = result?.owner ?? value;
           }
           setOwner(value);
           setCurrentOwnerValue(undefined);
@@ -13770,17 +13771,17 @@ export default function CreateDogForm(props) {
         }}
         currentFieldValue={currentOwnerValue}
         label={\\"Owner\\"}
-        items={Owner ? [Owner] : []}
-        hasError={errors?.Owner?.hasError}
-        errorMessage={errors?.Owner?.errorMessage}
-        getBadgeText={getDisplayValue.Owner}
+        items={owner ? [owner] : []}
+        hasError={errors?.owner?.hasError}
+        errorMessage={errors?.owner?.errorMessage}
+        getBadgeText={getDisplayValue.owner}
         setFieldValue={(model) => {
           setCurrentOwnerDisplayValue(
-            model ? getDisplayValue.Owner(model) : \\"\\"
+            model ? getDisplayValue.owner(model) : \\"\\"
           );
           setCurrentOwnerValue(model);
         }}
-        inputFieldRef={OwnerRef}
+        inputFieldRef={ownerRef}
         defaultFieldValue={\\"\\"}
       >
         <Autocomplete
@@ -13789,23 +13790,23 @@ export default function CreateDogForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Owner\\"
           value={currentOwnerDisplayValue}
-          options={OwnerRecords.filter(
-            (r) => !OwnerIdSet.has(getIDValue.Owner?.(r))
-          ).map((r) => ({
-            id: getIDValue.Owner?.(r),
-            label: getDisplayValue.Owner?.(r),
-          }))}
-          isLoading={OwnerLoading}
+          options={ownerRecords
+            .filter((r) => !ownerIdSet.has(getIDValue.owner?.(r)))
+            .map((r) => ({
+              id: getIDValue.owner?.(r),
+              label: getDisplayValue.owner?.(r),
+            }))}
+          isLoading={ownerLoading}
           onSelect={({ id, label }) => {
             setCurrentOwnerValue(
-              OwnerRecords.find((r) =>
+              ownerRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
               )
             );
             setCurrentOwnerDisplayValue(label);
-            runValidationTasks(\\"Owner\\", label);
+            runValidationTasks(\\"owner\\", label);
           }}
           onClear={() => {
             setCurrentOwnerDisplayValue(\\"\\");
@@ -13813,18 +13814,18 @@ export default function CreateDogForm(props) {
           onChange={(e) => {
             let { value } = e.target;
             fetchOwnerRecords(value);
-            if (errors.Owner?.hasError) {
-              runValidationTasks(\\"Owner\\", value);
+            if (errors.owner?.hasError) {
+              runValidationTasks(\\"owner\\", value);
             }
             setCurrentOwnerDisplayValue(value);
             setCurrentOwnerValue(undefined);
           }}
-          onBlur={() => runValidationTasks(\\"Owner\\", currentOwnerDisplayValue)}
-          errorMessage={errors.Owner?.errorMessage}
-          hasError={errors.Owner?.hasError}
-          ref={OwnerRef}
+          onBlur={() => runValidationTasks(\\"owner\\", currentOwnerDisplayValue)}
+          errorMessage={errors.owner?.errorMessage}
+          hasError={errors.owner?.hasError}
+          ref={ownerRef}
           labelHidden={true}
-          {...getOverrideProps(overrides, \\"Owner\\")}
+          {...getOverrideProps(overrides, \\"owner\\")}
         ></Autocomplete>
       </ArrayField>
       <Flex
@@ -13871,17 +13872,17 @@ export declare type ValidationResponse = {
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type CreateDogFormInputValues = {
     name?: string;
-    Owner?: Owner;
+    owner?: Owner;
 };
 export declare type CreateDogFormValidationValues = {
     name?: ValidationFunction<string>;
-    Owner?: ValidationFunction<Owner>;
+    owner?: ValidationFunction<Owner>;
 };
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type CreateDogFormOverridesProps = {
     CreateDogFormGrid?: PrimitiveOverrideProps<GridProps>;
     name?: PrimitiveOverrideProps<TextFieldProps>;
-    Owner?: PrimitiveOverrideProps<AutocompleteProps>;
+    owner?: PrimitiveOverrideProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type CreateDogFormProps = React.PropsWithChildren<{
     overrides?: CreateDogFormOverridesProps | undefined | null;
@@ -14234,12 +14235,12 @@ export default function CreateOwnerForm(props) {
                 variables: {
                   input: {
                     ...Dog,
-                    Owner: owner,
+                    owner: owner,
                   },
                 },
               })
             );
-            const ownerToUnlink = await dogToLink.Owner;
+            const ownerToUnlink = await dogToLink.owner;
             if (ownerToUnlink) {
               promises.push(
                 API.graphql({
@@ -26644,7 +26645,7 @@ import {
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Dog, Owner as Owner0 } from \\"../models\\";
+import { Dog, Owner } from \\"../models\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
@@ -26818,14 +26819,14 @@ export default function CreateDogForm(props) {
   } = props;
   const initialValues = {
     name: \\"\\",
-    Owner: undefined,
+    owner: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
-  const [Owner, setOwner] = React.useState(initialValues.Owner);
+  const [owner, setOwner] = React.useState(initialValues.owner);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     setName(initialValues.name);
-    setOwner(initialValues.Owner);
+    setOwner(initialValues.owner);
     setCurrentOwnerValue(undefined);
     setCurrentOwnerDisplayValue(\\"\\");
     setErrors({});
@@ -26833,25 +26834,25 @@ export default function CreateDogForm(props) {
   const [currentOwnerDisplayValue, setCurrentOwnerDisplayValue] =
     React.useState(\\"\\");
   const [currentOwnerValue, setCurrentOwnerValue] = React.useState(undefined);
-  const OwnerRef = React.createRef();
+  const ownerRef = React.createRef();
   const getIDValue = {
-    Owner: (r) => JSON.stringify({ id: r?.id }),
+    owner: (r) => JSON.stringify({ id: r?.id }),
   };
-  const OwnerIdSet = new Set(
-    Array.isArray(Owner)
-      ? Owner.map((r) => getIDValue.Owner?.(r))
-      : getIDValue.Owner?.(Owner)
+  const ownerIdSet = new Set(
+    Array.isArray(owner)
+      ? owner.map((r) => getIDValue.owner?.(r))
+      : getIDValue.owner?.(owner)
   );
   const ownerRecords = useDataStoreBinding({
     type: \\"collection\\",
-    model: Owner0,
+    model: Owner,
   }).items;
   const getDisplayValue = {
-    Owner: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+    owner: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
   };
   const validations = {
     name: [],
-    Owner: [{ type: \\"Required\\", validationMessage: \\"Owner is required.\\" }],
+    owner: [{ type: \\"Required\\", validationMessage: \\"Owner is required.\\" }],
   };
   const runValidationTasks = async (
     fieldName,
@@ -26880,7 +26881,7 @@ export default function CreateDogForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
-          Owner,
+          owner,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -26920,11 +26921,11 @@ export default function CreateDogForm(props) {
           });
           const dog = await DataStore.save(new Dog(modelFields));
           const promises = [];
-          const ownerToLink = modelFields.Owner;
+          const ownerToLink = modelFields.owner;
           if (ownerToLink) {
             promises.push(
               DataStore.save(
-                Owner0.copyOf(ownerToLink, (updated) => {
+                Owner.copyOf(ownerToLink, (updated) => {
                   updated.Dog = dog;
                 })
               )
@@ -26964,7 +26965,7 @@ export default function CreateDogForm(props) {
           if (onChange) {
             const modelFields = {
               name: value,
-              Owner,
+              owner,
             };
             const result = onChange(modelFields);
             value = result?.name ?? value;
@@ -26986,10 +26987,10 @@ export default function CreateDogForm(props) {
           if (onChange) {
             const modelFields = {
               name,
-              Owner: value,
+              owner: value,
             };
             const result = onChange(modelFields);
-            value = result?.Owner ?? value;
+            value = result?.owner ?? value;
           }
           setOwner(value);
           setCurrentOwnerValue(undefined);
@@ -26997,17 +26998,17 @@ export default function CreateDogForm(props) {
         }}
         currentFieldValue={currentOwnerValue}
         label={\\"Owner\\"}
-        items={Owner ? [Owner] : []}
-        hasError={errors?.Owner?.hasError}
-        errorMessage={errors?.Owner?.errorMessage}
-        getBadgeText={getDisplayValue.Owner}
+        items={owner ? [owner] : []}
+        hasError={errors?.owner?.hasError}
+        errorMessage={errors?.owner?.errorMessage}
+        getBadgeText={getDisplayValue.owner}
         setFieldValue={(model) => {
           setCurrentOwnerDisplayValue(
-            model ? getDisplayValue.Owner(model) : \\"\\"
+            model ? getDisplayValue.owner(model) : \\"\\"
           );
           setCurrentOwnerValue(model);
         }}
-        inputFieldRef={OwnerRef}
+        inputFieldRef={ownerRef}
         defaultFieldValue={\\"\\"}
       >
         <Autocomplete
@@ -27017,10 +27018,10 @@ export default function CreateDogForm(props) {
           placeholder=\\"Search Owner\\"
           value={currentOwnerDisplayValue}
           options={ownerRecords
-            .filter((r) => !OwnerIdSet.has(getIDValue.Owner?.(r)))
+            .filter((r) => !ownerIdSet.has(getIDValue.owner?.(r)))
             .map((r) => ({
-              id: getIDValue.Owner?.(r),
-              label: getDisplayValue.Owner?.(r),
+              id: getIDValue.owner?.(r),
+              label: getDisplayValue.owner?.(r),
             }))}
           onSelect={({ id, label }) => {
             setCurrentOwnerValue(
@@ -27031,25 +27032,25 @@ export default function CreateDogForm(props) {
               )
             );
             setCurrentOwnerDisplayValue(label);
-            runValidationTasks(\\"Owner\\", label);
+            runValidationTasks(\\"owner\\", label);
           }}
           onClear={() => {
             setCurrentOwnerDisplayValue(\\"\\");
           }}
           onChange={(e) => {
             let { value } = e.target;
-            if (errors.Owner?.hasError) {
-              runValidationTasks(\\"Owner\\", value);
+            if (errors.owner?.hasError) {
+              runValidationTasks(\\"owner\\", value);
             }
             setCurrentOwnerDisplayValue(value);
             setCurrentOwnerValue(undefined);
           }}
-          onBlur={() => runValidationTasks(\\"Owner\\", currentOwnerDisplayValue)}
-          errorMessage={errors.Owner?.errorMessage}
-          hasError={errors.Owner?.hasError}
-          ref={OwnerRef}
+          onBlur={() => runValidationTasks(\\"owner\\", currentOwnerDisplayValue)}
+          errorMessage={errors.owner?.errorMessage}
+          hasError={errors.owner?.hasError}
+          ref={ownerRef}
           labelHidden={true}
-          {...getOverrideProps(overrides, \\"Owner\\")}
+          {...getOverrideProps(overrides, \\"owner\\")}
         ></Autocomplete>
       </ArrayField>
       <Flex
@@ -27088,7 +27089,7 @@ exports[`amplify form renderer tests datastore form tests custom form tests shou
 "import * as React from \\"react\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
-import { Owner as Owner0 } from \\"../models\\";
+import { Owner } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -27096,17 +27097,17 @@ export declare type ValidationResponse = {
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type CreateDogFormInputValues = {
     name?: string;
-    Owner?: Owner0;
+    owner?: Owner;
 };
 export declare type CreateDogFormValidationValues = {
     name?: ValidationFunction<string>;
-    Owner?: ValidationFunction<Owner0>;
+    owner?: ValidationFunction<Owner>;
 };
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type CreateDogFormOverridesProps = {
     CreateDogFormGrid?: PrimitiveOverrideProps<GridProps>;
     name?: PrimitiveOverrideProps<TextFieldProps>;
-    Owner?: PrimitiveOverrideProps<AutocompleteProps>;
+    owner?: PrimitiveOverrideProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type CreateDogFormProps = React.PropsWithChildren<{
     overrides?: CreateDogFormOverridesProps | undefined | null;
@@ -27142,7 +27143,7 @@ import {
   getOverrideProps,
   useDataStoreBinding,
 } from \\"@aws-amplify/ui-react/internal\\";
-import { Dog, Owner as Owner0 } from \\"../models\\";
+import { Dog, Owner } from \\"../models\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { DataStore } from \\"aws-amplify\\";
 function ArrayField({
@@ -27317,17 +27318,17 @@ export default function UpdateDogForm(props) {
   } = props;
   const initialValues = {
     name: \\"\\",
-    Owner: undefined,
+    owner: undefined,
   };
   const [name, setName] = React.useState(initialValues.name);
-  const [Owner, setOwner] = React.useState(initialValues.Owner);
+  const [owner, setOwner] = React.useState(initialValues.owner);
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
     const cleanValues = dogRecord
-      ? { ...initialValues, ...dogRecord, Owner }
+      ? { ...initialValues, ...dogRecord, owner }
       : initialValues;
     setName(cleanValues.name);
-    setOwner(cleanValues.Owner);
+    setOwner(cleanValues.owner);
     setCurrentOwnerValue(undefined);
     setCurrentOwnerDisplayValue(\\"\\");
     setErrors({});
@@ -27337,34 +27338,34 @@ export default function UpdateDogForm(props) {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Dog, idProp) : dogModelProp;
       setDogRecord(record);
-      const OwnerRecord = record ? await record.Owner : undefined;
-      setOwner(OwnerRecord);
+      const ownerRecord = record ? await record.owner : undefined;
+      setOwner(ownerRecord);
     };
     queryData();
   }, [idProp, dogModelProp]);
-  React.useEffect(resetStateValues, [dogRecord, Owner]);
+  React.useEffect(resetStateValues, [dogRecord, owner]);
   const [currentOwnerDisplayValue, setCurrentOwnerDisplayValue] =
     React.useState(\\"\\");
   const [currentOwnerValue, setCurrentOwnerValue] = React.useState(undefined);
-  const OwnerRef = React.createRef();
+  const ownerRef = React.createRef();
   const getIDValue = {
-    Owner: (r) => JSON.stringify({ id: r?.id }),
+    owner: (r) => JSON.stringify({ id: r?.id }),
   };
-  const OwnerIdSet = new Set(
-    Array.isArray(Owner)
-      ? Owner.map((r) => getIDValue.Owner?.(r))
-      : getIDValue.Owner?.(Owner)
+  const ownerIdSet = new Set(
+    Array.isArray(owner)
+      ? owner.map((r) => getIDValue.owner?.(r))
+      : getIDValue.owner?.(owner)
   );
   const ownerRecords = useDataStoreBinding({
     type: \\"collection\\",
-    model: Owner0,
+    model: Owner,
   }).items;
   const getDisplayValue = {
-    Owner: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+    owner: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
   };
   const validations = {
     name: [],
-    Owner: [{ type: \\"Required\\", validationMessage: \\"Owner is required.\\" }],
+    owner: [{ type: \\"Required\\", validationMessage: \\"Owner is required.\\" }],
   };
   const runValidationTasks = async (
     fieldName,
@@ -27393,7 +27394,7 @@ export default function UpdateDogForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
-          Owner,
+          owner,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -27432,22 +27433,22 @@ export default function UpdateDogForm(props) {
             }
           });
           const promises = [];
-          const ownerToUnlink = await dogRecord.Owner;
+          const ownerToUnlink = await dogRecord.owner;
           if (ownerToUnlink) {
             promises.push(
               DataStore.save(
-                Owner0.copyOf(ownerToUnlink, (updated) => {
+                Owner.copyOf(ownerToUnlink, (updated) => {
                   updated.Dog = undefined;
                   updated.ownerDogId = undefined;
                 })
               )
             );
           }
-          const ownerToLink = modelFields.Owner;
+          const ownerToLink = modelFields.owner;
           if (ownerToLink) {
             promises.push(
               DataStore.save(
-                Owner0.copyOf(ownerToLink, (updated) => {
+                Owner.copyOf(ownerToLink, (updated) => {
                   updated.Dog = dogRecord;
                 })
               )
@@ -27465,7 +27466,7 @@ export default function UpdateDogForm(props) {
             DataStore.save(
               Dog.copyOf(dogRecord, (updated) => {
                 Object.assign(updated, modelFields);
-                if (!modelFields.Owner) {
+                if (!modelFields.owner) {
                   updated.dogOwnerId = undefined;
                 }
               })
@@ -27494,7 +27495,7 @@ export default function UpdateDogForm(props) {
           if (onChange) {
             const modelFields = {
               name: value,
-              Owner,
+              owner,
             };
             const result = onChange(modelFields);
             value = result?.name ?? value;
@@ -27516,10 +27517,10 @@ export default function UpdateDogForm(props) {
           if (onChange) {
             const modelFields = {
               name,
-              Owner: value,
+              owner: value,
             };
             const result = onChange(modelFields);
-            value = result?.Owner ?? value;
+            value = result?.owner ?? value;
           }
           setOwner(value);
           setCurrentOwnerValue(undefined);
@@ -27527,17 +27528,17 @@ export default function UpdateDogForm(props) {
         }}
         currentFieldValue={currentOwnerValue}
         label={\\"Owner\\"}
-        items={Owner ? [Owner] : []}
-        hasError={errors?.Owner?.hasError}
-        errorMessage={errors?.Owner?.errorMessage}
-        getBadgeText={getDisplayValue.Owner}
+        items={owner ? [owner] : []}
+        hasError={errors?.owner?.hasError}
+        errorMessage={errors?.owner?.errorMessage}
+        getBadgeText={getDisplayValue.owner}
         setFieldValue={(model) => {
           setCurrentOwnerDisplayValue(
-            model ? getDisplayValue.Owner(model) : \\"\\"
+            model ? getDisplayValue.owner(model) : \\"\\"
           );
           setCurrentOwnerValue(model);
         }}
-        inputFieldRef={OwnerRef}
+        inputFieldRef={ownerRef}
         defaultFieldValue={\\"\\"}
       >
         <Autocomplete
@@ -27547,10 +27548,10 @@ export default function UpdateDogForm(props) {
           placeholder=\\"Search Owner\\"
           value={currentOwnerDisplayValue}
           options={ownerRecords
-            .filter((r) => !OwnerIdSet.has(getIDValue.Owner?.(r)))
+            .filter((r) => !ownerIdSet.has(getIDValue.owner?.(r)))
             .map((r) => ({
-              id: getIDValue.Owner?.(r),
-              label: getDisplayValue.Owner?.(r),
+              id: getIDValue.owner?.(r),
+              label: getDisplayValue.owner?.(r),
             }))}
           onSelect={({ id, label }) => {
             setCurrentOwnerValue(
@@ -27561,26 +27562,26 @@ export default function UpdateDogForm(props) {
               )
             );
             setCurrentOwnerDisplayValue(label);
-            runValidationTasks(\\"Owner\\", label);
+            runValidationTasks(\\"owner\\", label);
           }}
           onClear={() => {
             setCurrentOwnerDisplayValue(\\"\\");
           }}
-          defaultValue={Owner}
+          defaultValue={owner}
           onChange={(e) => {
             let { value } = e.target;
-            if (errors.Owner?.hasError) {
-              runValidationTasks(\\"Owner\\", value);
+            if (errors.owner?.hasError) {
+              runValidationTasks(\\"owner\\", value);
             }
             setCurrentOwnerDisplayValue(value);
             setCurrentOwnerValue(undefined);
           }}
-          onBlur={() => runValidationTasks(\\"Owner\\", currentOwnerDisplayValue)}
-          errorMessage={errors.Owner?.errorMessage}
-          hasError={errors.Owner?.hasError}
-          ref={OwnerRef}
+          onBlur={() => runValidationTasks(\\"owner\\", currentOwnerDisplayValue)}
+          errorMessage={errors.owner?.errorMessage}
+          hasError={errors.owner?.hasError}
+          ref={ownerRef}
           labelHidden={true}
-          {...getOverrideProps(overrides, \\"Owner\\")}
+          {...getOverrideProps(overrides, \\"owner\\")}
         ></Autocomplete>
       </ArrayField>
       <Flex
@@ -27623,7 +27624,7 @@ exports[`amplify form renderer tests datastore form tests custom form tests shou
 "import * as React from \\"react\\";
 import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
 import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
-import { Dog, Owner as Owner0 } from \\"../models\\";
+import { Dog, Owner } from \\"../models\\";
 export declare type ValidationResponse = {
     hasError: boolean;
     errorMessage?: string;
@@ -27631,17 +27632,17 @@ export declare type ValidationResponse = {
 export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
 export declare type UpdateDogFormInputValues = {
     name?: string;
-    Owner?: Owner0;
+    owner?: Owner;
 };
 export declare type UpdateDogFormValidationValues = {
     name?: ValidationFunction<string>;
-    Owner?: ValidationFunction<Owner0>;
+    owner?: ValidationFunction<Owner>;
 };
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type UpdateDogFormOverridesProps = {
     UpdateDogFormGrid?: PrimitiveOverrideProps<GridProps>;
     name?: PrimitiveOverrideProps<TextFieldProps>;
-    Owner?: PrimitiveOverrideProps<AutocompleteProps>;
+    owner?: PrimitiveOverrideProps<AutocompleteProps>;
 } & EscapeHatchProps;
 export declare type UpdateDogFormProps = React.PropsWithChildren<{
     overrides?: UpdateDogFormOverridesProps | undefined | null;
@@ -27959,11 +27960,11 @@ export default function CreateOwnerForm(props) {
             promises.push(
               DataStore.save(
                 Dog0.copyOf(dogToLink, (updated) => {
-                  updated.Owner = owner;
+                  updated.owner = owner;
                 })
               )
             );
-            const ownerToUnlink = await dogToLink.Owner;
+            const ownerToUnlink = await dogToLink.owner;
             if (ownerToUnlink) {
               promises.push(
                 DataStore.save(
@@ -28484,11 +28485,11 @@ export default function UpdateOwnerForm(props) {
             promises.push(
               DataStore.save(
                 Dog0.copyOf(dogToLink, (updated) => {
-                  updated.Owner = ownerRecord;
+                  updated.owner = ownerRecord;
                 })
               )
             );
-            const ownerToUnlink = await dogToLink.Owner;
+            const ownerToUnlink = await dogToLink.owner;
             if (ownerToUnlink) {
               promises.push(
                 DataStore.save(

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -434,16 +434,16 @@ export default function CreateOwnerForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Dog\\"
           value={currentDogDisplayValue}
-          options={dogRecords
-            .filter((r) => !DogIdSet.has(getIDValue.Dog?.(r)))
-            .map((r) => ({
-              id: getIDValue.Dog?.(r),
-              label: getDisplayValue.Dog?.(r),
-            }))}
+          options={DogRecords.filter(
+            (r) => !DogIdSet.has(getIDValue.Dog?.(r))
+          ).map((r) => ({
+            id: getIDValue.Dog?.(r),
+            label: getDisplayValue.Dog?.(r),
+          }))}
           isLoading={DogLoading}
           onSelect={({ id, label }) => {
             setCurrentDogValue(
-              dogRecords.find((r) =>
+              DogRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -1758,16 +1758,16 @@ export default function MyMemberForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Team\\"
           value={currentTeamDisplayValue}
-          options={teamRecords
-            .filter((r) => !TeamIdSet.has(getIDValue.Team?.(r)))
-            .map((r) => ({
-              id: getIDValue.Team?.(r),
-              label: getDisplayValue.Team?.(r),
-            }))}
+          options={TeamRecords.filter(
+            (r) => !TeamIdSet.has(getIDValue.Team?.(r))
+          ).map((r) => ({
+            id: getIDValue.Team?.(r),
+            label: getDisplayValue.Team?.(r),
+          }))}
           isLoading={TeamLoading}
           onSelect={({ id, label }) => {
             setCurrentTeamValue(
-              teamRecords.find((r) =>
+              TeamRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -2269,16 +2269,16 @@ export default function SchoolCreateForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Student\\"
           value={currentStudentsDisplayValue}
-          options={studentsRecords
-            .filter((r) => !StudentsIdSet.has(getIDValue.Students?.(r)))
-            .map((r) => ({
-              id: getIDValue.Students?.(r),
-              label: getDisplayValue.Students?.(r),
-            }))}
+          options={StudentsRecords.filter(
+            (r) => !StudentsIdSet.has(getIDValue.Students?.(r))
+          ).map((r) => ({
+            id: getIDValue.Students?.(r),
+            label: getDisplayValue.Students?.(r),
+          }))}
           isLoading={StudentsLoading}
           onSelect={({ id, label }) => {
             setCurrentStudentsValue(
-              studentRecords.find((r) =>
+              StudentsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -2844,7 +2844,7 @@ export default function BookCreateForm(props) {
           isLoading={primaryAuthorLoading}
           onSelect={({ id, label }) => {
             setCurrentPrimaryAuthorValue(
-              authorRecords.find((r) =>
+              primaryAuthorRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -3367,14 +3367,14 @@ export default function TagCreateForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Post\\"
           value={currentPostsDisplayValue}
-          options={postsRecords.map((r) => ({
+          options={PostsRecords.map((r) => ({
             id: getIDValue.Posts?.(r),
             label: getDisplayValue.Posts?.(r),
           }))}
           isLoading={PostsLoading}
           onSelect={({ id, label }) => {
             setCurrentPostsValue(
-              postRecords.find((r) =>
+              PostsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -4052,7 +4052,7 @@ export default function BookCreateForm(props) {
           isLoading={primaryAuthorLoading}
           onSelect={({ id, label }) => {
             setCurrentPrimaryAuthorValue(
-              authorRecords.find((r) =>
+              primaryAuthorRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -4133,7 +4133,7 @@ export default function BookCreateForm(props) {
           isLoading={primaryTitleLoading}
           onSelect={({ id, label }) => {
             setCurrentPrimaryTitleValue(
-              titleRecords.find((r) =>
+              primaryTitleRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -4786,14 +4786,14 @@ export default function PostUpdateForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Comment\\"
           value={currentCommentsDisplayValue}
-          options={commentsRecords.map((r) => ({
+          options={CommentsRecords.map((r) => ({
             id: getIDValue.Comments?.(r),
             label: getDisplayValue.Comments?.(r),
           }))}
           isLoading={CommentsLoading}
           onSelect={({ id, label }) => {
             setCurrentCommentsValue(
-              commentRecords.find((r) =>
+              CommentsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -6347,7 +6347,7 @@ export default function MovieUpdateForm(props) {
           isLoading={tagsLoading}
           onSelect={({ id, label }) => {
             setCurrentTagsValue(
-              tagRecords.find((r) =>
+              tagsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -7035,16 +7035,16 @@ export default function CommentUpdateForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Post\\"
           value={currentPostDisplayValue}
-          options={postRecords
-            .filter((r) => !PostIdSet.has(getIDValue.Post?.(r)))
-            .map((r) => ({
-              id: getIDValue.Post?.(r),
-              label: getDisplayValue.Post?.(r),
-            }))}
+          options={PostRecords.filter(
+            (r) => !PostIdSet.has(getIDValue.Post?.(r))
+          ).map((r) => ({
+            id: getIDValue.Post?.(r),
+            label: getDisplayValue.Post?.(r),
+          }))}
           isLoading={PostLoading}
           onSelect={({ id, label }) => {
             setCurrentPostValue(
-              postRecords.find((r) =>
+              PostRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -7751,16 +7751,16 @@ export default function CommentUpdateForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Post\\"
           value={currentPostDisplayValue}
-          options={postRecords
-            .filter((r) => !PostIdSet.has(getIDValue.Post?.(r)))
-            .map((r) => ({
-              id: getIDValue.Post?.(r),
-              label: getDisplayValue.Post?.(r),
-            }))}
+          options={PostRecords.filter(
+            (r) => !PostIdSet.has(getIDValue.Post?.(r))
+          ).map((r) => ({
+            id: getIDValue.Post?.(r),
+            label: getDisplayValue.Post?.(r),
+          }))}
           isLoading={PostLoading}
           onSelect={({ id, label }) => {
             setCurrentPostValue(
-              postRecords.find((r) =>
+              PostRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -8402,7 +8402,7 @@ export default function ClassUpdateForm(props) {
           isLoading={studentsLoading}
           onSelect={({ id, label }) => {
             setCurrentStudentsValue(
-              studentRecords.find((r) =>
+              studentsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -9230,16 +9230,16 @@ export default function UpdateCPKTeacherForm(props) {
           isReadOnly={false}
           placeholder=\\"Search CPKStudent\\"
           value={currentCPKStudentDisplayValue}
-          options={cPKStudentRecords
-            .filter((r) => !CPKStudentIdSet.has(getIDValue.CPKStudent?.(r)))
-            .map((r) => ({
-              id: getIDValue.CPKStudent?.(r),
-              label: getDisplayValue.CPKStudent?.(r),
-            }))}
+          options={CPKStudentRecords.filter(
+            (r) => !CPKStudentIdSet.has(getIDValue.CPKStudent?.(r))
+          ).map((r) => ({
+            id: getIDValue.CPKStudent?.(r),
+            label: getDisplayValue.CPKStudent?.(r),
+          }))}
           isLoading={CPKStudentLoading}
           onSelect={({ id, label }) => {
             setCurrentCPKStudentValue(
-              cPKStudentRecords.find((r) =>
+              CPKStudentRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -9309,14 +9309,14 @@ export default function UpdateCPKTeacherForm(props) {
           isReadOnly={false}
           placeholder=\\"Search CPKClass\\"
           value={currentCPKClassesDisplayValue}
-          options={cPKClassesRecords.map((r) => ({
+          options={CPKClassesRecords.map((r) => ({
             id: getIDValue.CPKClasses?.(r),
             label: getDisplayValue.CPKClasses?.(r),
           }))}
           isLoading={CPKClassesLoading}
           onSelect={({ id, label }) => {
             setCurrentCPKClassesValue(
-              cPKClassRecords.find((r) =>
+              CPKClassesRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -9385,16 +9385,16 @@ export default function UpdateCPKTeacherForm(props) {
           isReadOnly={false}
           placeholder=\\"Search CPKProject\\"
           value={currentCPKProjectsDisplayValue}
-          options={cPKProjectsRecords
-            .filter((r) => !CPKProjectsIdSet.has(getIDValue.CPKProjects?.(r)))
-            .map((r) => ({
-              id: getIDValue.CPKProjects?.(r),
-              label: getDisplayValue.CPKProjects?.(r),
-            }))}
+          options={CPKProjectsRecords.filter(
+            (r) => !CPKProjectsIdSet.has(getIDValue.CPKProjects?.(r))
+          ).map((r) => ({
+            id: getIDValue.CPKProjects?.(r),
+            label: getDisplayValue.CPKProjects?.(r),
+          }))}
           isLoading={CPKProjectsLoading}
           onSelect={({ id, label }) => {
             setCurrentCPKProjectsValue(
-              cPKProjectRecords.find((r) =>
+              CPKProjectsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -10869,16 +10869,16 @@ export default function CreateCommentForm(props) {
           isReadOnly={false}
           placeholder=\\"Search User\\"
           value={currentUserDisplayValue}
-          options={userRecords
-            .filter((r) => !UserIdSet.has(getIDValue.User?.(r)))
-            .map((r) => ({
-              id: getIDValue.User?.(r),
-              label: getDisplayValue.User?.(r),
-            }))}
+          options={UserRecords.filter(
+            (r) => !UserIdSet.has(getIDValue.User?.(r))
+          ).map((r) => ({
+            id: getIDValue.User?.(r),
+            label: getDisplayValue.User?.(r),
+          }))}
           isLoading={UserLoading}
           onSelect={({ id, label }) => {
             setCurrentUserValue(
-              userRecords.find((r) =>
+              UserRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -10945,16 +10945,16 @@ export default function CreateCommentForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Org\\"
           value={currentOrgDisplayValue}
-          options={orgRecords
-            .filter((r) => !OrgIdSet.has(getIDValue.Org?.(r)))
-            .map((r) => ({
-              id: getIDValue.Org?.(r),
-              label: getDisplayValue.Org?.(r),
-            }))}
+          options={OrgRecords.filter(
+            (r) => !OrgIdSet.has(getIDValue.Org?.(r))
+          ).map((r) => ({
+            id: getIDValue.Org?.(r),
+            label: getDisplayValue.Org?.(r),
+          }))}
           isLoading={OrgLoading}
           onSelect={({ id, label }) => {
             setCurrentOrgValue(
-              orgRecords.find((r) =>
+              OrgRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -11856,18 +11856,16 @@ export default function CreateCompositeDogForm(props) {
           isReadOnly={false}
           placeholder=\\"Search CompositeBowl\\"
           value={currentCompositeBowlDisplayValue}
-          options={compositeBowlRecords
-            .filter(
-              (r) => !CompositeBowlIdSet.has(getIDValue.CompositeBowl?.(r))
-            )
-            .map((r) => ({
-              id: getIDValue.CompositeBowl?.(r),
-              label: getDisplayValue.CompositeBowl?.(r),
-            }))}
+          options={CompositeBowlRecords.filter(
+            (r) => !CompositeBowlIdSet.has(getIDValue.CompositeBowl?.(r))
+          ).map((r) => ({
+            id: getIDValue.CompositeBowl?.(r),
+            label: getDisplayValue.CompositeBowl?.(r),
+          }))}
           isLoading={CompositeBowlLoading}
           onSelect={({ id, label }) => {
             setCurrentCompositeBowlValue(
-              compositeBowlRecords.find((r) =>
+              CompositeBowlRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -11942,18 +11940,16 @@ export default function CreateCompositeDogForm(props) {
           isReadOnly={false}
           placeholder=\\"Search CompositeOwner\\"
           value={currentCompositeOwnerDisplayValue}
-          options={compositeOwnerRecords
-            .filter(
-              (r) => !CompositeOwnerIdSet.has(getIDValue.CompositeOwner?.(r))
-            )
-            .map((r) => ({
-              id: getIDValue.CompositeOwner?.(r),
-              label: getDisplayValue.CompositeOwner?.(r),
-            }))}
+          options={CompositeOwnerRecords.filter(
+            (r) => !CompositeOwnerIdSet.has(getIDValue.CompositeOwner?.(r))
+          ).map((r) => ({
+            id: getIDValue.CompositeOwner?.(r),
+            label: getDisplayValue.CompositeOwner?.(r),
+          }))}
           isLoading={CompositeOwnerLoading}
           onSelect={({ id, label }) => {
             setCurrentCompositeOwnerValue(
-              compositeOwnerRecords.find((r) =>
+              CompositeOwnerRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -12027,18 +12023,16 @@ export default function CreateCompositeDogForm(props) {
           isReadOnly={false}
           placeholder=\\"Search CompositeToy\\"
           value={currentCompositeToysDisplayValue}
-          options={compositeToysRecords
-            .filter(
-              (r) => !CompositeToysIdSet.has(getIDValue.CompositeToys?.(r))
-            )
-            .map((r) => ({
-              id: getIDValue.CompositeToys?.(r),
-              label: getDisplayValue.CompositeToys?.(r),
-            }))}
+          options={CompositeToysRecords.filter(
+            (r) => !CompositeToysIdSet.has(getIDValue.CompositeToys?.(r))
+          ).map((r) => ({
+            id: getIDValue.CompositeToys?.(r),
+            label: getDisplayValue.CompositeToys?.(r),
+          }))}
           isLoading={CompositeToysLoading}
           onSelect={({ id, label }) => {
             setCurrentCompositeToysValue(
-              compositeToyRecords.find((r) =>
+              CompositeToysRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -12112,14 +12106,14 @@ export default function CreateCompositeDogForm(props) {
           isReadOnly={false}
           placeholder=\\"Search CompositeVet\\"
           value={currentCompositeVetsDisplayValue}
-          options={compositeVetsRecords.map((r) => ({
+          options={CompositeVetsRecords.map((r) => ({
             id: getIDValue.CompositeVets?.(r),
             label: getDisplayValue.CompositeVets?.(r),
           }))}
           isLoading={CompositeVetsLoading}
           onSelect={({ id, label }) => {
             setCurrentCompositeVetsValue(
-              compositeVetRecords.find((r) =>
+              CompositeVetsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -12669,7 +12663,7 @@ export default function CreatePostForm(props) {
           isLoading={commentsLoading}
           onSelect={({ id, label }) => {
             setCurrentCommentsValue(
-              commentRecords.find((r) =>
+              commentsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -13260,7 +13254,7 @@ export default function UpdatePostForm(props) {
           isLoading={commentsLoading}
           onSelect={({ id, label }) => {
             setCurrentCommentsValue(
-              commentRecords.find((r) =>
+              commentsRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -13795,16 +13789,16 @@ export default function CreateDogForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Owner\\"
           value={currentOwnerDisplayValue}
-          options={ownerRecords
-            .filter((r) => !OwnerIdSet.has(getIDValue.Owner?.(r)))
-            .map((r) => ({
-              id: getIDValue.Owner?.(r),
-              label: getDisplayValue.Owner?.(r),
-            }))}
+          options={OwnerRecords.filter(
+            (r) => !OwnerIdSet.has(getIDValue.Owner?.(r))
+          ).map((r) => ({
+            id: getIDValue.Owner?.(r),
+            label: getDisplayValue.Owner?.(r),
+          }))}
           isLoading={OwnerLoading}
           onSelect={({ id, label }) => {
             setCurrentOwnerValue(
-              ownerRecords.find((r) =>
+              OwnerRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )
@@ -14337,16 +14331,16 @@ export default function CreateOwnerForm(props) {
           isReadOnly={false}
           placeholder=\\"Search Dog\\"
           value={currentDogDisplayValue}
-          options={dogRecords
-            .filter((r) => !DogIdSet.has(getIDValue.Dog?.(r)))
-            .map((r) => ({
-              id: getIDValue.Dog?.(r),
-              label: getDisplayValue.Dog?.(r),
-            }))}
+          options={DogRecords.filter(
+            (r) => !DogIdSet.has(getIDValue.Dog?.(r))
+          ).map((r) => ({
+            id: getIDValue.Dog?.(r),
+            label: getDisplayValue.Dog?.(r),
+          }))}
           isLoading={DogLoading}
           onSelect={({ id, label }) => {
             setCurrentDogValue(
-              dogRecords.find((r) =>
+              DogRecords.find((r) =>
                 Object.entries(JSON.parse(id)).every(
                   ([key, value]) => r[key] === value
                 )

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/all-props.ts
@@ -105,7 +105,7 @@ export const addFormAttributes = (
         );
       }
       attributes.push(
-        buildOnSelect({ sanitizedFieldName: renderedVariableName, fieldConfig, fieldName: componentName }),
+        buildOnSelect({ sanitizedFieldName: renderedVariableName, fieldConfig, fieldName: componentName, dataApi }),
       );
       attributes.push(buildOnClearStatement(componentName, fieldConfig));
     }

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
@@ -36,7 +36,7 @@ import {
   Expression,
   ExpressionStatement,
 } from 'typescript';
-import { lowerCaseFirst, getSetNameIdentifier, getModelNameProp } from '../../helpers';
+import { lowerCaseFirst, getSetNameIdentifier, getModelNameProp, fieldMatchesModel } from '../../helpers';
 import { buildTargetVariable } from './event-targets';
 import {
   buildAccessChain,
@@ -379,10 +379,12 @@ export function buildOnSelect({
   sanitizedFieldName,
   fieldName,
   fieldConfig,
+  dataApi,
 }: {
   sanitizedFieldName: string;
   fieldName: string;
   fieldConfig: FieldConfigMetadata;
+  dataApi?: DataApiKind;
 }): JsxAttribute {
   const labelString = 'label';
   const idString = 'id';
@@ -405,7 +407,8 @@ export function buildOnSelect({
     nextCurrentDisplayValue = factory.createIdentifier(labelString);
 
     nextCurrentValue = getMatchEveryModelFieldCallExpression({
-      recordsArrayName: getRecordsName(model),
+      recordsArrayName:
+        dataApi === 'GraphQL' ? getRecordsName(fieldName, fieldMatchesModel(fieldName, model)) : getRecordsName(model),
       JSONName: idString,
     });
   }

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/event-handler-props.ts
@@ -36,7 +36,7 @@ import {
   Expression,
   ExpressionStatement,
 } from 'typescript';
-import { lowerCaseFirst, getSetNameIdentifier, getModelNameProp, fieldMatchesModel } from '../../helpers';
+import { lowerCaseFirst, getSetNameIdentifier, getModelNameProp } from '../../helpers';
 import { buildTargetVariable } from './event-targets';
 import {
   buildAccessChain,
@@ -407,8 +407,7 @@ export function buildOnSelect({
     nextCurrentDisplayValue = factory.createIdentifier(labelString);
 
     nextCurrentValue = getMatchEveryModelFieldCallExpression({
-      recordsArrayName:
-        dataApi === 'GraphQL' ? getRecordsName(fieldName, fieldMatchesModel(fieldName, model)) : getRecordsName(model),
+      recordsArrayName: dataApi === 'GraphQL' ? `${fieldName}Records` : getRecordsName(model),
       JSONName: idString,
     });
   }

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
@@ -46,7 +46,6 @@ import { buildAccessChain, getRecordsName } from './form-state';
 import { getElementAccessExpression, getValidProperty } from './invalid-variable-helpers';
 import { isEnumDataType, isModelDataType } from './render-checkers';
 import { DataApiKind } from '../../react-render-config';
-import { fieldMatchesModel } from '../../helpers';
 
 export const getDisplayValueObjectName = 'getDisplayValue';
 
@@ -283,10 +282,7 @@ function getModelTypeSuggestions({
 }): CallExpression {
   const recordString = 'r';
   const labelExpression = getDisplayValueCallChain({ fieldName, recordString });
-  const optionsRecords =
-    dataApi === 'GraphQL'
-      ? getRecordsName(fieldName, fieldMatchesModel(fieldName, modelName))
-      : getRecordsName(modelName);
+  const optionsRecords = dataApi === 'GraphQL' ? `${fieldName}Records` : getRecordsName(modelName);
 
   const mappingFunction = factory.createArrowFunction(
     undefined,

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
@@ -46,6 +46,7 @@ import { buildAccessChain, getRecordsName } from './form-state';
 import { getElementAccessExpression, getValidProperty } from './invalid-variable-helpers';
 import { isEnumDataType, isModelDataType } from './render-checkers';
 import { DataApiKind } from '../../react-render-config';
+import { fieldMatchesModel } from '../../helpers';
 
 export const getDisplayValueObjectName = 'getDisplayValue';
 
@@ -282,7 +283,10 @@ function getModelTypeSuggestions({
 }): CallExpression {
   const recordString = 'r';
   const labelExpression = getDisplayValueCallChain({ fieldName, recordString });
-  const optionsRecords = dataApi === 'GraphQL' ? getRecordsName(fieldName) : getRecordsName(modelName);
+  const optionsRecords =
+    dataApi === 'GraphQL'
+      ? getRecordsName(fieldName, fieldMatchesModel(fieldName, modelName))
+      : getRecordsName(modelName);
 
   const mappingFunction = factory.createArrowFunction(
     undefined,

--- a/packages/codegen-ui-react/lib/helpers/index.ts
+++ b/packages/codegen-ui-react/lib/helpers/index.ts
@@ -15,7 +15,6 @@
  */
 import { GenericDataField, GenericDataSchema, StudioFormFields } from '@aws-amplify/codegen-ui/lib/types';
 import { factory, Statement, Expression, NodeFlags, Identifier, ParameterDeclaration, SyntaxKind } from 'typescript';
-import { plural } from 'pluralize';
 import { isPrimitive } from '../primitive';
 
 export const lowerCaseFirst = (input: string) => input.charAt(0).toLowerCase() + input.slice(1);
@@ -219,8 +218,4 @@ export function getControlledComponentDefaultValue(
     }
   });
   return defaultValue;
-}
-
-export function fieldMatchesModel(fieldName: string, modelName: string): boolean {
-  return fieldName === modelName || fieldName === plural(modelName);
 }

--- a/packages/codegen-ui-react/lib/helpers/index.ts
+++ b/packages/codegen-ui-react/lib/helpers/index.ts
@@ -15,6 +15,7 @@
  */
 import { GenericDataField, GenericDataSchema, StudioFormFields } from '@aws-amplify/codegen-ui/lib/types';
 import { factory, Statement, Expression, NodeFlags, Identifier, ParameterDeclaration, SyntaxKind } from 'typescript';
+import { plural } from 'pluralize';
 import { isPrimitive } from '../primitive';
 
 export const lowerCaseFirst = (input: string) => input.charAt(0).toLowerCase() + input.slice(1);
@@ -218,4 +219,8 @@ export function getControlledComponentDefaultValue(
     }
   });
   return defaultValue;
+}
+
+export function fieldMatchesModel(fieldName: string, modelName: string): boolean {
+  return fieldName === modelName || fieldName === plural(modelName);
 }

--- a/packages/codegen-ui/example-schemas/datastore/dog-owner-required.json
+++ b/packages/codegen-ui/example-schemas/datastore/dog-owner-required.json
@@ -5,8 +5,8 @@
       "fields": {
         "id": { "name": "id", "isArray": false, "type": "ID", "isRequired": true, "attributes": [] },
         "name": { "name": "name", "isArray": false, "type": "String", "isRequired": false, "attributes": [] },
-        "Owner": {
-          "name": "Owner",
+        "owner": {
+          "name": "owner",
           "isArray": false,
           "type": { "model": "Owner" },
           "isRequired": true,


### PR DESCRIPTION
## Problem

There are inconsistencies in casing and using model name instead of field name for a couple variables used for the Autocomplete control. This causes errors such as: `_____ is not defined`.

## Solution

Update variables used in `options` and `onSelect` to match the appropriate local state.

## Additional Notes

Update `dog-owner-required` schema to represent lowercase model fields to ensure we match casing from schema.

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
