### PR TITLE
fix: wrap set state with array expression

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1706,7 +1706,7 @@ export default function MyMemberForm(props) {
               : \\"\\"
           );
           setCurrentTeamIDValue(value);
-          setSelectedTeamIDRecords(teamIDRecords.find((r) => r.id === value));
+          setSelectedTeamIDRecords([teamIDRecords.find((r) => r.id === value)]);
         }}
         inputFieldRef={teamIDRef}
         defaultFieldValue={\\"\\"}
@@ -4018,7 +4018,7 @@ export default function CommentCreateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
+          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -9614,7 +9614,7 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
+          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -10344,7 +10344,7 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
+          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -10997,7 +10997,7 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
+          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -13869,9 +13869,9 @@ export default function CreateCompositeToyForm(props) {
               : \\"\\"
           );
           setCurrentCompositeDogCompositeToysNameValue(value);
-          setSelectedCompositeDogCompositeToysNameRecords(
-            compositeDogCompositeToysNameRecords.find((r) => r.name === value)
-          );
+          setSelectedCompositeDogCompositeToysNameRecords([
+            compositeDogCompositeToysNameRecords.find((r) => r.name === value),
+          ]);
         }}
         inputFieldRef={compositeDogCompositeToysNameRef}
         defaultFieldValue={\\"\\"}
@@ -13982,11 +13982,11 @@ export default function CreateCompositeToyForm(props) {
               : \\"\\"
           );
           setCurrentCompositeDogCompositeToysDescriptionValue(value);
-          setSelectedCompositeDogCompositeToysDescriptionRecords(
+          setSelectedCompositeDogCompositeToysDescriptionRecords([
             compositeDogCompositeToysDescriptionRecords.find(
               (r) => r.description === value
-            )
-          );
+            ),
+          ]);
         }}
         inputFieldRef={compositeDogCompositeToysDescriptionRef}
         defaultFieldValue={\\"\\"}
@@ -14929,9 +14929,9 @@ export default function CreateCommentForm(props) {
               : \\"\\"
           );
           setCurrentPostCommentsIdValue(value);
-          setSelectedPostCommentsIdRecords(
-            postCommentsIdRecords.find((r) => r.id === value)
-          );
+          setSelectedPostCommentsIdRecords([
+            postCommentsIdRecords.find((r) => r.id === value),
+          ]);
         }}
         inputFieldRef={postCommentsIdRef}
         defaultFieldValue={\\"\\"}
@@ -17788,11 +17788,11 @@ export default function ChildItemUpdateForm(props) {
               : \\"\\"
           );
           setCurrentCustomKeyModelChildrenMycustomkeyValue(value);
-          setSelectedCustomKeyModelChildrenMycustomkeyRecords(
+          setSelectedCustomKeyModelChildrenMycustomkeyRecords([
             customKeyModelChildrenMycustomkeyRecords.find(
               (r) => r.mycustomkey === value
-            )
-          );
+            ),
+          ]);
         }}
         inputFieldRef={customKeyModelChildrenMycustomkeyRef}
         defaultFieldValue={\\"\\"}
@@ -20181,7 +20181,7 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords(postIDRecords.find((r) => r.id === value));
+          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
@@ -365,39 +365,41 @@ export const renderArrayFieldComponent = (
               getSetNameIdentifier(`selected${capitalizeFirstLetter(fieldName)}Records`),
               undefined,
               [
-                factory.createCallExpression(
-                  factory.createPropertyAccessExpression(
-                    factory.createIdentifier(getRecordsName(fieldName)),
-                    factory.createIdentifier('find'),
-                  ),
-                  undefined,
-                  [
-                    factory.createArrowFunction(
-                      undefined,
-                      undefined,
-                      [
-                        factory.createParameterDeclaration(
-                          undefined,
-                          undefined,
-                          undefined,
-                          factory.createIdentifier('r'),
-                          undefined,
-                          undefined,
-                        ),
-                      ],
-                      undefined,
-                      factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                      factory.createBinaryExpression(
-                        factory.createPropertyAccessExpression(
-                          factory.createIdentifier('r'),
-                          factory.createIdentifier(scalarKey),
-                        ),
-                        factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
-                        factory.createIdentifier('value'),
-                      ),
+                factory.createArrayLiteralExpression([
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier(getRecordsName(fieldName)),
+                      factory.createIdentifier('find'),
                     ),
-                  ],
-                ),
+                    undefined,
+                    [
+                      factory.createArrowFunction(
+                        undefined,
+                        undefined,
+                        [
+                          factory.createParameterDeclaration(
+                            undefined,
+                            undefined,
+                            undefined,
+                            factory.createIdentifier('r'),
+                            undefined,
+                            undefined,
+                          ),
+                        ],
+                        undefined,
+                        factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                        factory.createBinaryExpression(
+                          factory.createPropertyAccessExpression(
+                            factory.createIdentifier('r'),
+                            factory.createIdentifier(scalarKey),
+                          ),
+                          factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                          factory.createIdentifier('value'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ]),
               ],
             ),
           ),


### PR DESCRIPTION
## Problem

The form throws when changing selection of a record for the autocomplete field.

## Solution

Wrap value for setting local state in an array.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
