### PR TITLE
fix: update inputs for linking and unlinking bidirectional relationships

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -342,8 +342,8 @@ export default function CreateOwnerForm(props) {
                 query: updateDog,
                 variables: {
                   input: {
-                    ...Dog,
-                    owner: owner,
+                    id: Dog.id,
+                    dogOwnerId: owner.id,
                   },
                 },
               })
@@ -355,9 +355,8 @@ export default function CreateOwnerForm(props) {
                   query: updateOwner,
                   variables: {
                     input: {
-                      ...ownerToUnlink,
-                      Dog: undefined,
-                      ownerDogId: undefined,
+                      id: ownerToUnlink.id,
+                      ownerDogId: null,
                     },
                   },
                 })
@@ -15632,8 +15631,11 @@ export default function CreateCompositeDogForm(props) {
                 query: updateCompositeOwner,
                 variables: {
                   input: {
-                    ...CompositeOwner,
-                    CompositeDog: compositeDog,
+                    lastName: CompositeOwner.lastName,
+                    firstName: CompositeOwner.firstName,
+                    compositeOwnerCompositeDogName: compositeDog.name,
+                    compositeOwnerCompositeDogDescription:
+                      compositeDog.description,
                   },
                 },
               })
@@ -15646,10 +15648,10 @@ export default function CreateCompositeDogForm(props) {
                   query: updateCompositeDog,
                   variables: {
                     input: {
-                      ...compositeDogToUnlink,
-                      CompositeOwner: undefined,
-                      compositeDogCompositeOwnerLastName: undefined,
-                      compositeDogCompositeOwnerFirstName: undefined,
+                      name: compositeDogToUnlink.name,
+                      description: compositeDogToUnlink.description,
+                      compositeDogCompositeOwnerLastName: null,
+                      compositeDogCompositeOwnerFirstName: null,
                     },
                   },
                 })
@@ -18708,7 +18710,6 @@ import {
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
 import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
-import { Owner } from \\"../API\\";
 import { fetchByPath, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { listOwners } from \\"../graphql/queries\\";
@@ -19034,8 +19035,8 @@ export default function CreateDogForm(props) {
                 query: updateOwner,
                 variables: {
                   input: {
-                    ...Owner,
-                    Dog: dog,
+                    id: owner.id,
+                    ownerDogId: dog.id,
                   },
                 },
               })
@@ -19581,8 +19582,8 @@ export default function CreateOwnerForm(props) {
                 query: updateDog,
                 variables: {
                   input: {
-                    ...Dog,
-                    owner: owner,
+                    id: Dog.id,
+                    dogOwnerId: owner.id,
                   },
                 },
               })
@@ -19594,9 +19595,8 @@ export default function CreateOwnerForm(props) {
                   query: updateOwner,
                   variables: {
                     input: {
-                      ...ownerToUnlink,
-                      Dog: undefined,
-                      ownerDogId: undefined,
+                      id: ownerToUnlink.id,
+                      ownerDogId: null,
                     },
                   },
                 })

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/cta-props.ts
@@ -271,6 +271,7 @@ export const buildExpression = (
         fieldConfig,
         modelName,
         savedRecordName,
+        thisModelPrimaryKeys,
         dataApi,
       }),
     );


### PR DESCRIPTION
## Problem

When submitting update forms with bidirectional relationships, the form throws with an error message: `The variables input contains a field that is not defined for input object type ______`.

## Solution

Change inputs for update GraphQL calls for linking and unlinking records.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
