### PR TITLE
fix: conditionally set selected record state

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1706,7 +1706,10 @@ export default function MyMemberForm(props) {
               : \\"\\"
           );
           setCurrentTeamIDValue(value);
-          setSelectedTeamIDRecords([teamIDRecords.find((r) => r.id === value)]);
+          const selectedRecord = teamIDRecords.find((r) => r.id === value);
+          if (selectedRecord) {
+            setSelectedTeamIDRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={teamIDRef}
         defaultFieldValue={\\"\\"}
@@ -4018,7 +4021,10 @@ export default function CommentCreateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
+          const selectedRecord = postIDRecords.find((r) => r.id === value);
+          if (selectedRecord) {
+            setSelectedPostIDRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -9614,7 +9620,10 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
+          const selectedRecord = postIDRecords.find((r) => r.id === value);
+          if (selectedRecord) {
+            setSelectedPostIDRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -10344,7 +10353,10 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
+          const selectedRecord = postIDRecords.find((r) => r.id === value);
+          if (selectedRecord) {
+            setSelectedPostIDRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -10997,7 +11009,10 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
+          const selectedRecord = postIDRecords.find((r) => r.id === value);
+          if (selectedRecord) {
+            setSelectedPostIDRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}
@@ -13869,9 +13884,12 @@ export default function CreateCompositeToyForm(props) {
               : \\"\\"
           );
           setCurrentCompositeDogCompositeToysNameValue(value);
-          setSelectedCompositeDogCompositeToysNameRecords([
-            compositeDogCompositeToysNameRecords.find((r) => r.name === value),
-          ]);
+          const selectedRecord = compositeDogCompositeToysNameRecords.find(
+            (r) => r.name === value
+          );
+          if (selectedRecord) {
+            setSelectedCompositeDogCompositeToysNameRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={compositeDogCompositeToysNameRef}
         defaultFieldValue={\\"\\"}
@@ -13982,11 +14000,15 @@ export default function CreateCompositeToyForm(props) {
               : \\"\\"
           );
           setCurrentCompositeDogCompositeToysDescriptionValue(value);
-          setSelectedCompositeDogCompositeToysDescriptionRecords([
+          const selectedRecord =
             compositeDogCompositeToysDescriptionRecords.find(
               (r) => r.description === value
-            ),
-          ]);
+            );
+          if (selectedRecord) {
+            setSelectedCompositeDogCompositeToysDescriptionRecords([
+              selectedRecord,
+            ]);
+          }
         }}
         inputFieldRef={compositeDogCompositeToysDescriptionRef}
         defaultFieldValue={\\"\\"}
@@ -14929,9 +14951,12 @@ export default function CreateCommentForm(props) {
               : \\"\\"
           );
           setCurrentPostCommentsIdValue(value);
-          setSelectedPostCommentsIdRecords([
-            postCommentsIdRecords.find((r) => r.id === value),
-          ]);
+          const selectedRecord = postCommentsIdRecords.find(
+            (r) => r.id === value
+          );
+          if (selectedRecord) {
+            setSelectedPostCommentsIdRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={postCommentsIdRef}
         defaultFieldValue={\\"\\"}
@@ -17788,11 +17813,14 @@ export default function ChildItemUpdateForm(props) {
               : \\"\\"
           );
           setCurrentCustomKeyModelChildrenMycustomkeyValue(value);
-          setSelectedCustomKeyModelChildrenMycustomkeyRecords([
-            customKeyModelChildrenMycustomkeyRecords.find(
-              (r) => r.mycustomkey === value
-            ),
-          ]);
+          const selectedRecord = customKeyModelChildrenMycustomkeyRecords.find(
+            (r) => r.mycustomkey === value
+          );
+          if (selectedRecord) {
+            setSelectedCustomKeyModelChildrenMycustomkeyRecords([
+              selectedRecord,
+            ]);
+          }
         }}
         inputFieldRef={customKeyModelChildrenMycustomkeyRef}
         defaultFieldValue={\\"\\"}
@@ -20181,7 +20209,10 @@ export default function CommentUpdateForm(props) {
               : \\"\\"
           );
           setCurrentPostIDValue(value);
-          setSelectedPostIDRecords([postIDRecords.find((r) => r.id === value)]);
+          const selectedRecord = postIDRecords.find((r) => r.id === value);
+          if (selectedRecord) {
+            setSelectedPostIDRecords([selectedRecord]);
+          }
         }}
         inputFieldRef={postIDRef}
         defaultFieldValue={\\"\\"}

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -1691,8 +1691,8 @@ export default function MyMemberForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.teamID(
-                selectedTeamIDRecords.find((r) => r.id === value) ??
-                  teamIDRecords.find((r) => r.id === value)
+                teamIDRecords.find((r) => r.id === value) ??
+                  selectedTeamIDRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -1700,8 +1700,8 @@ export default function MyMemberForm(props) {
           setCurrentTeamIDDisplayValue(
             value
               ? getDisplayValue.teamID(
-                  selectedTeamIDRecords.find((r) => r.id === value) ??
-                    teamIDRecords.find((r) => r.id === value)
+                  teamIDRecords.find((r) => r.id === value) ??
+                    selectedTeamIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
@@ -4006,8 +4006,8 @@ export default function CommentCreateForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postID(
-                selectedPostIDRecords.find((r) => r.id === value) ??
-                  postIDRecords.find((r) => r.id === value)
+                postIDRecords.find((r) => r.id === value) ??
+                  selectedPostIDRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -4015,8 +4015,8 @@ export default function CommentCreateForm(props) {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  selectedPostIDRecords.find((r) => r.id === value) ??
-                    postIDRecords.find((r) => r.id === value)
+                  postIDRecords.find((r) => r.id === value) ??
+                    selectedPostIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
@@ -9605,8 +9605,8 @@ export default function CommentUpdateForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postID(
-                selectedPostIDRecords.find((r) => r.id === value) ??
-                  postIDRecords.find((r) => r.id === value)
+                postIDRecords.find((r) => r.id === value) ??
+                  selectedPostIDRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -9614,8 +9614,8 @@ export default function CommentUpdateForm(props) {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  selectedPostIDRecords.find((r) => r.id === value) ??
-                    postIDRecords.find((r) => r.id === value)
+                  postIDRecords.find((r) => r.id === value) ??
+                    selectedPostIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
@@ -10338,8 +10338,8 @@ export default function CommentUpdateForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postID(
-                selectedPostIDRecords.find((r) => r.id === value) ??
-                  postIDRecords.find((r) => r.id === value)
+                postIDRecords.find((r) => r.id === value) ??
+                  selectedPostIDRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -10347,8 +10347,8 @@ export default function CommentUpdateForm(props) {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  selectedPostIDRecords.find((r) => r.id === value) ??
-                    postIDRecords.find((r) => r.id === value)
+                  postIDRecords.find((r) => r.id === value) ??
+                    selectedPostIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
@@ -10994,8 +10994,8 @@ export default function CommentUpdateForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postID(
-                selectedPostIDRecords.find((r) => r.id === value) ??
-                  postIDRecords.find((r) => r.id === value)
+                postIDRecords.find((r) => r.id === value) ??
+                  selectedPostIDRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -11003,8 +11003,8 @@ export default function CommentUpdateForm(props) {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  selectedPostIDRecords.find((r) => r.id === value) ??
-                    postIDRecords.find((r) => r.id === value)
+                  postIDRecords.find((r) => r.id === value) ??
+                    selectedPostIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
@@ -13861,11 +13861,11 @@ export default function CreateCompositeToyForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.compositeDogCompositeToysName(
-                selectedCompositeDogCompositeToysNameRecords.find(
-                  (r) => r.id === value
+                compositeDogCompositeToysNameRecords.find(
+                  (r) => r.name === value
                 ) ??
-                  compositeDogCompositeToysNameRecords.find(
-                    (r) => r.name === value
+                  selectedCompositeDogCompositeToysNameRecords.find(
+                    (r) => r.id === value
                   )
               )
             : \\"\\"
@@ -13874,11 +13874,11 @@ export default function CreateCompositeToyForm(props) {
           setCurrentCompositeDogCompositeToysNameDisplayValue(
             value
               ? getDisplayValue.compositeDogCompositeToysName(
-                  selectedCompositeDogCompositeToysNameRecords.find(
-                    (r) => r.id === value
+                  compositeDogCompositeToysNameRecords.find(
+                    (r) => r.name === value
                   ) ??
-                    compositeDogCompositeToysNameRecords.find(
-                      (r) => r.name === value
+                    selectedCompositeDogCompositeToysNameRecords.find(
+                      (r) => r.id === value
                     )
                 )
               : \\"\\"
@@ -13977,11 +13977,11 @@ export default function CreateCompositeToyForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.compositeDogCompositeToysDescription(
-                selectedCompositeDogCompositeToysDescriptionRecords.find(
-                  (r) => r.id === value
+                compositeDogCompositeToysDescriptionRecords.find(
+                  (r) => r.description === value
                 ) ??
-                  compositeDogCompositeToysDescriptionRecords.find(
-                    (r) => r.description === value
+                  selectedCompositeDogCompositeToysDescriptionRecords.find(
+                    (r) => r.id === value
                   )
               )
             : \\"\\"
@@ -13990,11 +13990,11 @@ export default function CreateCompositeToyForm(props) {
           setCurrentCompositeDogCompositeToysDescriptionDisplayValue(
             value
               ? getDisplayValue.compositeDogCompositeToysDescription(
-                  selectedCompositeDogCompositeToysDescriptionRecords.find(
-                    (r) => r.id === value
+                  compositeDogCompositeToysDescriptionRecords.find(
+                    (r) => r.description === value
                   ) ??
-                    compositeDogCompositeToysDescriptionRecords.find(
-                      (r) => r.description === value
+                    selectedCompositeDogCompositeToysDescriptionRecords.find(
+                      (r) => r.id === value
                     )
                 )
               : \\"\\"
@@ -14936,8 +14936,8 @@ export default function CreateCommentForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postCommentsId(
-                selectedPostCommentsIdRecords.find((r) => r.id === value) ??
-                  postCommentsIdRecords.find((r) => r.id === value)
+                postCommentsIdRecords.find((r) => r.id === value) ??
+                  selectedPostCommentsIdRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -14945,8 +14945,8 @@ export default function CreateCommentForm(props) {
           setCurrentPostCommentsIdDisplayValue(
             value
               ? getDisplayValue.postCommentsId(
-                  selectedPostCommentsIdRecords.find((r) => r.id === value) ??
-                    postCommentsIdRecords.find((r) => r.id === value)
+                  postCommentsIdRecords.find((r) => r.id === value) ??
+                    selectedPostCommentsIdRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );
@@ -17790,11 +17790,11 @@ export default function ChildItemUpdateForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.customKeyModelChildrenMycustomkey(
-                selectedCustomKeyModelChildrenMycustomkeyRecords.find(
-                  (r) => r.id === value
+                customKeyModelChildrenMycustomkeyRecords.find(
+                  (r) => r.mycustomkey === value
                 ) ??
-                  customKeyModelChildrenMycustomkeyRecords.find(
-                    (r) => r.mycustomkey === value
+                  selectedCustomKeyModelChildrenMycustomkeyRecords.find(
+                    (r) => r.id === value
                   )
               )
             : \\"\\"
@@ -17803,11 +17803,11 @@ export default function ChildItemUpdateForm(props) {
           setCurrentCustomKeyModelChildrenMycustomkeyDisplayValue(
             value
               ? getDisplayValue.customKeyModelChildrenMycustomkey(
-                  selectedCustomKeyModelChildrenMycustomkeyRecords.find(
-                    (r) => r.id === value
+                  customKeyModelChildrenMycustomkeyRecords.find(
+                    (r) => r.mycustomkey === value
                   ) ??
-                    customKeyModelChildrenMycustomkeyRecords.find(
-                      (r) => r.mycustomkey === value
+                    selectedCustomKeyModelChildrenMycustomkeyRecords.find(
+                      (r) => r.id === value
                     )
                 )
               : \\"\\"
@@ -20194,8 +20194,8 @@ export default function CommentUpdateForm(props) {
         getBadgeText={(value) =>
           value
             ? getDisplayValue.postID(
-                selectedPostIDRecords.find((r) => r.id === value) ??
-                  postIDRecords.find((r) => r.id === value)
+                postIDRecords.find((r) => r.id === value) ??
+                  selectedPostIDRecords.find((r) => r.id === value)
               )
             : \\"\\"
         }
@@ -20203,8 +20203,8 @@ export default function CommentUpdateForm(props) {
           setCurrentPostIDDisplayValue(
             value
               ? getDisplayValue.postID(
-                  selectedPostIDRecords.find((r) => r.id === value) ??
-                    postIDRecords.find((r) => r.id === value)
+                  postIDRecords.find((r) => r.id === value) ??
+                    selectedPostIDRecords.find((r) => r.id === value)
                 )
               : \\"\\"
           );

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
@@ -92,6 +92,40 @@ export function getDisplayValueScalar(fieldName: string, model: string, key: str
           ? factory.createBinaryExpression(
               factory.createCallExpression(
                 factory.createPropertyAccessExpression(
+                  factory.createIdentifier(getRecordsName(model)),
+                  factory.createIdentifier('find'),
+                ),
+                undefined,
+                [
+                  factory.createArrowFunction(
+                    undefined,
+                    undefined,
+                    [
+                      factory.createParameterDeclaration(
+                        undefined,
+                        undefined,
+                        undefined,
+                        factory.createIdentifier(recordString),
+                        undefined,
+                        undefined,
+                      ),
+                    ],
+                    undefined,
+                    factory.createToken(SyntaxKind.EqualsGreaterThanToken),
+                    factory.createBinaryExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier(recordString),
+                        factory.createIdentifier(key),
+                      ),
+                      factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
+                      factory.createIdentifier('value'),
+                    ),
+                  ),
+                ],
+              ),
+              factory.createToken(SyntaxKind.QuestionQuestionToken),
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
                   factory.createIdentifier(`selected${capitalizeFirstLetter(fieldName)}Records`),
                   factory.createIdentifier('find'),
                 ),
@@ -117,40 +151,6 @@ export function getDisplayValueScalar(fieldName: string, model: string, key: str
                       factory.createPropertyAccessExpression(
                         factory.createIdentifier(recordString),
                         factory.createIdentifier('id'),
-                      ),
-                      factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
-                      factory.createIdentifier('value'),
-                    ),
-                  ),
-                ],
-              ),
-              factory.createToken(SyntaxKind.QuestionQuestionToken),
-              factory.createCallExpression(
-                factory.createPropertyAccessExpression(
-                  factory.createIdentifier(getRecordsName(model)),
-                  factory.createIdentifier('find'),
-                ),
-                undefined,
-                [
-                  factory.createArrowFunction(
-                    undefined,
-                    undefined,
-                    [
-                      factory.createParameterDeclaration(
-                        undefined,
-                        undefined,
-                        undefined,
-                        factory.createIdentifier(recordString),
-                        undefined,
-                        undefined,
-                      ),
-                    ],
-                    undefined,
-                    factory.createToken(SyntaxKind.EqualsGreaterThanToken),
-                    factory.createBinaryExpression(
-                      factory.createPropertyAccessExpression(
-                        factory.createIdentifier(recordString),
-                        factory.createIdentifier(key),
                       ),
                       factory.createToken(SyntaxKind.EqualsEqualsEqualsToken),
                       factory.createIdentifier('value'),

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/render-array-field.ts
@@ -359,13 +359,17 @@ export const renderArrayFieldComponent = (
       );
 
       if (dataApi === 'GraphQL') {
+        const selectedRecordName = 'selectedRecord';
+
         setStateStatements.push(
-          factory.createExpressionStatement(
-            factory.createCallExpression(
-              getSetNameIdentifier(`selected${capitalizeFirstLetter(fieldName)}Records`),
-              undefined,
+          factory.createVariableStatement(
+            undefined,
+            factory.createVariableDeclarationList(
               [
-                factory.createArrayLiteralExpression([
+                factory.createVariableDeclaration(
+                  factory.createIdentifier(selectedRecordName),
+                  undefined,
+                  undefined,
                   factory.createCallExpression(
                     factory.createPropertyAccessExpression(
                       factory.createIdentifier(getRecordsName(fieldName)),
@@ -384,6 +388,7 @@ export const renderArrayFieldComponent = (
                             factory.createIdentifier('r'),
                             undefined,
                             undefined,
+                            undefined,
                           ),
                         ],
                         undefined,
@@ -399,9 +404,24 @@ export const renderArrayFieldComponent = (
                       ),
                     ],
                   ),
-                ]),
+                ),
               ],
+              NodeFlags.Const,
             ),
+          ),
+        );
+        setStateStatements.push(
+          factory.createIfStatement(
+            factory.createIdentifier(selectedRecordName),
+            factory.createBlock([
+              factory.createExpressionStatement(
+                factory.createCallExpression(
+                  getSetNameIdentifier(`selected${capitalizeFirstLetter(fieldName)}Records`),
+                  undefined,
+                  [factory.createArrayLiteralExpression([factory.createIdentifier(selectedRecordName)])],
+                ),
+              ),
+            ]),
           ),
         );
       }


### PR DESCRIPTION
## Problem

In certain situations when starting to update a selected record in an autocomplete field and canceling without updating selection, selected record state becomes `undefined`.

## Solution

Conditionally set selected record state if setting a new value, otherwise it will keep its original value.

## Additional Notes

Reordered which state to try to find a matching record for badge text and field value.

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
