### PR TITLE
fix: pluralize table name when building join table index query

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -10040,7 +10040,7 @@ import {
   getClass,
   listStudentClasses,
   listStudents,
-  studentClassByClassId,
+  studentClassesByClassId,
 } from \\"../graphql/queries\\";
 import { API } from \\"aws-amplify\\";
 import {
@@ -10251,12 +10251,12 @@ export default function ClassUpdateForm(props) {
       const linkedStudents = record
         ? (
             await API.graphql({
-              query: studentClassByClassId,
+              query: studentClassesByClassId,
               variables: {
                 classId: record.id,
               },
             })
-          ).data.studentClassByClassId.items.map((t) => t.student)
+          ).data.studentClassesByClassId.items.map((t) => t.student)
         : [];
       setLinkedStudents(linkedStudents);
       setClassRecord(record);
@@ -11249,7 +11249,7 @@ import {
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import {
-  cPKTeacherCPKClassByCPKTeacherSpecialTeacherId,
+  cPKTeacherCPKClassesByCPKTeacherSpecialTeacherId,
   getCPKTeacher,
   listCPKClasses,
   listCPKProjects,
@@ -11498,12 +11498,12 @@ export default function UpdateCPKTeacherForm(props) {
       const linkedCPKClasses = record
         ? (
             await API.graphql({
-              query: cPKTeacherCPKClassByCPKTeacherSpecialTeacherId,
+              query: cPKTeacherCPKClassesByCPKTeacherSpecialTeacherId,
               variables: {
                 cPKTeacherSpecialTeacherId: record.specialTeacherId,
               },
             })
-          ).data.cPKTeacherCPKClassByCPKTeacherSpecialTeacherId.items.map(
+          ).data.cPKTeacherCPKClassesByCPKTeacherSpecialTeacherId.items.map(
             (t) => t.cpkClass
           )
         : [];

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -31,6 +31,7 @@ import {
   GenericDataField,
   GenericDataSchema,
 } from '@aws-amplify/codegen-ui';
+import { plural } from 'pluralize';
 import {
   getRecordsName,
   getLinkedDataName,
@@ -1083,7 +1084,7 @@ export const buildGetRelationshipModels = (
         const joinTableThisModelName = fieldConfigMetaData.relationship.relatedModelFields[0];
         const joinTableThisModelFields =
           extractAssociatedFields(joinTableMetadata!.fields[joinTableThisModelName]) || [];
-        const joinTableIndexedQuery = `${lowerCaseFirst(relatedJoinTableName)}By${joinTableThisModelFields
+        const joinTableIndexedQuery = `${plural(lowerCaseFirst(relatedJoinTableName))}By${joinTableThisModelFields
           .map(capitalizeFirstLetter)
           .join('And')}`;
         importCollection.addGraphqlQueryImport(joinTableIndexedQuery);


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->
update forms are generated with import statements for non-existent join table query
## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
pluralize the join table name when building the query name to get the correct import
## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [ ] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
