### PR TITLE
fix: remove belongsto field for update related model expression

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -15348,7 +15348,6 @@ export default function CreatePostForm(props) {
                     input: {
                       id: original.id,
                       postCommentsId: post.id,
-                      post: post,
                     },
                   },
                 })

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -2042,15 +2042,6 @@ const getUpdateRelatedModelExpression = (
       );
     });
 
-    if (belongsToFieldOnRelatedModel) {
-      statements.push(
-        factory.createPropertyAssignment(
-          factory.createIdentifier(belongsToFieldOnRelatedModel),
-          setToNull ? factory.createNull() : factory.createIdentifier(savedModelName),
-        ),
-      );
-    }
-
     /**
      * API.graphql({
      *    query: updateStudent,


### PR DESCRIPTION
## Problem

BelongsTo field does not exist as an input for update related model GraphQL expressions yet we are feeding it as an input.

## Solution

Remove BelongsTo field for related models for create forms with hasMany and BelongsTo relationships.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
