### PR TITLE
fix: add fallback for non-required fields on submit

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -282,7 +282,7 @@ export default function CreateOwnerForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
-          Dog,
+          Dog: Dog ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -322,7 +322,7 @@ export default function CreateOwnerForm(props) {
           });
           const modelFieldsToSave = {
             name: modelFields.name,
-            ownerDogId: modelFields?.Dog?.id,
+            ownerDogId: modelFields?.Dog?.id ?? null,
           };
           const owner = (
             await API.graphql({
@@ -810,13 +810,13 @@ export default function MyPostForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          caption,
-          username,
-          post_url,
-          metadata,
-          profile_url,
-          nonModelField,
-          nonModelFieldArray,
+          caption: caption ?? null,
+          username: username ?? null,
+          post_url: post_url ?? null,
+          metadata: metadata ?? null,
+          profile_url: profile_url ?? null,
+          nonModelField: nonModelField ?? null,
+          nonModelFieldArray: nonModelFieldArray ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -847,11 +847,11 @@ export default function MyPostForm(props) {
             }
           });
           const modelFieldsToSave = {
-            caption: modelFields.caption,
-            username: modelFields.username,
-            post_url: modelFields.post_url,
-            metadata: modelFields.metadata,
-            profile_url: modelFields.profile_url,
+            caption: modelFields.caption ?? null,
+            username: modelFields.username ?? null,
+            post_url: modelFields.post_url ?? null,
+            metadata: modelFields.metadata ?? null,
+            profile_url: modelFields.profile_url ?? null,
             nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
               JSON.parse(s)
             ),
@@ -1535,9 +1535,9 @@ export default function MyMemberForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
+          name: name ?? null,
           teamID,
-          Team,
+          Team: Team ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -1576,9 +1576,9 @@ export default function MyMemberForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
+            name: modelFields.name ?? null,
             teamID: modelFields.teamID,
-            teamMembersId: modelFields?.Team?.id,
+            teamMembersId: modelFields?.Team?.id ?? null,
           };
           await API.graphql({
             query: createMember,
@@ -2174,8 +2174,8 @@ export default function MovieCreateForm(props) {
           movieKey,
           title,
           genre,
-          rating,
-          tags,
+          rating: rating ?? null,
+          tags: tags ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -2217,7 +2217,7 @@ export default function MovieCreateForm(props) {
             movieKey: modelFields.movieKey,
             title: modelFields.title,
             genre: modelFields.genre,
-            rating: modelFields.rating,
+            rating: modelFields.rating ?? null,
           };
           const movie = (
             await API.graphql({
@@ -2813,8 +2813,8 @@ export default function SchoolCreateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
-          Students,
+          name: name ?? null,
+          Students: Students ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -2853,7 +2853,7 @@ export default function SchoolCreateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
+            name: modelFields.name ?? null,
           };
           const school = (
             await API.graphql({
@@ -3369,8 +3369,8 @@ export default function BookCreateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
-          primaryAuthor,
+          name: name ?? null,
+          primaryAuthor: primaryAuthor ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -3409,8 +3409,8 @@ export default function BookCreateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
-            authorId: modelFields?.primaryAuthor?.id,
+            name: modelFields.name ?? null,
+            authorId: modelFields?.primaryAuthor?.id ?? null,
           };
           await API.graphql({
             query: createBook,
@@ -3898,7 +3898,7 @@ export default function CommentCreateForm(props) {
         event.preventDefault();
         let modelFields = {
           content,
-          postID,
+          postID: postID ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -4430,9 +4430,9 @@ export default function TagCreateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          label,
-          Posts,
-          statuses,
+          label: label ?? null,
+          Posts: Posts ?? null,
+          statuses: statuses ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -4471,8 +4471,8 @@ export default function TagCreateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            label: modelFields.label,
-            statuses: modelFields.statuses,
+            label: modelFields.label ?? null,
+            statuses: modelFields.statuses ?? null,
           };
           const tag = (
             await API.graphql({
@@ -5101,9 +5101,9 @@ export default function BookCreateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
-          primaryAuthor,
-          primaryTitle,
+          name: name ?? null,
+          primaryAuthor: primaryAuthor ?? null,
+          primaryTitle: primaryTitle ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -5142,9 +5142,9 @@ export default function BookCreateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
-            authorId: modelFields?.primaryAuthor?.id,
-            titleId: modelFields?.primaryTitle?.id,
+            name: modelFields.name ?? null,
+            authorId: modelFields?.primaryAuthor?.id ?? null,
+            titleId: modelFields?.primaryTitle?.id ?? null,
           };
           await API.graphql({
             query: createBook,
@@ -5837,9 +5837,9 @@ export default function CreateCPKTeacherForm(props) {
         event.preventDefault();
         let modelFields = {
           specialTeacherId,
-          CPKStudent,
-          CPKClasses,
-          CPKProjects,
+          CPKStudent: CPKStudent ?? null,
+          CPKClasses: CPKClasses ?? null,
+          CPKProjects: CPKProjects ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -5880,7 +5880,7 @@ export default function CreateCPKTeacherForm(props) {
           const modelFieldsToSave = {
             specialTeacherId: modelFields.specialTeacherId,
             cPKTeacherCPKStudentSpecialStudentId:
-              modelFields?.CPKStudent?.specialStudentId,
+              modelFields?.CPKStudent?.specialStudentId ?? null,
           };
           const cPKTeacher = (
             await API.graphql({
@@ -6576,9 +6576,9 @@ export default function CreateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
-          nmTest,
-          parentTable,
+          name: name ?? null,
+          nmTest: nmTest ?? null,
+          parentTable: parentTable ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -6617,8 +6617,8 @@ export default function CreateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
-            parentTableBasicTablesId: modelFields?.parentTable?.id,
+            name: modelFields.name ?? null,
+            parentTableBasicTablesId: modelFields?.parentTable?.id ?? null,
             nmTest: modelFields.nmTest
               ? JSON.parse(modelFields.nmTest)
               : modelFields.nmTest,
@@ -7185,10 +7185,10 @@ export default function PostUpdateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          title,
-          body,
-          publishDate,
-          Comments,
+          title: title ?? null,
+          body: body ?? null,
+          publishDate: publishDate ?? null,
+          Comments: Comments ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -7277,9 +7277,9 @@ export default function PostUpdateForm(props) {
             );
           });
           const modelFieldsToSave = {
-            title: modelFields.title,
-            body: modelFields.body,
-            publishDate: modelFields.publishDate,
+            title: modelFields.title ?? null,
+            body: modelFields.body ?? null,
+            publishDate: modelFields.publishDate ?? null,
           };
           promises.push(
             API.graphql({
@@ -7848,14 +7848,14 @@ export default function MyPostForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          TextAreaFieldbbd63464,
-          caption,
-          username,
-          profile_url,
-          post_url,
-          metadata,
-          nonModelField,
-          nonModelFieldArray,
+          TextAreaFieldbbd63464: TextAreaFieldbbd63464 ?? null,
+          caption: caption ?? null,
+          username: username ?? null,
+          profile_url: profile_url ?? null,
+          post_url: post_url ?? null,
+          metadata: metadata ?? null,
+          nonModelField: nonModelField ?? null,
+          nonModelFieldArray: nonModelFieldArray ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -7886,11 +7886,11 @@ export default function MyPostForm(props) {
             }
           });
           const modelFieldsToSave = {
-            caption: modelFields.caption,
-            username: modelFields.username,
-            profile_url: modelFields.profile_url,
-            post_url: modelFields.post_url,
-            metadata: modelFields.metadata,
+            caption: modelFields.caption ?? null,
+            username: modelFields.username ?? null,
+            profile_url: modelFields.profile_url ?? null,
+            post_url: modelFields.post_url ?? null,
+            metadata: modelFields.metadata ?? null,
             nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
               JSON.parse(s)
             ),
@@ -8679,8 +8679,8 @@ export default function MovieUpdateForm(props) {
           movieKey,
           title,
           genre,
-          rating,
-          tags,
+          rating: rating ?? null,
+          tags: tags ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -8811,7 +8811,7 @@ export default function MovieUpdateForm(props) {
             movieKey: modelFields.movieKey,
             title: modelFields.title,
             genre: modelFields.genre,
-            rating: modelFields.rating,
+            rating: modelFields.rating ?? null,
           };
           promises.push(
             API.graphql({
@@ -9476,10 +9476,10 @@ export default function CommentUpdateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          content,
+          content: content ?? null,
           postID,
-          Post,
-          post: post1,
+          Post: Post ?? null,
+          post: post ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -9518,9 +9518,9 @@ export default function CommentUpdateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            content: modelFields.content,
+            content: modelFields.content ?? null,
             postID: modelFields.postID,
-            postCommentsId: modelFields?.Post?.id,
+            postCommentsId: modelFields?.Post?.id ?? null,
           };
           await API.graphql({
             query: updateComment,
@@ -10206,10 +10206,10 @@ export default function CommentUpdateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          content,
+          content: content ?? null,
           postID,
-          Post,
-          post: post1,
+          Post: Post ?? null,
+          post: post ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -10248,9 +10248,9 @@ export default function CommentUpdateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            content: modelFields.content,
+            content: modelFields.content ?? null,
             postID: modelFields.postID,
-            postCommentsId: modelFields?.Post?.id,
+            postCommentsId: modelFields?.Post?.id ?? null,
           };
           await API.graphql({
             query: updateComment,
@@ -10879,7 +10879,7 @@ export default function CommentUpdateForm(props) {
         event.preventDefault();
         let modelFields = {
           content,
-          postID,
+          postID: postID ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -11436,7 +11436,7 @@ export default function ClassUpdateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          students,
+          students: students ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -12049,9 +12049,9 @@ export default function UpdateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
-          nmTest,
-          parentTable,
+          name: name ?? null,
+          nmTest: nmTest ?? null,
+          parentTable: parentTable ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -12090,8 +12090,8 @@ export default function UpdateForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
-            parentTableBasicTablesId: modelFields?.parentTable?.id,
+            name: modelFields.name ?? null,
+            parentTableBasicTablesId: modelFields?.parentTable?.id ?? null,
             nmTest: modelFields.nmTest
               ? JSON.parse(modelFields.nmTest)
               : modelFields.nmTest,
@@ -12778,9 +12778,9 @@ export default function UpdateCPKTeacherForm(props) {
         event.preventDefault();
         let modelFields = {
           specialTeacherId,
-          CPKStudent,
-          CPKClasses,
-          CPKProjects,
+          CPKStudent: CPKStudent ?? null,
+          CPKClasses: CPKClasses ?? null,
+          CPKProjects: CPKProjects ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -12966,7 +12966,7 @@ export default function UpdateCPKTeacherForm(props) {
           const modelFieldsToSave = {
             specialTeacherId: modelFields.specialTeacherId,
             cPKTeacherCPKStudentSpecialStudentId:
-              modelFields?.CPKStudent?.specialStudentId,
+              modelFields?.CPKStudent?.specialStudentId ?? null,
           };
           promises.push(
             API.graphql({
@@ -13704,8 +13704,9 @@ export default function CreateCompositeToyForm(props) {
         let modelFields = {
           kind,
           color,
-          compositeDogCompositeToysName,
-          compositeDogCompositeToysDescription,
+          compositeDogCompositeToysName: compositeDogCompositeToysName ?? null,
+          compositeDogCompositeToysDescription:
+            compositeDogCompositeToysDescription ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -14548,10 +14549,10 @@ export default function CreateCommentForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
-          post,
-          User,
+          post: post ?? null,
+          User: User ?? null,
           Org,
-          postCommentsId,
+          postCommentsId: postCommentsId ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -14591,10 +14592,10 @@ export default function CreateCommentForm(props) {
           });
           const modelFieldsToSave = {
             name: modelFields.name,
-            postID: modelFields?.post?.id,
-            userCommentsId: modelFields?.User?.id,
-            orgCommentsId: modelFields?.Org?.id,
-            postCommentsId: modelFields.postCommentsId,
+            postID: modelFields?.post?.id ?? null,
+            userCommentsId: modelFields?.User?.id ?? null,
+            orgCommentsId: modelFields?.Org?.id ?? null,
+            postCommentsId: modelFields.postCommentsId ?? null,
           };
           await API.graphql({
             query: createComment,
@@ -15535,10 +15536,10 @@ export default function CreateCompositeDogForm(props) {
         let modelFields = {
           name,
           description,
-          CompositeBowl,
-          CompositeOwner,
-          CompositeToys,
-          CompositeVets,
+          CompositeBowl: CompositeBowl ?? null,
+          CompositeOwner: CompositeOwner ?? null,
+          CompositeToys: CompositeToys ?? null,
+          CompositeVets: CompositeVets ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -15579,12 +15580,14 @@ export default function CreateCompositeDogForm(props) {
           const modelFieldsToSave = {
             name: modelFields.name,
             description: modelFields.description,
-            compositeDogCompositeBowlShape: modelFields?.CompositeBowl?.shape,
-            compositeDogCompositeBowlSize: modelFields?.CompositeBowl?.size,
+            compositeDogCompositeBowlShape:
+              modelFields?.CompositeBowl?.shape ?? null,
+            compositeDogCompositeBowlSize:
+              modelFields?.CompositeBowl?.size ?? null,
             compositeDogCompositeOwnerLastName:
-              modelFields?.CompositeOwner?.lastName,
+              modelFields?.CompositeOwner?.lastName ?? null,
             compositeDogCompositeOwnerFirstName:
-              modelFields?.CompositeOwner?.firstName,
+              modelFields?.CompositeOwner?.firstName ?? null,
           };
           const compositeDog = (
             await API.graphql({
@@ -16448,8 +16451,8 @@ export default function CreatePostForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
-          comments,
+          name: name ?? null,
+          comments: comments ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -16488,7 +16491,7 @@ export default function CreatePostForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
+            name: modelFields.name ?? null,
           };
           const post = (
             await API.graphql({
@@ -17012,8 +17015,8 @@ export default function UpdatePostForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
-          comments,
+          name: name ?? null,
+          comments: comments ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -17102,7 +17105,7 @@ export default function UpdatePostForm(props) {
             );
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
+            name: modelFields.name ?? null,
           };
           promises.push(
             API.graphql({
@@ -17655,7 +17658,8 @@ export default function ChildItemUpdateForm(props) {
         event.preventDefault();
         let modelFields = {
           content,
-          customKeyModelChildrenMycustomkey,
+          customKeyModelChildrenMycustomkey:
+            customKeyModelChildrenMycustomkey ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -18279,8 +18283,8 @@ export default function PostUpdateForm(props) {
         event.preventDefault();
         let modelFields = {
           title,
-          blog,
-          comments,
+          blog: blog ?? null,
+          comments: comments ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -18370,7 +18374,7 @@ export default function PostUpdateForm(props) {
           });
           const modelFieldsToSave = {
             title: modelFields.title,
-            blogPostsId: modelFields?.blog?.id,
+            blogPostsId: modelFields?.blog?.id ?? null,
           };
           promises.push(
             API.graphql({
@@ -18941,7 +18945,7 @@ export default function CreateDogForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          name,
+          name: name ?? null,
           owner,
         };
         const validationResponses = await Promise.all(
@@ -18981,8 +18985,8 @@ export default function CreateDogForm(props) {
             }
           });
           const modelFieldsToSave = {
-            name: modelFields.name,
-            dogOwnerId: modelFields?.owner?.id,
+            name: modelFields.name ?? null,
+            dogOwnerId: modelFields?.owner?.id ?? null,
           };
           const dog = (
             await API.graphql({
@@ -19489,7 +19493,7 @@ export default function CreateOwnerForm(props) {
         event.preventDefault();
         let modelFields = {
           name,
-          Dog,
+          Dog: Dog ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {
@@ -19529,7 +19533,7 @@ export default function CreateOwnerForm(props) {
           });
           const modelFieldsToSave = {
             name: modelFields.name,
-            ownerDogId: modelFields?.Dog?.id,
+            ownerDogId: modelFields?.Dog?.id ?? null,
           };
           const owner = (
             await API.graphql({
@@ -20062,7 +20066,7 @@ export default function CommentUpdateForm(props) {
       onSubmit={async (event) => {
         event.preventDefault();
         let modelFields = {
-          content,
+          content: content ?? null,
           postID,
         };
         const validationResponses = await Promise.all(
@@ -20619,7 +20623,7 @@ export default function UpdateForm(props) {
         let modelFields = {
           mycustomkey,
           content,
-          children,
+          children: children ?? null,
         };
         const validationResponses = await Promise.all(
           Object.keys(validations).reduce((promises, fieldName) => {

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -323,7 +323,12 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                   [],
                 ),
               ),
-              buildModelFieldObject(dataSourceType !== 'DataStore', formMetadata?.fieldConfigs),
+              buildModelFieldObject(
+                dataSourceType !== 'DataStore',
+                formMetadata?.fieldConfigs,
+                undefined,
+                this.renderConfig.apiConfiguration?.dataApi,
+              ),
               ...onSubmitValidationRun(hasModelField),
               ...this.getOnSubmitDSCall(),
             ],


### PR DESCRIPTION
## Problem

Removing a relationship for update forms does not actually remove the relationship.

## Solution

Provide `null` as a fallback for non-required fields so GraphQL will remove relationships.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
