### PR TITLE
fix: collection components should not directly query for child collection data

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -946,15 +946,8 @@ export default function AuthorProfileCollection(
           query: listAuthors,
           variables,
         })
-      ).data.listAuthors;
-      var loaded = await Promise.all(
-        result.items.map(async (item) => {
-          return {
-            ...item,
-          };
-        })
-      );
-      newCache.push(...loaded);
+      ).data.listAuthors.items;
+      newCache.push(...result);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
@@ -1128,15 +1121,8 @@ export default function CollectionOfCustomButtons(
           query: listUsers,
           variables,
         })
-      ).data.listUsers;
-      var loaded = await Promise.all(
-        result.items.map(async (item) => {
-          return {
-            ...item,
-          };
-        })
-      );
-      newCache.push(...loaded);
+      ).data.listUsers.items;
+      newCache.push(...result);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
@@ -1301,15 +1287,8 @@ export default function ListingCardCollection(
           query: listUntitledModels,
           variables,
         })
-      ).data.listUntitledModels;
-      var loaded = await Promise.all(
-        result.items.map(async (item) => {
-          return {
-            ...item,
-          };
-        })
-      );
-      newCache.push(...loaded);
+      ).data.listUntitledModels.items;
+      newCache.push(...result);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
@@ -1573,29 +1552,8 @@ export default function AuthorProfileCollection(
           query: listAuthors,
           variables,
         })
-      ).data.listAuthors;
-      var loaded = await Promise.all(
-        result.items.map(async (item) => {
-          const Books = (
-            await API.graphql({
-              query: booksByAuthorID,
-              variables: { authorID: item.id },
-            })
-          ).data.booksByAuthorID.items;
-          const Publishers = (
-            await API.graphql({
-              query: publishersByAuthorID,
-              variables: { authorID: item.id },
-            })
-          ).data.publishersByAuthorID.items;
-          return {
-            ...item,
-            Books,
-            Publisher,
-          };
-        })
-      );
-      newCache.push(...loaded);
+      ).data.listAuthors.items;
+      newCache.push(...result);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -2064,107 +2064,42 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                       undefined,
                       factory.createPropertyAccessExpression(
                         factory.createPropertyAccessExpression(
-                          factory.createParenthesizedExpression(
-                            factory.createAwaitExpression(
-                              factory.createCallExpression(
-                                factory.createPropertyAccessExpression(
-                                  factory.createIdentifier('API'),
-                                  factory.createIdentifier('graphql'),
-                                ),
-                                undefined,
-                                [
-                                  factory.createObjectLiteralExpression(
-                                    [
-                                      factory.createPropertyAssignment(
-                                        factory.createIdentifier('query'),
-                                        factory.createIdentifier(modelQuery),
-                                      ),
-                                      factory.createShorthandPropertyAssignment(
-                                        factory.createIdentifier('variables'),
-                                        undefined,
-                                      ),
-                                    ],
-                                    true,
+                          factory.createPropertyAccessExpression(
+                            factory.createParenthesizedExpression(
+                              factory.createAwaitExpression(
+                                factory.createCallExpression(
+                                  factory.createPropertyAccessExpression(
+                                    factory.createIdentifier('API'),
+                                    factory.createIdentifier('graphql'),
                                   ),
-                                ],
+                                  undefined,
+                                  [
+                                    factory.createObjectLiteralExpression(
+                                      [
+                                        factory.createPropertyAssignment(
+                                          factory.createIdentifier('query'),
+                                          factory.createIdentifier(modelQuery),
+                                        ),
+                                        factory.createShorthandPropertyAssignment(
+                                          factory.createIdentifier('variables'),
+                                          undefined,
+                                        ),
+                                      ],
+                                      true,
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
+                            factory.createIdentifier('data'),
                           ),
-                          factory.createIdentifier('data'),
+                          factory.createIdentifier(modelQuery),
                         ),
-                        factory.createIdentifier(modelQuery),
+                        factory.createIdentifier('items'),
                       ),
                     ),
                   ],
                   ts.NodeFlags.Const,
-                ),
-              ),
-              factory.createVariableStatement(
-                undefined,
-                factory.createVariableDeclarationList(
-                  [
-                    factory.createVariableDeclaration(
-                      factory.createIdentifier('loaded'),
-                      undefined,
-                      undefined,
-                      factory.createAwaitExpression(
-                        factory.createCallExpression(
-                          factory.createPropertyAccessExpression(
-                            factory.createIdentifier('Promise'),
-                            factory.createIdentifier('all'),
-                          ),
-                          undefined,
-                          [
-                            factory.createCallExpression(
-                              factory.createPropertyAccessExpression(
-                                factory.createPropertyAccessExpression(
-                                  factory.createIdentifier('result'),
-                                  factory.createIdentifier('items'),
-                                ),
-                                factory.createIdentifier('map'),
-                              ),
-                              undefined,
-                              [
-                                factory.createArrowFunction(
-                                  [factory.createToken(ts.SyntaxKind.AsyncKeyword)],
-                                  undefined,
-                                  [
-                                    factory.createParameterDeclaration(
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                      factory.createIdentifier('item'),
-                                      undefined,
-                                      undefined,
-                                      undefined,
-                                    ),
-                                  ],
-                                  undefined,
-                                  factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                  factory.createBlock(
-                                    [
-                                      ...loadedFieldStatements,
-                                      factory.createReturnStatement(
-                                        factory.createObjectLiteralExpression(
-                                          [
-                                            factory.createSpreadAssignment(factory.createIdentifier('item')),
-                                            ...loadedFields,
-                                          ],
-                                          true,
-                                        ),
-                                      ),
-                                    ],
-                                    true,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                  ts.NodeFlags.AwaitContext,
                 ),
               ),
               factory.createExpressionStatement(
@@ -2174,7 +2109,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                     factory.createIdentifier('push'),
                   ),
                   undefined,
-                  [factory.createSpreadElement(factory.createIdentifier('loaded'))],
+                  [factory.createSpreadElement(factory.createIdentifier('result'))],
                 ),
               ),
               factory.createExpressionStatement(


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->
collection components are generating GraphQL requests using queries that do not exist in the customer's AppSync API
## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
Collections need to be updated to operate on the same assumptions as forms and rely on the main record's query already having their child collections populated.
## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
