### PR TITLE
fix: store selected relationship data for scalar fields

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1410,6 +1410,7 @@ export default function MyMemberForm(props) {
   const [teamID, setTeamID] = React.useState(initialValues.teamID);
   const [teamIDLoading, setTeamIDLoading] = React.useState(false);
   const [teamIDRecords, setTeamIDRecords] = React.useState([]);
+  const [selectedTeamIDRecords, setSelectedTeamIDRecords] = React.useState([]);
   const [Team, setTeam] = React.useState(initialValues.Team);
   const [TeamLoading, setTeamLoading] = React.useState(false);
   const [TeamRecords, setTeamRecords] = React.useState([]);
@@ -1689,18 +1690,23 @@ export default function MyMemberForm(props) {
         errorMessage={errors?.teamID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.teamID(teamIDRecords.find((r) => r.id === value))
+            ? getDisplayValue.teamID(
+                selectedTeamIDRecords.find((r) => r.id === value) ??
+                  teamIDRecords.find((r) => r.id === value)
+              )
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentTeamIDDisplayValue(
             value
               ? getDisplayValue.teamID(
-                  teamIDRecords.find((r) => r.id === value)
+                  selectedTeamIDRecords.find((r) => r.id === value) ??
+                    teamIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
           setCurrentTeamIDValue(value);
+          setSelectedTeamIDRecords(teamIDRecords.find((r) => r.id === value));
         }}
         inputFieldRef={teamIDRef}
         defaultFieldValue={\\"\\"}
@@ -3814,6 +3820,7 @@ export default function CommentCreateForm(props) {
   const [postID, setPostID] = React.useState(initialValues.postID);
   const [postIDLoading, setPostIDLoading] = React.useState(false);
   const [postIDRecords, setPostIDRecords] = React.useState([]);
+  const [selectedPostIDRecords, setSelectedPostIDRecords] = React.useState([]);
   const autocompleteLength = 10;
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
@@ -3995,18 +4002,23 @@ export default function CommentCreateForm(props) {
         errorMessage={errors?.postID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
+            ? getDisplayValue.postID(
+                selectedPostIDRecords.find((r) => r.id === value) ??
+                  postIDRecords.find((r) => r.id === value)
+              )
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  postIDRecords.find((r) => r.id === value)
+                  selectedPostIDRecords.find((r) => r.id === value) ??
+                    postIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
           setCurrentPostIDValue(value);
+          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -9302,6 +9314,7 @@ export default function CommentUpdateForm(props) {
   const [postID, setPostID] = React.useState(initialValues.postID);
   const [postIDLoading, setPostIDLoading] = React.useState(false);
   const [postIDRecords, setPostIDRecords] = React.useState([]);
+  const [selectedPostIDRecords, setSelectedPostIDRecords] = React.useState([]);
   const [Post, setPost] = React.useState(initialValues.Post);
   const [PostLoading, setPostLoading] = React.useState(false);
   const [PostRecords, setPostRecords] = React.useState([]);
@@ -9343,7 +9356,7 @@ export default function CommentUpdateForm(props) {
           )?.data?.getPost
         : undefined;
       setPostID(postIDRecord);
-      setPostIDRecords([postRecord]);
+      setSelectedPostIDRecords([postRecord]);
       const PostRecord = record ? await record.Post : undefined;
       setPost(PostRecord);
       setCommentRecord(record);
@@ -9585,18 +9598,23 @@ export default function CommentUpdateForm(props) {
         errorMessage={errors?.postID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
+            ? getDisplayValue.postID(
+                selectedPostIDRecords.find((r) => r.id === value) ??
+                  postIDRecords.find((r) => r.id === value)
+              )
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  postIDRecords.find((r) => r.id === value)
+                  selectedPostIDRecords.find((r) => r.id === value) ??
+                    postIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
           setCurrentPostIDValue(value);
+          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -10026,6 +10044,7 @@ export default function CommentUpdateForm(props) {
   const [postID, setPostID] = React.useState(initialValues.postID);
   const [postIDLoading, setPostIDLoading] = React.useState(false);
   const [postIDRecords, setPostIDRecords] = React.useState([]);
+  const [selectedPostIDRecords, setSelectedPostIDRecords] = React.useState([]);
   const [Post, setPost] = React.useState(initialValues.Post);
   const [PostLoading, setPostLoading] = React.useState(false);
   const [PostRecords, setPostRecords] = React.useState([]);
@@ -10067,7 +10086,7 @@ export default function CommentUpdateForm(props) {
           )?.data?.getPost
         : undefined;
       setPostID(postIDRecord);
-      setPostIDRecords([postRecord]);
+      setSelectedPostIDRecords([postRecord]);
       const PostRecord = record ? await record.Post : undefined;
       setPost(PostRecord);
       setCommentRecord(record);
@@ -10309,18 +10328,23 @@ export default function CommentUpdateForm(props) {
         errorMessage={errors?.postID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
+            ? getDisplayValue.postID(
+                selectedPostIDRecords.find((r) => r.id === value) ??
+                  postIDRecords.find((r) => r.id === value)
+              )
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  postIDRecords.find((r) => r.id === value)
+                  selectedPostIDRecords.find((r) => r.id === value) ??
+                    postIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
           setCurrentPostIDValue(value);
+          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -10747,6 +10771,7 @@ export default function CommentUpdateForm(props) {
   const [postID, setPostID] = React.useState(initialValues.postID);
   const [postIDLoading, setPostIDLoading] = React.useState(false);
   const [postIDRecords, setPostIDRecords] = React.useState([]);
+  const [selectedPostIDRecords, setSelectedPostIDRecords] = React.useState([]);
   const autocompleteLength = 10;
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
@@ -10780,7 +10805,7 @@ export default function CommentUpdateForm(props) {
           )?.data?.getPost
         : undefined;
       setPostID(postIDRecord);
-      setPostIDRecords([postRecord]);
+      setSelectedPostIDRecords([postRecord]);
       setCommentRecord(record);
     };
     queryData();
@@ -10956,18 +10981,23 @@ export default function CommentUpdateForm(props) {
         errorMessage={errors?.postID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
+            ? getDisplayValue.postID(
+                selectedPostIDRecords.find((r) => r.id === value) ??
+                  postIDRecords.find((r) => r.id === value)
+              )
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  postIDRecords.find((r) => r.id === value)
+                  selectedPostIDRecords.find((r) => r.id === value) ??
+                    postIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
           setCurrentPostIDValue(value);
+          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -13520,6 +13550,10 @@ export default function CreateCompositeToyForm(props) {
     setCompositeDogCompositeToysNameRecords,
   ] = React.useState([]);
   const [
+    selectedCompositeDogCompositeToysNameRecords,
+    setSelectedCompositeDogCompositeToysNameRecords,
+  ] = React.useState([]);
+  const [
     compositeDogCompositeToysDescription,
     setCompositeDogCompositeToysDescription,
   ] = React.useState(initialValues.compositeDogCompositeToysDescription);
@@ -13530,6 +13564,10 @@ export default function CreateCompositeToyForm(props) {
   const [
     compositeDogCompositeToysDescriptionRecords,
     setCompositeDogCompositeToysDescriptionRecords,
+  ] = React.useState([]);
+  const [
+    selectedCompositeDogCompositeToysDescriptionRecords,
+    setSelectedCompositeDogCompositeToysDescriptionRecords,
   ] = React.useState([]);
   const autocompleteLength = 10;
   const [errors, setErrors] = React.useState({});
@@ -13808,9 +13846,12 @@ export default function CreateCompositeToyForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.compositeDogCompositeToysName(
-                compositeDogCompositeToysNameRecords.find(
-                  (r) => r.name === value
-                )
+                selectedCompositeDogCompositeToysNameRecords.find(
+                  (r) => r.id === value
+                ) ??
+                  compositeDogCompositeToysNameRecords.find(
+                    (r) => r.name === value
+                  )
               )
             : \\"\\"
         }
@@ -13818,13 +13859,19 @@ export default function CreateCompositeToyForm(props) {
           setCurrentCompositeDogCompositeToysNameDisplayValue(
             value
               ? getDisplayValue.compositeDogCompositeToysName(
-                  compositeDogCompositeToysNameRecords.find(
-                    (r) => r.name === value
-                  )
+                  selectedCompositeDogCompositeToysNameRecords.find(
+                    (r) => r.id === value
+                  ) ??
+                    compositeDogCompositeToysNameRecords.find(
+                      (r) => r.name === value
+                    )
                 )
               : \\"\\"
           );
           setCurrentCompositeDogCompositeToysNameValue(value);
+          setSelectedCompositeDogCompositeToysNameRecords(
+            compositeDogCompositeToysNameRecords.find((r) => r.name === value)
+          );
         }}
         inputFieldRef={compositeDogCompositeToysNameRef}
         defaultFieldValue={\\"\\"}
@@ -13912,9 +13959,12 @@ export default function CreateCompositeToyForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.compositeDogCompositeToysDescription(
-                compositeDogCompositeToysDescriptionRecords.find(
-                  (r) => r.description === value
-                )
+                selectedCompositeDogCompositeToysDescriptionRecords.find(
+                  (r) => r.id === value
+                ) ??
+                  compositeDogCompositeToysDescriptionRecords.find(
+                    (r) => r.description === value
+                  )
               )
             : \\"\\"
         }
@@ -13922,13 +13972,21 @@ export default function CreateCompositeToyForm(props) {
           setCurrentCompositeDogCompositeToysDescriptionDisplayValue(
             value
               ? getDisplayValue.compositeDogCompositeToysDescription(
-                  compositeDogCompositeToysDescriptionRecords.find(
-                    (r) => r.description === value
-                  )
+                  selectedCompositeDogCompositeToysDescriptionRecords.find(
+                    (r) => r.id === value
+                  ) ??
+                    compositeDogCompositeToysDescriptionRecords.find(
+                      (r) => r.description === value
+                    )
                 )
               : \\"\\"
           );
           setCurrentCompositeDogCompositeToysDescriptionValue(value);
+          setSelectedCompositeDogCompositeToysDescriptionRecords(
+            compositeDogCompositeToysDescriptionRecords.find(
+              (r) => r.description === value
+            )
+          );
         }}
         inputFieldRef={compositeDogCompositeToysDescriptionRef}
         defaultFieldValue={\\"\\"}
@@ -14271,6 +14329,8 @@ export default function CreateCommentForm(props) {
   const [postCommentsIdLoading, setPostCommentsIdLoading] =
     React.useState(false);
   const [postCommentsIdRecords, setPostCommentsIdRecords] = React.useState([]);
+  const [selectedPostCommentsIdRecords, setSelectedPostCommentsIdRecords] =
+    React.useState([]);
   const autocompleteLength = 10;
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
@@ -14854,7 +14914,8 @@ export default function CreateCommentForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postCommentsId(
-                postCommentsIdRecords.find((r) => r.id === value)
+                selectedPostCommentsIdRecords.find((r) => r.id === value) ??
+                  postCommentsIdRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -14862,11 +14923,15 @@ export default function CreateCommentForm(props) {
           setCurrentPostCommentsIdDisplayValue(
             value
               ? getDisplayValue.postCommentsId(
-                  postCommentsIdRecords.find((r) => r.id === value)
+                  selectedPostCommentsIdRecords.find((r) => r.id === value) ??
+                    postCommentsIdRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
           setCurrentPostCommentsIdValue(value);
+          setSelectedPostCommentsIdRecords(
+            postCommentsIdRecords.find((r) => r.id === value)
+          );
         }}
         inputFieldRef={postCommentsIdRef}
         defaultFieldValue={\\"\\"}
@@ -17241,6 +17306,1359 @@ export default function UpdatePostForm(props: UpdatePostFormProps): React.ReactE
 "
 `;
 
+exports[`amplify form renderer tests GraphQL form tests should render an update form with child field 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { API } from \\"aws-amplify\\";
+import {
+  getChildItem,
+  getCustomKeyModel,
+  listCustomKeyModels,
+} from \\"../graphql/queries\\";
+import { updateChildItem } from \\"../graphql/mutations\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  runValidationTasks,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    const { hasError } = runValidationTasks();
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button size=\\"small\\" variation=\\"link\\" onClick={addItem}>
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function ChildItemUpdateForm(props) {
+  const {
+    id: idProp,
+    childItem: childItemModelProp,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    content: \\"\\",
+    customKeyModelChildrenMycustomkey: undefined,
+  };
+  const [content, setContent] = React.useState(initialValues.content);
+  const [
+    customKeyModelChildrenMycustomkey,
+    setCustomKeyModelChildrenMycustomkey,
+  ] = React.useState(initialValues.customKeyModelChildrenMycustomkey);
+  const [
+    customKeyModelChildrenMycustomkeyLoading,
+    setCustomKeyModelChildrenMycustomkeyLoading,
+  ] = React.useState(false);
+  const [
+    customKeyModelChildrenMycustomkeyRecords,
+    setCustomKeyModelChildrenMycustomkeyRecords,
+  ] = React.useState([]);
+  const [
+    selectedCustomKeyModelChildrenMycustomkeyRecords,
+    setSelectedCustomKeyModelChildrenMycustomkeyRecords,
+  ] = React.useState([]);
+  const autocompleteLength = 10;
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    const cleanValues = childItemRecord
+      ? {
+          ...initialValues,
+          ...childItemRecord,
+          customKeyModelChildrenMycustomkey,
+        }
+      : initialValues;
+    setContent(cleanValues.content);
+    setCustomKeyModelChildrenMycustomkey(
+      cleanValues.customKeyModelChildrenMycustomkey
+    );
+    setCurrentCustomKeyModelChildrenMycustomkeyValue(undefined);
+    setCurrentCustomKeyModelChildrenMycustomkeyDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [childItemRecord, setChildItemRecord] =
+    React.useState(childItemModelProp);
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = idProp
+        ? (
+            await API.graphql({
+              query: getChildItem,
+              variables: { id: idProp },
+            })
+          )?.data?.getChildItem
+        : childItemModelProp;
+      const customKeyModelChildrenMycustomkeyRecord = record
+        ? record.customKeyModelChildrenMycustomkey
+        : undefined;
+      const customKeyModelRecord = customKeyModelChildrenMycustomkeyRecord
+        ? (
+            await API.graphql({
+              query: getCustomKeyModel,
+              variables: { id: customKeyModelChildrenMycustomkeyRecord },
+            })
+          )?.data?.getCustomKeyModel
+        : undefined;
+      setCustomKeyModelChildrenMycustomkey(
+        customKeyModelChildrenMycustomkeyRecord
+      );
+      setSelectedCustomKeyModelChildrenMycustomkeyRecords([
+        customKeyModelRecord,
+      ]);
+      setChildItemRecord(record);
+    };
+    queryData();
+  }, [idProp, childItemModelProp]);
+  React.useEffect(resetStateValues, [
+    childItemRecord,
+    customKeyModelChildrenMycustomkey,
+  ]);
+  const [
+    currentCustomKeyModelChildrenMycustomkeyDisplayValue,
+    setCurrentCustomKeyModelChildrenMycustomkeyDisplayValue,
+  ] = React.useState(\\"\\");
+  const [
+    currentCustomKeyModelChildrenMycustomkeyValue,
+    setCurrentCustomKeyModelChildrenMycustomkeyValue,
+  ] = React.useState(undefined);
+  const customKeyModelChildrenMycustomkeyRef = React.createRef();
+  const getDisplayValue = {
+    customKeyModelChildrenMycustomkey: (r) =>
+      \`\${r?.content ? r?.content + \\" - \\" : \\"\\"}\${r?.mycustomkey}\`,
+  };
+  const validations = {
+    content: [{ type: \\"Required\\" }],
+    customKeyModelChildrenMycustomkey: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  const fetchCustomKeyModelChildrenMycustomkeyRecords = async (value) => {
+    setCustomKeyModelChildrenMycustomkeyLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [
+            { content: { contains: value } },
+            { mycustomkey: { contains: value } },
+          ],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listCustomKeyModels,
+          variables,
+        })
+      )?.data?.listCustomKeyModels?.items;
+      var loaded = result.filter(
+        (item) => customKeyModelChildrenMycustomkey !== item.id
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setCustomKeyModelChildrenMycustomkeyRecords(
+      newOptions.slice(0, autocompleteLength)
+    );
+    setCustomKeyModelChildrenMycustomkeyLoading(false);
+  };
+  React.useEffect(() => {
+    fetchCustomKeyModelChildrenMycustomkeyRecords(\\"\\");
+  }, []);
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          content,
+          customKeyModelChildrenMycustomkey,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(fieldName, item)
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(fieldName, modelFields[fieldName])
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          await API.graphql({
+            query: updateChildItem,
+            variables: {
+              input: {
+                id: childItemRecord.id,
+                ...modelFields,
+              },
+            },
+          });
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"ChildItemUpdateForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Content\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={content}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              content: value,
+              customKeyModelChildrenMycustomkey,
+            };
+            const result = onChange(modelFields);
+            value = result?.content ?? value;
+          }
+          if (errors.content?.hasError) {
+            runValidationTasks(\\"content\\", value);
+          }
+          setContent(value);
+        }}
+        onBlur={() => runValidationTasks(\\"content\\", content)}
+        errorMessage={errors.content?.errorMessage}
+        hasError={errors.content?.hasError}
+        {...getOverrideProps(overrides, \\"content\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              content,
+              customKeyModelChildrenMycustomkey: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.customKeyModelChildrenMycustomkey ?? value;
+          }
+          setCustomKeyModelChildrenMycustomkey(value);
+          setCurrentCustomKeyModelChildrenMycustomkeyValue(undefined);
+        }}
+        currentFieldValue={currentCustomKeyModelChildrenMycustomkeyValue}
+        label={\\"Custom key model children mycustomkey\\"}
+        items={
+          customKeyModelChildrenMycustomkey
+            ? [customKeyModelChildrenMycustomkey]
+            : []
+        }
+        hasError={errors?.customKeyModelChildrenMycustomkey?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(
+            \\"customKeyModelChildrenMycustomkey\\",
+            currentCustomKeyModelChildrenMycustomkeyValue
+          )
+        }
+        errorMessage={errors?.customKeyModelChildrenMycustomkey?.errorMessage}
+        getBadgeText={(value) =>
+          value
+            ? getDisplayValue.customKeyModelChildrenMycustomkey(
+                selectedCustomKeyModelChildrenMycustomkeyRecords.find(
+                  (r) => r.id === value
+                ) ??
+                  customKeyModelChildrenMycustomkeyRecords.find(
+                    (r) => r.mycustomkey === value
+                  )
+              )
+            : \\"\\"
+        }
+        setFieldValue={(value) => {
+          setCurrentCustomKeyModelChildrenMycustomkeyDisplayValue(
+            value
+              ? getDisplayValue.customKeyModelChildrenMycustomkey(
+                  selectedCustomKeyModelChildrenMycustomkeyRecords.find(
+                    (r) => r.id === value
+                  ) ??
+                    customKeyModelChildrenMycustomkeyRecords.find(
+                      (r) => r.mycustomkey === value
+                    )
+                )
+              : \\"\\"
+          );
+          setCurrentCustomKeyModelChildrenMycustomkeyValue(value);
+          setSelectedCustomKeyModelChildrenMycustomkeyRecords(
+            customKeyModelChildrenMycustomkeyRecords.find(
+              (r) => r.mycustomkey === value
+            )
+          );
+        }}
+        inputFieldRef={customKeyModelChildrenMycustomkeyRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Custom key model children mycustomkey\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search CustomKeyModel\\"
+          value={currentCustomKeyModelChildrenMycustomkeyDisplayValue}
+          options={customKeyModelChildrenMycustomkeyRecords
+            .filter(
+              (r, i, arr) =>
+                arr.findIndex(
+                  (member) => member?.mycustomkey === r?.mycustomkey
+                ) === i
+            )
+            .map((r) => ({
+              id: r?.mycustomkey,
+              label: getDisplayValue.customKeyModelChildrenMycustomkey?.(r),
+            }))}
+          isLoading={customKeyModelChildrenMycustomkeyLoading}
+          onSelect={({ id, label }) => {
+            setCurrentCustomKeyModelChildrenMycustomkeyValue(id);
+            setCurrentCustomKeyModelChildrenMycustomkeyDisplayValue(label);
+            runValidationTasks(\\"customKeyModelChildrenMycustomkey\\", label);
+          }}
+          onClear={() => {
+            setCurrentCustomKeyModelChildrenMycustomkeyDisplayValue(\\"\\");
+          }}
+          defaultValue={customKeyModelChildrenMycustomkey}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchCustomKeyModelChildrenMycustomkeyRecords(value);
+            if (errors.customKeyModelChildrenMycustomkey?.hasError) {
+              runValidationTasks(\\"customKeyModelChildrenMycustomkey\\", value);
+            }
+            setCurrentCustomKeyModelChildrenMycustomkeyDisplayValue(value);
+            setCurrentCustomKeyModelChildrenMycustomkeyValue(undefined);
+          }}
+          onBlur={() =>
+            runValidationTasks(
+              \\"customKeyModelChildrenMycustomkey\\",
+              currentCustomKeyModelChildrenMycustomkeyValue
+            )
+          }
+          errorMessage={errors.customKeyModelChildrenMycustomkey?.errorMessage}
+          hasError={errors.customKeyModelChildrenMycustomkey?.hasError}
+          ref={customKeyModelChildrenMycustomkeyRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"customKeyModelChildrenMycustomkey\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          isDisabled={!(idProp || childItemModelProp)}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={
+              !(idProp || childItemModelProp) ||
+              Object.values(errors).some((e) => e?.hasError)
+            }
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should render an update form with child field 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { ChildItem } from \\"../API\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type ChildItemUpdateFormInputValues = {
+    content?: string;
+    customKeyModelChildrenMycustomkey?: string;
+};
+export declare type ChildItemUpdateFormValidationValues = {
+    content?: ValidationFunction<string>;
+    customKeyModelChildrenMycustomkey?: ValidationFunction<string>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type ChildItemUpdateFormOverridesProps = {
+    ChildItemUpdateFormGrid?: PrimitiveOverrideProps<GridProps>;
+    content?: PrimitiveOverrideProps<TextFieldProps>;
+    customKeyModelChildrenMycustomkey?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type ChildItemUpdateFormProps = React.PropsWithChildren<{
+    overrides?: ChildItemUpdateFormOverridesProps | undefined | null;
+} & {
+    id?: string;
+    childItem?: ChildItem;
+    onSubmit?: (fields: ChildItemUpdateFormInputValues) => ChildItemUpdateFormInputValues;
+    onSuccess?: (fields: ChildItemUpdateFormInputValues) => void;
+    onError?: (fields: ChildItemUpdateFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: ChildItemUpdateFormInputValues) => ChildItemUpdateFormInputValues;
+    onValidate?: ChildItemUpdateFormValidationValues;
+} & React.CSSProperties>;
+export default function ChildItemUpdateForm(props: ChildItemUpdateFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should render an update form with id field instead of belongsTo 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { API } from \\"aws-amplify\\";
+import { getPost, listBlogs, listComments } from \\"../graphql/queries\\";
+import { updateComment, updatePost } from \\"../graphql/mutations\\";
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  runValidationTasks,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    const { hasError } = runValidationTasks();
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button size=\\"small\\" variation=\\"link\\" onClick={addItem}>
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function PostUpdateForm(props) {
+  const {
+    id: idProp,
+    post: postModelProp,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    title: \\"\\",
+    blog: undefined,
+    comments: [],
+  };
+  const [title, setTitle] = React.useState(initialValues.title);
+  const [blog, setBlog] = React.useState(initialValues.blog);
+  const [blogLoading, setBlogLoading] = React.useState(false);
+  const [blogRecords, setBlogRecords] = React.useState([]);
+  const [comments, setComments] = React.useState(initialValues.comments);
+  const [commentsLoading, setCommentsLoading] = React.useState(false);
+  const [commentsRecords, setCommentsRecords] = React.useState([]);
+  const autocompleteLength = 10;
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    const cleanValues = postRecord
+      ? { ...initialValues, ...postRecord, blog, comments: linkedComments }
+      : initialValues;
+    setTitle(cleanValues.title);
+    setBlog(cleanValues.blog);
+    setCurrentBlogValue(undefined);
+    setCurrentBlogDisplayValue(\\"\\");
+    setComments(cleanValues.comments ?? []);
+    setCurrentCommentsValue(undefined);
+    setCurrentCommentsDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [postRecord, setPostRecord] = React.useState(postModelProp);
+  const [linkedComments, setLinkedComments] = React.useState([]);
+  const canUnlinkComments = true;
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = idProp
+        ? (
+            await API.graphql({
+              query: getPost,
+              variables: { id: idProp },
+            })
+          )?.data?.getPost
+        : postModelProp;
+      const blogRecord = record ? await record.blog : undefined;
+      setBlog(blogRecord);
+      const linkedComments = record?.comments?.items ?? [];
+      setLinkedComments(linkedComments);
+      setPostRecord(record);
+    };
+    queryData();
+  }, [idProp, postModelProp]);
+  React.useEffect(resetStateValues, [postRecord, blog, linkedComments]);
+  const [currentBlogDisplayValue, setCurrentBlogDisplayValue] =
+    React.useState(\\"\\");
+  const [currentBlogValue, setCurrentBlogValue] = React.useState(undefined);
+  const blogRef = React.createRef();
+  const [currentCommentsDisplayValue, setCurrentCommentsDisplayValue] =
+    React.useState(\\"\\");
+  const [currentCommentsValue, setCurrentCommentsValue] =
+    React.useState(undefined);
+  const commentsRef = React.createRef();
+  const getIDValue = {
+    blog: (r) => JSON.stringify({ id: r?.id }),
+    comments: (r) => JSON.stringify({ id: r?.id }),
+  };
+  const blogIdSet = new Set(
+    Array.isArray(blog)
+      ? blog.map((r) => getIDValue.blog?.(r))
+      : getIDValue.blog?.(blog)
+  );
+  const commentsIdSet = new Set(
+    Array.isArray(comments)
+      ? comments.map((r) => getIDValue.comments?.(r))
+      : getIDValue.comments?.(comments)
+  );
+  const getDisplayValue = {
+    blog: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+    comments: (r) => \`\${r?.content ? r?.content + \\" - \\" : \\"\\"}\${r?.id}\`,
+  };
+  const validations = {
+    title: [{ type: \\"Required\\" }],
+    blog: [],
+    comments: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  const fetchBlogRecords = async (value) => {
+    setBlogLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [{ name: { contains: value } }, { id: { contains: value } }],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listBlogs,
+          variables,
+        })
+      )?.data?.listBlogs?.items;
+      var loaded = result.filter(
+        (item) => !blogIdSet.has(getIDValue.blog?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setBlogRecords(newOptions.slice(0, autocompleteLength));
+    setBlogLoading(false);
+  };
+  const fetchCommentsRecords = async (value) => {
+    setCommentsLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [{ content: { contains: value } }, { id: { contains: value } }],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await API.graphql({
+          query: listComments,
+          variables,
+        })
+      )?.data?.listComments?.items;
+      var loaded = result.filter(
+        (item) => !commentsIdSet.has(getIDValue.comments?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setCommentsRecords(newOptions.slice(0, autocompleteLength));
+    setCommentsLoading(false);
+  };
+  React.useEffect(() => {
+    fetchBlogRecords(\\"\\");
+    fetchCommentsRecords(\\"\\");
+  }, []);
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          title,
+          blog,
+          comments,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          const promises = [];
+          const commentsToLink = [];
+          const commentsToUnLink = [];
+          const commentsSet = new Set();
+          const linkedCommentsSet = new Set();
+          comments.forEach((r) => commentsSet.add(getIDValue.comments?.(r)));
+          linkedComments.forEach((r) =>
+            linkedCommentsSet.add(getIDValue.comments?.(r))
+          );
+          linkedComments.forEach((r) => {
+            if (!commentsSet.has(getIDValue.comments?.(r))) {
+              commentsToUnLink.push(r);
+            }
+          });
+          comments.forEach((r) => {
+            if (!linkedCommentsSet.has(getIDValue.comments?.(r))) {
+              commentsToLink.push(r);
+            }
+          });
+          commentsToUnLink.forEach((original) => {
+            if (!canUnlinkComments) {
+              throw Error(
+                \`Comment \${original.id} cannot be unlinked from Post because postID is a required field.\`
+              );
+            }
+            promises.push(
+              API.graphql({
+                query: updateComment,
+                variables: {
+                  input: {
+                    id: original.id,
+                    postID: null,
+                  },
+                },
+              })
+            );
+          });
+          commentsToLink.forEach((original) => {
+            promises.push(
+              API.graphql({
+                query: updateComment,
+                variables: {
+                  input: {
+                    id: original.id,
+                    postID: postRecord.id,
+                  },
+                },
+              })
+            );
+          });
+          const modelFieldsToSave = {
+            title: modelFields.title,
+            blogPostsId: modelFields?.blog?.id,
+          };
+          promises.push(
+            API.graphql({
+              query: updatePost,
+              variables: {
+                input: {
+                  id: postRecord.id,
+                  ...modelFieldsToSave,
+                },
+              },
+            })
+          );
+          await Promise.all(promises);
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"PostUpdateForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Title\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={title}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              title: value,
+              blog,
+              comments,
+            };
+            const result = onChange(modelFields);
+            value = result?.title ?? value;
+          }
+          if (errors.title?.hasError) {
+            runValidationTasks(\\"title\\", value);
+          }
+          setTitle(value);
+        }}
+        onBlur={() => runValidationTasks(\\"title\\", title)}
+        errorMessage={errors.title?.errorMessage}
+        hasError={errors.title?.hasError}
+        {...getOverrideProps(overrides, \\"title\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              title,
+              blog: value,
+              comments,
+            };
+            const result = onChange(modelFields);
+            value = result?.blog ?? value;
+          }
+          setBlog(value);
+          setCurrentBlogValue(undefined);
+          setCurrentBlogDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentBlogValue}
+        label={\\"Blog\\"}
+        items={blog ? [blog] : []}
+        hasError={errors?.blog?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(\\"blog\\", currentBlogValue)
+        }
+        errorMessage={errors?.blog?.errorMessage}
+        getBadgeText={getDisplayValue.blog}
+        setFieldValue={(model) => {
+          setCurrentBlogDisplayValue(model ? getDisplayValue.blog(model) : \\"\\");
+          setCurrentBlogValue(model);
+        }}
+        inputFieldRef={blogRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Blog\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Blog\\"
+          value={currentBlogDisplayValue}
+          options={blogRecords
+            .filter((r) => !blogIdSet.has(getIDValue.blog?.(r)))
+            .map((r) => ({
+              id: getIDValue.blog?.(r),
+              label: getDisplayValue.blog?.(r),
+            }))}
+          isLoading={blogLoading}
+          onSelect={({ id, label }) => {
+            setCurrentBlogValue(
+              blogRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentBlogDisplayValue(label);
+            runValidationTasks(\\"blog\\", label);
+          }}
+          onClear={() => {
+            setCurrentBlogDisplayValue(\\"\\");
+          }}
+          defaultValue={blog}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchBlogRecords(value);
+            if (errors.blog?.hasError) {
+              runValidationTasks(\\"blog\\", value);
+            }
+            setCurrentBlogDisplayValue(value);
+            setCurrentBlogValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"blog\\", currentBlogDisplayValue)}
+          errorMessage={errors.blog?.errorMessage}
+          hasError={errors.blog?.hasError}
+          ref={blogRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"blog\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        onChange={async (items) => {
+          let values = items;
+          if (onChange) {
+            const modelFields = {
+              title,
+              blog,
+              comments: values,
+            };
+            const result = onChange(modelFields);
+            values = result?.comments ?? values;
+          }
+          setComments(values);
+          setCurrentCommentsValue(undefined);
+          setCurrentCommentsDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentCommentsValue}
+        label={\\"Comments\\"}
+        items={comments}
+        hasError={errors?.comments?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(\\"comments\\", currentCommentsValue)
+        }
+        errorMessage={errors?.comments?.errorMessage}
+        getBadgeText={getDisplayValue.comments}
+        setFieldValue={(model) => {
+          setCurrentCommentsDisplayValue(
+            model ? getDisplayValue.comments(model) : \\"\\"
+          );
+          setCurrentCommentsValue(model);
+        }}
+        inputFieldRef={commentsRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Comments\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Comment\\"
+          value={currentCommentsDisplayValue}
+          options={commentsRecords
+            .filter((r) => !commentsIdSet.has(getIDValue.comments?.(r)))
+            .map((r) => ({
+              id: getIDValue.comments?.(r),
+              label: getDisplayValue.comments?.(r),
+            }))}
+          isLoading={commentsLoading}
+          onSelect={({ id, label }) => {
+            setCurrentCommentsValue(
+              commentsRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentCommentsDisplayValue(label);
+            runValidationTasks(\\"comments\\", label);
+          }}
+          onClear={() => {
+            setCurrentCommentsDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchCommentsRecords(value);
+            if (errors.comments?.hasError) {
+              runValidationTasks(\\"comments\\", value);
+            }
+            setCurrentCommentsDisplayValue(value);
+            setCurrentCommentsValue(undefined);
+          }}
+          onBlur={() =>
+            runValidationTasks(\\"comments\\", currentCommentsDisplayValue)
+          }
+          errorMessage={errors.comments?.errorMessage}
+          hasError={errors.comments?.hasError}
+          ref={commentsRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"comments\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          isDisabled={!(idProp || postModelProp)}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={
+              !(idProp || postModelProp) ||
+              Object.values(errors).some((e) => e?.hasError)
+            }
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should render an update form with id field instead of belongsTo 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Blog, Comment, Post } from \\"../API\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type PostUpdateFormInputValues = {
+    title?: string;
+    blog?: Blog;
+    comments?: Comment[];
+};
+export declare type PostUpdateFormValidationValues = {
+    title?: ValidationFunction<string>;
+    blog?: ValidationFunction<Blog>;
+    comments?: ValidationFunction<Comment>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type PostUpdateFormOverridesProps = {
+    PostUpdateFormGrid?: PrimitiveOverrideProps<GridProps>;
+    title?: PrimitiveOverrideProps<TextFieldProps>;
+    blog?: PrimitiveOverrideProps<AutocompleteProps>;
+    comments?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type PostUpdateFormProps = React.PropsWithChildren<{
+    overrides?: PostUpdateFormOverridesProps | undefined | null;
+} & {
+    id?: string;
+    post?: Post;
+    onSubmit?: (fields: PostUpdateFormInputValues) => PostUpdateFormInputValues;
+    onSuccess?: (fields: PostUpdateFormInputValues) => void;
+    onError?: (fields: PostUpdateFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: PostUpdateFormInputValues) => PostUpdateFormInputValues;
+    onValidate?: PostUpdateFormValidationValues;
+} & React.CSSProperties>;
+export default function PostUpdateForm(props: PostUpdateFormProps): React.ReactElement;
+"
+`;
+
 exports[`amplify form renderer tests GraphQL form tests should render thrown error for required parent field 1:1 relationships - Create 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
@@ -18537,6 +19955,7 @@ export default function CommentUpdateForm(props) {
   const [postID, setPostID] = React.useState(initialValues.postID);
   const [postIDLoading, setPostIDLoading] = React.useState(false);
   const [postIDRecords, setPostIDRecords] = React.useState([]);
+  const [selectedPostIDRecords, setSelectedPostIDRecords] = React.useState([]);
   const autocompleteLength = 10;
   const [errors, setErrors] = React.useState({});
   const resetStateValues = () => {
@@ -18570,7 +19989,7 @@ export default function CommentUpdateForm(props) {
           )?.data?.getPost
         : undefined;
       setPostID(postIDRecord);
-      setPostIDRecords([postRecord]);
+      setSelectedPostIDRecords([postRecord]);
       setCommentRecord(record);
     };
     queryData();
@@ -18746,18 +20165,23 @@ export default function CommentUpdateForm(props) {
         errorMessage={errors?.postID?.errorMessage}
         getBadgeText={(value) =>
           value
-            ? getDisplayValue.postID(postIDRecords.find((r) => r.id === value))
+            ? getDisplayValue.postID(
+                selectedPostIDRecords.find((r) => r.id === value) ??
+                  postIDRecords.find((r) => r.id === value)
+              )
             : \\"\\"
         }
         setFieldValue={(value) => {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  postIDRecords.find((r) => r.id === value)
+                  selectedPostIDRecords.find((r) => r.id === value) ??
+                    postIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
           setCurrentPostIDValue(value);
+          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -1184,6 +1184,30 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });
+
+    it('should render an update form with child field', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'models/custom-key-model/forms/ChildItemUpdateForm',
+        'models/custom-key-model/schema',
+        { ...defaultCLIRenderConfig, ...rendererConfigWithGraphQL },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
+
+    it('should render an update form with id field instead of belongsTo', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'models/comment-with-postID/forms/PostUpdateForm',
+        'models/comment-with-postID/schema',
+        { ...defaultCLIRenderConfig, ...rendererConfigWithGraphQL },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
   });
 
   describe('NoApi form tests', () => {

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
@@ -46,6 +46,7 @@ import { buildAccessChain, getRecordsName } from './form-state';
 import { getElementAccessExpression, getValidProperty } from './invalid-variable-helpers';
 import { isEnumDataType, isModelDataType } from './render-checkers';
 import { DataApiKind } from '../../react-render-config';
+import { capitalizeFirstLetter } from '../../helpers';
 
 export const getDisplayValueObjectName = 'getDisplayValue';
 
@@ -74,7 +75,7 @@ const getDisplayValueCallChain = ({ fieldName, recordString }: { fieldName: stri
     compositeDogRecords.find((r) => r.description === value)
   )
  */
-export function getDisplayValueScalar(fieldName: string, model: string, key: string) {
+export function getDisplayValueScalar(fieldName: string, model: string, key: string, dataApi?: DataApiKind) {
   const recordString = 'r';
 
   return factory.createConditionalExpression(
@@ -87,39 +88,110 @@ export function getDisplayValueScalar(fieldName: string, model: string, key: str
       ),
       undefined,
       [
-        factory.createCallExpression(
-          factory.createPropertyAccessExpression(
-            factory.createIdentifier(getRecordsName(model)),
-            factory.createIdentifier('find'),
-          ),
-          undefined,
-          [
-            factory.createArrowFunction(
-              undefined,
+        dataApi === 'GraphQL'
+          ? factory.createBinaryExpression(
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier(`selected${capitalizeFirstLetter(fieldName)}Records`),
+                  factory.createIdentifier('find'),
+                ),
+                undefined,
+                [
+                  factory.createArrowFunction(
+                    undefined,
+                    undefined,
+                    [
+                      factory.createParameterDeclaration(
+                        undefined,
+                        undefined,
+                        undefined,
+                        factory.createIdentifier(recordString),
+                        undefined,
+                        undefined,
+                        undefined,
+                      ),
+                    ],
+                    undefined,
+                    factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                    factory.createBinaryExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier(recordString),
+                        factory.createIdentifier('id'),
+                      ),
+                      factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                      factory.createIdentifier('value'),
+                    ),
+                  ),
+                ],
+              ),
+              factory.createToken(SyntaxKind.QuestionQuestionToken),
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier(getRecordsName(model)),
+                  factory.createIdentifier('find'),
+                ),
+                undefined,
+                [
+                  factory.createArrowFunction(
+                    undefined,
+                    undefined,
+                    [
+                      factory.createParameterDeclaration(
+                        undefined,
+                        undefined,
+                        undefined,
+                        factory.createIdentifier(recordString),
+                        undefined,
+                        undefined,
+                      ),
+                    ],
+                    undefined,
+                    factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                    factory.createBinaryExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier(recordString),
+                        factory.createIdentifier(key),
+                      ),
+                      factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                      factory.createIdentifier('value'),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          : factory.createCallExpression(
+              factory.createPropertyAccessExpression(
+                factory.createIdentifier(getRecordsName(model)),
+                factory.createIdentifier('find'),
+              ),
               undefined,
               [
-                factory.createParameterDeclaration(
+                factory.createArrowFunction(
                   undefined,
                   undefined,
+                  [
+                    factory.createParameterDeclaration(
+                      undefined,
+                      undefined,
+                      undefined,
+                      factory.createIdentifier(recordString),
+                      undefined,
+                      undefined,
+                    ),
+                  ],
                   undefined,
-                  factory.createIdentifier(recordString),
-                  undefined,
-                  undefined,
+                  factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                  factory.createBinaryExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier(recordString),
+                      factory.createIdentifier(key),
+                    ),
+                    factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                    factory.createIdentifier('value'),
+                  ),
                 ),
               ],
-              undefined,
-              factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-              factory.createBinaryExpression(
-                factory.createPropertyAccessExpression(
-                  factory.createIdentifier(recordString),
-                  factory.createIdentifier(key),
-                ),
-                factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
-                factory.createIdentifier('value'),
-              ),
             ),
-          ],
-        ),
       ],
     ),
     factory.createToken(SyntaxKind.ColonToken),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -1371,9 +1371,11 @@ export const buildGetRelationshipModels = (
         ]),
       ),
       factory.createExpressionStatement(
-        factory.createCallExpression(getSetNameIdentifier(`${fieldName}Records`), undefined, [
-          factory.createArrayLiteralExpression([factory.createIdentifier(`${relatedModelName}Record`)]),
-        ]),
+        factory.createCallExpression(
+          getSetNameIdentifier(`selected${capitalizeFirstLetter(fieldName)}Records`),
+          undefined,
+          [factory.createArrayLiteralExpression([factory.createIdentifier(`${relatedModelName}Record`)])],
+        ),
       ),
     ];
   }

--- a/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
+++ b/packages/codegen-ui-react/lib/forms/react-form-renderer.ts
@@ -478,7 +478,7 @@ export abstract class ReactFormTemplateRenderer extends StudioTemplateRenderer<
 
     statements.push(getInitialValues(formMetadata.fieldConfigs, this.component));
 
-    statements.push(...getUseStateHooks(formMetadata.fieldConfigs, dataApi));
+    statements.push(...getUseStateHooks(formMetadata.fieldConfigs, formActionType, dataApi, hasAutoComplete));
 
     statements.push(...getAutocompleteOptions(formMetadata.fieldConfigs, hasAutoComplete, dataApi));
 

--- a/packages/codegen-ui/example-schemas/models/comment-with-postID/forms/PostUpdateForm.json
+++ b/packages/codegen-ui/example-schemas/models/comment-with-postID/forms/PostUpdateForm.json
@@ -1,0 +1,12 @@
+{
+    "name": "PostUpdateForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "Post"
+    },
+    "formActionType": "update",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+  }

--- a/packages/codegen-ui/example-schemas/models/custom-key-model/forms/ChildItemUpdateForm.json
+++ b/packages/codegen-ui/example-schemas/models/custom-key-model/forms/ChildItemUpdateForm.json
@@ -1,0 +1,12 @@
+{
+    "name": "ChildItemUpdateForm",
+    "dataType": {
+        "dataSourceType": "DataStore",
+        "dataTypeName": "ChildItem"
+    },
+    "formActionType": "update",
+    "fields": {},
+    "sectionalElements": {},
+    "style": {},
+    "cta": {}
+  }


### PR DESCRIPTION
## Problem

For forms with GraphQL, scalar relationship autocomplete fields can load with the badge text as `undefined`.

## Solution

Store relationship data in local state for badge text with the autocomplete options as a fallback for when a customer selects an autocomplete option.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
