### PR TITLE
fix: update create parent and update child graphql expressions

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3618,6 +3618,7 @@ import {
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../API\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { listPosts } from \\"../graphql/queries\\";
@@ -3961,8 +3962,8 @@ export default function TagCreateForm(props) {
                   query: createTagPost,
                   variables: {
                     input: {
-                      tag,
-                      post,
+                      tagID: tag.id,
+                      postID: Post.id,
                     },
                   },
                 })
@@ -4897,6 +4898,841 @@ export declare type BookCreateFormProps = React.PropsWithChildren<{
     onValidate?: BookCreateFormValidationValues;
 } & React.CSSProperties>;
 export default function BookCreateForm(props: BookCreateFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate a create form with multiple relationship & cpk 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { CPKClass } from \\"../API\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { API } from \\"aws-amplify\\";
+import {
+  listCPKClasses,
+  listCPKProjects,
+  listCPKStudents,
+} from \\"../graphql/queries\\";
+import {
+  createCPKTeacher,
+  createCPKTeacherCPKClass,
+  updateCPKProject,
+} from \\"../graphql/mutations\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button
+            size=\\"small\\"
+            variation=\\"link\\"
+            isDisabled={hasError}
+            onClick={addItem}
+          >
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function CreateCPKTeacherForm(props) {
+  const {
+    clearOnSuccess = true,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    specialTeacherId: \\"\\",
+    CPKStudent: undefined,
+    CPKClasses: [],
+    CPKProjects: [],
+  };
+  const [specialTeacherId, setSpecialTeacherId] = React.useState(
+    initialValues.specialTeacherId
+  );
+  const [CPKStudent, setCPKStudent] = React.useState(initialValues.CPKStudent);
+  const [CPKStudentLoading, setCPKStudentLoading] = React.useState(false);
+  const [CPKStudentRecords, setCPKStudentRecords] = React.useState([]);
+  const [CPKClasses, setCPKClasses] = React.useState(initialValues.CPKClasses);
+  const [CPKClassesLoading, setCPKClassesLoading] = React.useState(false);
+  const [CPKClassesRecords, setCPKClassesRecords] = React.useState([]);
+  const [CPKProjects, setCPKProjects] = React.useState(
+    initialValues.CPKProjects
+  );
+  const [CPKProjectsLoading, setCPKProjectsLoading] = React.useState(false);
+  const [CPKProjectsRecords, setCPKProjectsRecords] = React.useState([]);
+  const autocompleteLength = 10;
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setSpecialTeacherId(initialValues.specialTeacherId);
+    setCPKStudent(initialValues.CPKStudent);
+    setCurrentCPKStudentValue(undefined);
+    setCurrentCPKStudentDisplayValue(\\"\\");
+    setCPKClasses(initialValues.CPKClasses);
+    setCurrentCPKClassesValue(undefined);
+    setCurrentCPKClassesDisplayValue(\\"\\");
+    setCPKProjects(initialValues.CPKProjects);
+    setCurrentCPKProjectsValue(undefined);
+    setCurrentCPKProjectsDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [currentCPKStudentDisplayValue, setCurrentCPKStudentDisplayValue] =
+    React.useState(\\"\\");
+  const [currentCPKStudentValue, setCurrentCPKStudentValue] =
+    React.useState(undefined);
+  const CPKStudentRef = React.createRef();
+  const [currentCPKClassesDisplayValue, setCurrentCPKClassesDisplayValue] =
+    React.useState(\\"\\");
+  const [currentCPKClassesValue, setCurrentCPKClassesValue] =
+    React.useState(undefined);
+  const CPKClassesRef = React.createRef();
+  const [currentCPKProjectsDisplayValue, setCurrentCPKProjectsDisplayValue] =
+    React.useState(\\"\\");
+  const [currentCPKProjectsValue, setCurrentCPKProjectsValue] =
+    React.useState(undefined);
+  const CPKProjectsRef = React.createRef();
+  const getIDValue = {
+    CPKStudent: (r) =>
+      JSON.stringify({ specialStudentId: r?.specialStudentId }),
+    CPKClasses: (r) => JSON.stringify({ specialClassId: r?.specialClassId }),
+    CPKProjects: (r) =>
+      JSON.stringify({ specialProjectId: r?.specialProjectId }),
+  };
+  const CPKStudentIdSet = new Set(
+    Array.isArray(CPKStudent)
+      ? CPKStudent.map((r) => getIDValue.CPKStudent?.(r))
+      : getIDValue.CPKStudent?.(CPKStudent)
+  );
+  const CPKClassesIdSet = new Set(
+    Array.isArray(CPKClasses)
+      ? CPKClasses.map((r) => getIDValue.CPKClasses?.(r))
+      : getIDValue.CPKClasses?.(CPKClasses)
+  );
+  const CPKProjectsIdSet = new Set(
+    Array.isArray(CPKProjects)
+      ? CPKProjects.map((r) => getIDValue.CPKProjects?.(r))
+      : getIDValue.CPKProjects?.(CPKProjects)
+  );
+  const getDisplayValue = {
+    CPKStudent: (r) => r?.specialStudentId,
+    CPKClasses: (r) => r?.specialClassId,
+    CPKProjects: (r) => r?.specialProjectId,
+  };
+  const validations = {
+    specialTeacherId: [{ type: \\"Required\\" }],
+    CPKStudent: [],
+    CPKClasses: [],
+    CPKProjects: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  const fetchCPKStudentRecords = async (value) => {
+    setCPKStudentLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: { or: [{ specialStudentId: { contains: value } }] },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listCPKStudents,
+          variables,
+        })
+      )?.data?.listCPKStudents?.items;
+      var loaded = result.filter(
+        (item) => !CPKStudentIdSet.has(getIDValue.CPKStudent?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setCPKStudentRecords(newOptions.slice(0, autocompleteLength));
+    setCPKStudentLoading(false);
+  };
+  const fetchCPKClassesRecords = async (value) => {
+    setCPKClassesLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: { or: [{ specialClassId: { contains: value } }] },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listCPKClasses,
+          variables,
+        })
+      )?.data?.listCPKClasses?.items;
+      var loaded = result.filter(
+        (item) => !CPKClassesIdSet.has(getIDValue.CPKClasses?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setCPKClassesRecords(newOptions.slice(0, autocompleteLength));
+    setCPKClassesLoading(false);
+  };
+  const fetchCPKProjectsRecords = async (value) => {
+    setCPKProjectsLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: { or: [{ specialProjectId: { contains: value } }] },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listCPKProjects,
+          variables,
+        })
+      )?.data?.listCPKProjects?.items;
+      var loaded = result.filter(
+        (item) => !CPKProjectsIdSet.has(getIDValue.CPKProjects?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setCPKProjectsRecords(newOptions.slice(0, autocompleteLength));
+    setCPKProjectsLoading(false);
+  };
+  React.useEffect(() => {
+    fetchCPKStudentRecords(\\"\\");
+    fetchCPKClassesRecords(\\"\\");
+    fetchCPKProjectsRecords(\\"\\");
+  }, []);
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          specialTeacherId,
+          cPKTeacherCPKStudentSpecialStudentId: CPKStudent.specialStudentId,
+          CPKClasses,
+          CPKProjects,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          const modelFieldsToSave = {
+            specialTeacherId: modelFields.specialTeacherId,
+            CPKStudent: modelFields.CPKStudent,
+          };
+          const cPKTeacher = (
+            await API.graphql({
+              query: createCPKTeacher,
+              variables: {
+                input: {
+                  ...modelFieldsToSave,
+                },
+              },
+            })
+          )?.data?.createCPKTeacher;
+          const promises = [];
+          promises.push(
+            ...CPKClasses.reduce((promises, cpkClass) => {
+              promises.push(
+                API.graphql({
+                  query: createCPKTeacherCPKClass,
+                  variables: {
+                    input: {
+                      cPKTeacherSpecialTeacherId: cPKTeacher.specialTeacherId,
+                      cPKClassSpecialClassId: CPKClass.specialClassId,
+                    },
+                  },
+                })
+              );
+              return promises;
+            }, [])
+          );
+          promises.push(
+            ...CPKProjects.reduce((promises, original) => {
+              promises.push(
+                API.graphql({
+                  query: updateCPKProject,
+                  variables: {
+                    input: {
+                      specialProjectId: original.specialProjectId,
+                      cPKTeacherID: cPKTeacher.specialTeacherId,
+                    },
+                  },
+                })
+              );
+              return promises;
+            }, [])
+          );
+          await Promise.all(promises);
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+          if (clearOnSuccess) {
+            resetStateValues();
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"CreateCPKTeacherForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Special teacher id\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={specialTeacherId}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              specialTeacherId: value,
+              cPKTeacherCPKStudentSpecialStudentId: CPKStudent.specialStudentId,
+              CPKClasses,
+              CPKProjects,
+            };
+            const result = onChange(modelFields);
+            value = result?.specialTeacherId ?? value;
+          }
+          if (errors.specialTeacherId?.hasError) {
+            runValidationTasks(\\"specialTeacherId\\", value);
+          }
+          setSpecialTeacherId(value);
+        }}
+        onBlur={() => runValidationTasks(\\"specialTeacherId\\", specialTeacherId)}
+        errorMessage={errors.specialTeacherId?.errorMessage}
+        hasError={errors.specialTeacherId?.hasError}
+        {...getOverrideProps(overrides, \\"specialTeacherId\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              specialTeacherId,
+              CPKStudent: value,
+              CPKClasses,
+              CPKProjects,
+            };
+            const result = onChange(modelFields);
+            value = result?.CPKStudent ?? value;
+          }
+          setCPKStudent(value);
+          setCurrentCPKStudentValue(undefined);
+          setCurrentCPKStudentDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentCPKStudentValue}
+        label={\\"Cpk student\\"}
+        items={CPKStudent ? [CPKStudent] : []}
+        hasError={errors?.CPKStudent?.hasError}
+        errorMessage={errors?.CPKStudent?.errorMessage}
+        getBadgeText={getDisplayValue.CPKStudent}
+        setFieldValue={(model) => {
+          setCurrentCPKStudentDisplayValue(
+            model ? getDisplayValue.CPKStudent(model) : \\"\\"
+          );
+          setCurrentCPKStudentValue(model);
+        }}
+        inputFieldRef={CPKStudentRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Cpk student\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search CPKStudent\\"
+          value={currentCPKStudentDisplayValue}
+          options={CPKStudentRecords.filter(
+            (r) => !CPKStudentIdSet.has(getIDValue.CPKStudent?.(r))
+          ).map((r) => ({
+            id: getIDValue.CPKStudent?.(r),
+            label: getDisplayValue.CPKStudent?.(r),
+          }))}
+          isLoading={CPKStudentLoading}
+          onSelect={({ id, label }) => {
+            setCurrentCPKStudentValue(
+              CPKStudentRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentCPKStudentDisplayValue(label);
+            runValidationTasks(\\"CPKStudent\\", label);
+          }}
+          onClear={() => {
+            setCurrentCPKStudentDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchCPKStudentRecords(value);
+            if (errors.CPKStudent?.hasError) {
+              runValidationTasks(\\"CPKStudent\\", value);
+            }
+            setCurrentCPKStudentDisplayValue(value);
+            setCurrentCPKStudentValue(undefined);
+          }}
+          onBlur={() =>
+            runValidationTasks(\\"CPKStudent\\", currentCPKStudentDisplayValue)
+          }
+          errorMessage={errors.CPKStudent?.errorMessage}
+          hasError={errors.CPKStudent?.hasError}
+          ref={CPKStudentRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"CPKStudent\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        onChange={async (items) => {
+          let values = items;
+          if (onChange) {
+            const modelFields = {
+              specialTeacherId,
+              cPKTeacherCPKStudentSpecialStudentId: CPKStudent.specialStudentId,
+              CPKClasses: values,
+              CPKProjects,
+            };
+            const result = onChange(modelFields);
+            values = result?.CPKClasses ?? values;
+          }
+          setCPKClasses(values);
+          setCurrentCPKClassesValue(undefined);
+          setCurrentCPKClassesDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentCPKClassesValue}
+        label={\\"Cpk classes\\"}
+        items={CPKClasses}
+        hasError={errors?.CPKClasses?.hasError}
+        errorMessage={errors?.CPKClasses?.errorMessage}
+        getBadgeText={getDisplayValue.CPKClasses}
+        setFieldValue={(model) => {
+          setCurrentCPKClassesDisplayValue(
+            model ? getDisplayValue.CPKClasses(model) : \\"\\"
+          );
+          setCurrentCPKClassesValue(model);
+        }}
+        inputFieldRef={CPKClassesRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Cpk classes\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search CPKClass\\"
+          value={currentCPKClassesDisplayValue}
+          options={CPKClassesRecords.map((r) => ({
+            id: getIDValue.CPKClasses?.(r),
+            label: getDisplayValue.CPKClasses?.(r),
+          }))}
+          isLoading={CPKClassesLoading}
+          onSelect={({ id, label }) => {
+            setCurrentCPKClassesValue(
+              CPKClassesRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentCPKClassesDisplayValue(label);
+            runValidationTasks(\\"CPKClasses\\", label);
+          }}
+          onClear={() => {
+            setCurrentCPKClassesDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchCPKClassesRecords(value);
+            if (errors.CPKClasses?.hasError) {
+              runValidationTasks(\\"CPKClasses\\", value);
+            }
+            setCurrentCPKClassesDisplayValue(value);
+            setCurrentCPKClassesValue(undefined);
+          }}
+          onBlur={() =>
+            runValidationTasks(\\"CPKClasses\\", currentCPKClassesDisplayValue)
+          }
+          errorMessage={errors.CPKClasses?.errorMessage}
+          hasError={errors.CPKClasses?.hasError}
+          ref={CPKClassesRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"CPKClasses\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        onChange={async (items) => {
+          let values = items;
+          if (onChange) {
+            const modelFields = {
+              specialTeacherId,
+              cPKTeacherCPKStudentSpecialStudentId: CPKStudent.specialStudentId,
+              CPKClasses,
+              CPKProjects: values,
+            };
+            const result = onChange(modelFields);
+            values = result?.CPKProjects ?? values;
+          }
+          setCPKProjects(values);
+          setCurrentCPKProjectsValue(undefined);
+          setCurrentCPKProjectsDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentCPKProjectsValue}
+        label={\\"Cpk projects\\"}
+        items={CPKProjects}
+        hasError={errors?.CPKProjects?.hasError}
+        errorMessage={errors?.CPKProjects?.errorMessage}
+        getBadgeText={getDisplayValue.CPKProjects}
+        setFieldValue={(model) => {
+          setCurrentCPKProjectsDisplayValue(
+            model ? getDisplayValue.CPKProjects(model) : \\"\\"
+          );
+          setCurrentCPKProjectsValue(model);
+        }}
+        inputFieldRef={CPKProjectsRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Cpk projects\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search CPKProject\\"
+          value={currentCPKProjectsDisplayValue}
+          options={CPKProjectsRecords.filter(
+            (r) => !CPKProjectsIdSet.has(getIDValue.CPKProjects?.(r))
+          ).map((r) => ({
+            id: getIDValue.CPKProjects?.(r),
+            label: getDisplayValue.CPKProjects?.(r),
+          }))}
+          isLoading={CPKProjectsLoading}
+          onSelect={({ id, label }) => {
+            setCurrentCPKProjectsValue(
+              CPKProjectsRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentCPKProjectsDisplayValue(label);
+            runValidationTasks(\\"CPKProjects\\", label);
+          }}
+          onClear={() => {
+            setCurrentCPKProjectsDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchCPKProjectsRecords(value);
+            if (errors.CPKProjects?.hasError) {
+              runValidationTasks(\\"CPKProjects\\", value);
+            }
+            setCurrentCPKProjectsDisplayValue(value);
+            setCurrentCPKProjectsValue(undefined);
+          }}
+          onBlur={() =>
+            runValidationTasks(\\"CPKProjects\\", currentCPKProjectsDisplayValue)
+          }
+          errorMessage={errors.CPKProjects?.errorMessage}
+          hasError={errors.CPKProjects?.hasError}
+          ref={CPKProjectsRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"CPKProjects\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Clear\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          {...getOverrideProps(overrides, \\"ClearButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e?.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate a create form with multiple relationship & cpk 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { CPKClass, CPKProject, CPKStudent } from \\"../API\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type CreateCPKTeacherFormInputValues = {
+    specialTeacherId?: string;
+    CPKStudent?: CPKStudent;
+    CPKClasses?: CPKClass[];
+    CPKProjects?: CPKProject[];
+};
+export declare type CreateCPKTeacherFormValidationValues = {
+    specialTeacherId?: ValidationFunction<string>;
+    CPKStudent?: ValidationFunction<CPKStudent>;
+    CPKClasses?: ValidationFunction<CPKClass>;
+    CPKProjects?: ValidationFunction<CPKProject>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type CreateCPKTeacherFormOverridesProps = {
+    CreateCPKTeacherFormGrid?: PrimitiveOverrideProps<GridProps>;
+    specialTeacherId?: PrimitiveOverrideProps<TextFieldProps>;
+    CPKStudent?: PrimitiveOverrideProps<AutocompleteProps>;
+    CPKClasses?: PrimitiveOverrideProps<AutocompleteProps>;
+    CPKProjects?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type CreateCPKTeacherFormProps = React.PropsWithChildren<{
+    overrides?: CreateCPKTeacherFormOverridesProps | undefined | null;
+} & {
+    clearOnSuccess?: boolean;
+    onSubmit?: (fields: CreateCPKTeacherFormInputValues) => CreateCPKTeacherFormInputValues;
+    onSuccess?: (fields: CreateCPKTeacherFormInputValues) => void;
+    onError?: (fields: CreateCPKTeacherFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: CreateCPKTeacherFormInputValues) => CreateCPKTeacherFormInputValues;
+    onValidate?: CreateCPKTeacherFormValidationValues;
+} & React.CSSProperties>;
+export default function CreateCPKTeacherForm(props: CreateCPKTeacherFormProps): React.ReactElement;
 "
 `;
 
@@ -12455,7 +13291,8 @@ export default function CreateCompositeDogForm(props) {
                   query: updateCompositeToy,
                   variables: {
                     input: {
-                      id: original.id,
+                      kind: original.kind,
+                      color: original.color,
                       compositeDogCompositeToysName: compositeDog.name,
                       compositeDogCompositeToysDescription:
                         compositeDog.description,

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -323,14 +323,16 @@ export default function CreateOwnerForm(props) {
               modelFields[key] = null;
             }
           });
-          const owner = await API.graphql({
-            query: createOwner,
-            variables: {
-              input: {
-                ...modelFields,
+          const owner = (
+            await API.graphql({
+              query: createOwner,
+              variables: {
+                input: {
+                  ...modelFields,
+                },
               },
-            },
-          });
+            })
+          )?.data?.createOwner;
           const promises = [];
           const dogToLink = modelFields.Dog;
           if (dogToLink) {
@@ -1854,6 +1856,661 @@ export default function MyMemberForm(props: MyMemberFormProps): React.ReactEleme
 "
 `;
 
+exports[`amplify form renderer tests GraphQL form tests should generate a create form with composite primary key 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Tag } from \\"../API\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { API } from \\"aws-amplify\\";
+import { listTags } from \\"../graphql/queries\\";
+import { createMovie, createMovieTags } from \\"../graphql/mutations\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button
+            size=\\"small\\"
+            variation=\\"link\\"
+            isDisabled={hasError}
+            onClick={addItem}
+          >
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function MovieCreateForm(props) {
+  const {
+    clearOnSuccess = true,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    movieKey: \\"\\",
+    title: \\"\\",
+    genre: \\"\\",
+    rating: \\"\\",
+    tags: [],
+  };
+  const [movieKey, setMovieKey] = React.useState(initialValues.movieKey);
+  const [title, setTitle] = React.useState(initialValues.title);
+  const [genre, setGenre] = React.useState(initialValues.genre);
+  const [rating, setRating] = React.useState(initialValues.rating);
+  const [tags, setTags] = React.useState(initialValues.tags);
+  const [tagsLoading, setTagsLoading] = React.useState(false);
+  const [tagsRecords, setTagsRecords] = React.useState([]);
+  const autocompleteLength = 10;
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setMovieKey(initialValues.movieKey);
+    setTitle(initialValues.title);
+    setGenre(initialValues.genre);
+    setRating(initialValues.rating);
+    setTags(initialValues.tags);
+    setCurrentTagsValue(undefined);
+    setCurrentTagsDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [currentTagsDisplayValue, setCurrentTagsDisplayValue] =
+    React.useState(\\"\\");
+  const [currentTagsValue, setCurrentTagsValue] = React.useState(undefined);
+  const tagsRef = React.createRef();
+  const getIDValue = {
+    tags: (r) => JSON.stringify({ id: r?.id }),
+  };
+  const tagsIdSet = new Set(
+    Array.isArray(tags)
+      ? tags.map((r) => getIDValue.tags?.(r))
+      : getIDValue.tags?.(tags)
+  );
+  const getDisplayValue = {
+    tags: (r) => \`\${r?.label ? r?.label + \\" - \\" : \\"\\"}\${r?.id}\`,
+  };
+  const validations = {
+    movieKey: [{ type: \\"Required\\" }],
+    title: [{ type: \\"Required\\" }],
+    genre: [{ type: \\"Required\\" }],
+    rating: [],
+    tags: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  const fetchTagsRecords = async (value) => {
+    setTagsLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [{ label: { contains: value } }, { id: { contains: value } }],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listTags,
+          variables,
+        })
+      )?.data?.listTags?.items;
+      var loaded = result.filter(
+        (item) => !tagsIdSet.has(getIDValue.tags?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setTagsRecords(newOptions.slice(0, autocompleteLength));
+    setTagsLoading(false);
+  };
+  React.useEffect(() => {
+    fetchTagsRecords(\\"\\");
+  }, []);
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          movieKey,
+          title,
+          genre,
+          rating,
+          tags,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          const modelFieldsToSave = {
+            movieKey: modelFields.movieKey,
+            title: modelFields.title,
+            genre: modelFields.genre,
+            rating: modelFields.rating,
+          };
+          const movie = (
+            await API.graphql({
+              query: createMovie,
+              variables: {
+                input: {
+                  ...modelFieldsToSave,
+                },
+              },
+            })
+          )?.data?.createMovie;
+          const promises = [];
+          promises.push(
+            ...tags.reduce((promises, tag) => {
+              promises.push(
+                API.graphql({
+                  query: createMovieTags,
+                  variables: {
+                    input: {
+                      movieMovieKey: movie.movieKey,
+                      movietitle: movie.title,
+                      moviegenre: movie.genre,
+                      tagId: Tag.id,
+                    },
+                  },
+                })
+              );
+              return promises;
+            }, [])
+          );
+          await Promise.all(promises);
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+          if (clearOnSuccess) {
+            resetStateValues();
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"MovieCreateForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Movie key\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={movieKey}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              movieKey: value,
+              title,
+              genre,
+              rating,
+              tags,
+            };
+            const result = onChange(modelFields);
+            value = result?.movieKey ?? value;
+          }
+          if (errors.movieKey?.hasError) {
+            runValidationTasks(\\"movieKey\\", value);
+          }
+          setMovieKey(value);
+        }}
+        onBlur={() => runValidationTasks(\\"movieKey\\", movieKey)}
+        errorMessage={errors.movieKey?.errorMessage}
+        hasError={errors.movieKey?.hasError}
+        {...getOverrideProps(overrides, \\"movieKey\\")}
+      ></TextField>
+      <TextField
+        label=\\"Title\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={title}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              movieKey,
+              title: value,
+              genre,
+              rating,
+              tags,
+            };
+            const result = onChange(modelFields);
+            value = result?.title ?? value;
+          }
+          if (errors.title?.hasError) {
+            runValidationTasks(\\"title\\", value);
+          }
+          setTitle(value);
+        }}
+        onBlur={() => runValidationTasks(\\"title\\", title)}
+        errorMessage={errors.title?.errorMessage}
+        hasError={errors.title?.hasError}
+        {...getOverrideProps(overrides, \\"title\\")}
+      ></TextField>
+      <TextField
+        label=\\"Genre\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={genre}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              movieKey,
+              title,
+              genre: value,
+              rating,
+              tags,
+            };
+            const result = onChange(modelFields);
+            value = result?.genre ?? value;
+          }
+          if (errors.genre?.hasError) {
+            runValidationTasks(\\"genre\\", value);
+          }
+          setGenre(value);
+        }}
+        onBlur={() => runValidationTasks(\\"genre\\", genre)}
+        errorMessage={errors.genre?.errorMessage}
+        hasError={errors.genre?.hasError}
+        {...getOverrideProps(overrides, \\"genre\\")}
+      ></TextField>
+      <TextField
+        label=\\"Rating\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={rating}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              movieKey,
+              title,
+              genre,
+              rating: value,
+              tags,
+            };
+            const result = onChange(modelFields);
+            value = result?.rating ?? value;
+          }
+          if (errors.rating?.hasError) {
+            runValidationTasks(\\"rating\\", value);
+          }
+          setRating(value);
+        }}
+        onBlur={() => runValidationTasks(\\"rating\\", rating)}
+        errorMessage={errors.rating?.errorMessage}
+        hasError={errors.rating?.hasError}
+        {...getOverrideProps(overrides, \\"rating\\")}
+      ></TextField>
+      <ArrayField
+        onChange={async (items) => {
+          let values = items;
+          if (onChange) {
+            const modelFields = {
+              movieKey,
+              title,
+              genre,
+              rating,
+              tags: values,
+            };
+            const result = onChange(modelFields);
+            values = result?.tags ?? values;
+          }
+          setTags(values);
+          setCurrentTagsValue(undefined);
+          setCurrentTagsDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentTagsValue}
+        label={\\"Tags\\"}
+        items={tags}
+        hasError={errors?.tags?.hasError}
+        errorMessage={errors?.tags?.errorMessage}
+        getBadgeText={getDisplayValue.tags}
+        setFieldValue={(model) => {
+          setCurrentTagsDisplayValue(model ? getDisplayValue.tags(model) : \\"\\");
+          setCurrentTagsValue(model);
+        }}
+        inputFieldRef={tagsRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Tags\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Tag\\"
+          value={currentTagsDisplayValue}
+          options={tagsRecords.map((r) => ({
+            id: getIDValue.tags?.(r),
+            label: getDisplayValue.tags?.(r),
+          }))}
+          isLoading={tagsLoading}
+          onSelect={({ id, label }) => {
+            setCurrentTagsValue(
+              tagsRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentTagsDisplayValue(label);
+            runValidationTasks(\\"tags\\", label);
+          }}
+          onClear={() => {
+            setCurrentTagsDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchTagsRecords(value);
+            if (errors.tags?.hasError) {
+              runValidationTasks(\\"tags\\", value);
+            }
+            setCurrentTagsDisplayValue(value);
+            setCurrentTagsValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"tags\\", currentTagsDisplayValue)}
+          errorMessage={errors.tags?.errorMessage}
+          hasError={errors.tags?.hasError}
+          ref={tagsRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"tags\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Clear\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          {...getOverrideProps(overrides, \\"ClearButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e?.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate a create form with composite primary key 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Tag } from \\"../API\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type MovieCreateFormInputValues = {
+    movieKey?: string;
+    title?: string;
+    genre?: string;
+    rating?: string;
+    tags?: Tag[];
+};
+export declare type MovieCreateFormValidationValues = {
+    movieKey?: ValidationFunction<string>;
+    title?: ValidationFunction<string>;
+    genre?: ValidationFunction<string>;
+    rating?: ValidationFunction<string>;
+    tags?: ValidationFunction<Tag>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type MovieCreateFormOverridesProps = {
+    MovieCreateFormGrid?: PrimitiveOverrideProps<GridProps>;
+    movieKey?: PrimitiveOverrideProps<TextFieldProps>;
+    title?: PrimitiveOverrideProps<TextFieldProps>;
+    genre?: PrimitiveOverrideProps<TextFieldProps>;
+    rating?: PrimitiveOverrideProps<TextFieldProps>;
+    tags?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type MovieCreateFormProps = React.PropsWithChildren<{
+    overrides?: MovieCreateFormOverridesProps | undefined | null;
+} & {
+    clearOnSuccess?: boolean;
+    onSubmit?: (fields: MovieCreateFormInputValues) => MovieCreateFormInputValues;
+    onSuccess?: (fields: MovieCreateFormInputValues) => void;
+    onError?: (fields: MovieCreateFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: MovieCreateFormInputValues) => MovieCreateFormInputValues;
+    onValidate?: MovieCreateFormValidationValues;
+} & React.CSSProperties>;
+export default function MovieCreateForm(props: MovieCreateFormProps): React.ReactElement;
+"
+`;
+
 exports[`amplify form renderer tests GraphQL form tests should generate a create form with hasMany relationship 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
@@ -1874,7 +2531,7 @@ import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { listStudents } from \\"../graphql/queries\\";
-import { createSchool, updateSchool } from \\"../graphql/mutations\\";
+import { createSchool, updateStudent } from \\"../graphql/mutations\\";
 function ArrayField({
   items = [],
   onChange,
@@ -2180,23 +2837,25 @@ export default function SchoolCreateForm(props) {
           const modelFieldsToSave = {
             name: modelFields.name,
           };
-          const school = await API.graphql({
-            query: createSchool,
-            variables: {
-              input: {
-                ...modelFieldsToSave,
+          const school = (
+            await API.graphql({
+              query: createSchool,
+              variables: {
+                input: {
+                  ...modelFieldsToSave,
+                },
               },
-            },
-          });
+            })
+          )?.data?.createSchool;
           const promises = [];
           promises.push(
             ...Students.reduce((promises, original) => {
               promises.push(
                 API.graphql({
-                  query: updateSchool,
+                  query: updateStudent,
                   variables: {
                     input: {
-                      ...original,
+                      id: original.id,
                       schoolID: school.id,
                     },
                   },
@@ -3284,14 +3943,16 @@ export default function TagCreateForm(props) {
             label: modelFields.label,
             statuses: modelFields.statuses,
           };
-          const tag = await API.graphql({
-            query: createTag,
-            variables: {
-              input: {
-                ...modelFieldsToSave,
+          const tag = (
+            await API.graphql({
+              query: createTag,
+              variables: {
+                input: {
+                  ...modelFieldsToSave,
+                },
               },
-            },
-          });
+            })
+          )?.data?.createTag;
           const promises = [];
           promises.push(
             ...Posts.reduce((promises, post) => {
@@ -4471,7 +5132,7 @@ export default function PostUpdateForm(props) {
             })
           )?.data?.getPost
         : postModelProp;
-      const linkedComments = record?.Comment?.items ?? [];
+      const linkedComments = record?.Comments?.items ?? [];
       setLinkedComments(linkedComments);
       setPostRecord(record);
     };
@@ -8833,7 +9494,7 @@ export default function UpdateCPKTeacherForm(props) {
           )
         : [];
       setLinkedCPKClasses(linkedCPKClasses);
-      const linkedCPKProjects = record?.CPKProject?.items ?? [];
+      const linkedCPKProjects = record?.CPKProjects?.items ?? [];
       setLinkedCPKProjects(linkedCPKProjects);
       setCPKTeacherRecord(record);
     };
@@ -11233,6 +11894,7 @@ import {
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { CompositeVet } from \\"../API\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import {
@@ -11246,6 +11908,7 @@ import {
   createCompositeDogCompositeVet,
   updateCompositeDog,
   updateCompositeOwner,
+  updateCompositeToy,
 } from \\"../graphql/mutations\\";
 function ArrayField({
   items = [],
@@ -11743,14 +12406,16 @@ export default function CreateCompositeDogForm(props) {
             CompositeBowl: modelFields.CompositeBowl,
             CompositeOwner: modelFields.CompositeOwner,
           };
-          const compositeDog = await API.graphql({
-            query: createCompositeDog,
-            variables: {
-              input: {
-                ...modelFieldsToSave,
+          const compositeDog = (
+            await API.graphql({
+              query: createCompositeDog,
+              variables: {
+                input: {
+                  ...modelFieldsToSave,
+                },
               },
-            },
-          });
+            })
+          )?.data?.createCompositeDog;
           const promises = [];
           const compositeOwnerToLink = modelFields.CompositeOwner;
           if (compositeOwnerToLink) {
@@ -11787,10 +12452,10 @@ export default function CreateCompositeDogForm(props) {
             ...CompositeToys.reduce((promises, original) => {
               promises.push(
                 API.graphql({
-                  query: updateCompositeDog,
+                  query: updateCompositeToy,
                   variables: {
                     input: {
-                      ...original,
+                      id: original.id,
                       compositeDogCompositeToysName: compositeDog.name,
                       compositeDogCompositeToysDescription:
                         compositeDog.description,
@@ -11808,8 +12473,10 @@ export default function CreateCompositeDogForm(props) {
                   query: createCompositeDogCompositeVet,
                   variables: {
                     input: {
-                      compositeDog,
-                      compositeVet,
+                      compositeDogName: compositeDog.name,
+                      compositeDogdescription: compositeDog.description,
+                      compositeVetSpecialty: CompositeVet.specialty,
+                      compositeVetcity: CompositeVet.city,
                     },
                   },
                 })
@@ -12336,7 +13003,7 @@ import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { listComments } from \\"../graphql/queries\\";
-import { createPost, updatePost } from \\"../graphql/mutations\\";
+import { createPost, updateComment } from \\"../graphql/mutations\\";
 function ArrayField({
   items = [],
   onChange,
@@ -12643,23 +13310,25 @@ export default function CreatePostForm(props) {
           const modelFieldsToSave = {
             name: modelFields.name,
           };
-          const post = await API.graphql({
-            query: createPost,
-            variables: {
-              input: {
-                ...modelFieldsToSave,
+          const post = (
+            await API.graphql({
+              query: createPost,
+              variables: {
+                input: {
+                  ...modelFieldsToSave,
+                },
               },
-            },
-          });
+            })
+          )?.data?.createPost;
           const promises = [];
           promises.push(
             ...comments.reduce((promises, original) => {
               promises.push(
                 API.graphql({
-                  query: updatePost,
+                  query: updateComment,
                   variables: {
                     input: {
-                      ...original,
+                      id: original.id,
                       postCommentsId: post.id,
                       post: post,
                     },
@@ -13079,7 +13748,7 @@ export default function UpdatePostForm(props) {
             })
           )?.data?.getPost
         : postModelProp;
-      const linkedComments = record?.Comment?.items ?? [];
+      const linkedComments = record?.comments?.items ?? [];
       setLinkedComments(linkedComments);
       setPostRecord(record);
     };
@@ -13779,14 +14448,16 @@ export default function CreateDogForm(props) {
               modelFields[key] = null;
             }
           });
-          const dog = await API.graphql({
-            query: createDog,
-            variables: {
-              input: {
-                ...modelFields,
+          const dog = (
+            await API.graphql({
+              query: createDog,
+              variables: {
+                input: {
+                  ...modelFields,
+                },
               },
-            },
-          });
+            })
+          )?.data?.createDog;
           const promises = [];
           const ownerToLink = modelFields.owner;
           if (ownerToLink) {
@@ -14320,14 +14991,16 @@ export default function CreateOwnerForm(props) {
               modelFields[key] = null;
             }
           });
-          const owner = await API.graphql({
-            query: createOwner,
-            variables: {
-              input: {
-                ...modelFields,
+          const owner = (
+            await API.graphql({
+              query: createOwner,
+              variables: {
+                input: {
+                  ...modelFields,
+                },
               },
-            },
-          });
+            })
+          )?.data?.createOwner;
           const promises = [];
           const dogToLink = modelFields.Dog;
           if (dogToLink) {

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -1098,6 +1098,21 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });
+
+    it('should generate a create form with multiple relationship & cpk', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/cpk-teacher-datastore-create',
+        'datastore/cpk-relationships',
+        { ...defaultCLIRenderConfig, ...rendererConfigWithGraphQL },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      // check for import statement for graphql operation
+      expect(componentText).not.toContain('DataStore');
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
   });
 
   describe('NoApi form tests', () => {

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -1086,6 +1086,18 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });
+
+    it('should generate a create form with composite primary key', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/relationships/create-movie',
+        'models/composite-key-movie',
+        { ...defaultCLIRenderConfig, ...rendererConfigWithGraphQL },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
   });
 
   describe('NoApi form tests', () => {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
@@ -409,7 +409,19 @@ export const buildExpression = (
                 factory.createIdentifier(savedRecordName),
                 undefined,
                 undefined,
-                factory.createAwaitExpression(recordCreateCallExpression),
+                dataApi === 'GraphQL'
+                  ? factory.createPropertyAccessChain(
+                      factory.createPropertyAccessChain(
+                        factory.createParenthesizedExpression(
+                          factory.createAwaitExpression(recordCreateCallExpression),
+                        ),
+                        factory.createToken(SyntaxKind.QuestionDotToken),
+                        factory.createIdentifier('data'),
+                      ),
+                      factory.createToken(SyntaxKind.QuestionDotToken),
+                      factory.createIdentifier(getGraphqlQueryForModel(ActionType.CREATE, importedModelName)),
+                    )
+                  : factory.createAwaitExpression(recordCreateCallExpression),
               ),
             ],
             NodeFlags.Const,

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -265,7 +265,6 @@ export const buildManyToManyRelationshipStatements = (
   const joinTableThisModelName = relatedModelFields[0];
   const joinTableRelatedModelName = relatedJoinFieldName;
   const isGraphql = dataApi === 'GraphQL';
-  const isCompositeKey = thisModelPrimaryKeys.length > 1;
 
   if (!relatedJoinTableName) {
     throw new InternalError(`Cannot find join table for ${fieldName}`);
@@ -1025,7 +1024,7 @@ export const buildManyToManyRelationshipStatements = (
                             ),
                             undefined,
                             [
-                              isGraphql && isCompositeKey
+                              isGraphql
                                 ? getGraphQLJoinTableCreateExpression(
                                     relatedJoinTableName,
                                     savedModelName,
@@ -1781,6 +1780,7 @@ export const buildHasManyRelationshipStatements = (
                                 ),
                             })
                           : getUpdateRelatedModelExpression(
+                              keys,
                               thisModelRecord,
                               relatedModelVariableName,
                               relatedModelFields,
@@ -1859,6 +1859,7 @@ export const buildHasManyRelationshipStatements = (
                               ],
                             })
                           : getUpdateRelatedModelExpression(
+                              keys,
                               thisModelRecord,
                               relatedModelVariableName,
                               relatedModelFields,
@@ -1881,6 +1882,7 @@ export const buildHasManyRelationshipStatements = (
   }
 
   const updateRelatedModelExpression = getUpdateRelatedModelExpression(
+    keys,
     savedModelName,
     relatedModelName,
     relatedModelFields,
@@ -2010,6 +2012,7 @@ export const getRelationshipBasedRecordUpdateStatements = ({
 };
 
 const getUpdateRelatedModelExpression = (
+  primaryKeys: string[],
   savedModelName: string,
   relatedModelName: string,
   relatedModelFields: string[],
@@ -2060,9 +2063,11 @@ const getUpdateRelatedModelExpression = (
      * })
      */
     const inputs = [
-      factory.createPropertyAssignment(
-        factory.createIdentifier('id'),
-        factory.createPropertyAccessExpression(factory.createIdentifier('original'), factory.createIdentifier('id')),
+      ...primaryKeys.map((key) =>
+        factory.createPropertyAssignment(
+          factory.createIdentifier(key),
+          factory.createPropertyAccessExpression(factory.createIdentifier('original'), factory.createIdentifier(key)),
+        ),
       ),
       ...statements,
     ];

--- a/packages/codegen-ui/example-schemas/forms/cpk-teacher-datastore-create.json
+++ b/packages/codegen-ui/example-schemas/forms/cpk-teacher-datastore-create.json
@@ -1,0 +1,12 @@
+{
+    "name": "CreateCPKTeacherForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "CPKTeacher"
+    },
+    "formActionType": "create",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+}

--- a/packages/codegen-ui/example-schemas/forms/relationships/create-movie.json
+++ b/packages/codegen-ui/example-schemas/forms/relationships/create-movie.json
@@ -1,0 +1,12 @@
+{
+    "name": "MovieCreateForm",
+    "formActionType": "create",
+    "fields": {},
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "Movie"
+    },
+    "style": {},
+    "sectionalElements": {},
+    "cta": {}
+  }


### PR DESCRIPTION
## Problem

Creating a record with child throws with the following error: `The variables input contains a field that is not defined for input object type '_____'`

## Solution

Get correct response data from create parent GraphQL statement and change inputs passed to update child GraphQL statement.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
