### PR TITLE
fix: move graphql collection 'items' property access off of result variable

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -946,8 +946,8 @@ export default function AuthorProfileCollection(
           query: listAuthors,
           variables,
         })
-      ).data.listAuthors.items;
-      newCache.push(...result);
+      ).data.listAuthors;
+      newCache.push(...result.items);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
@@ -1121,8 +1121,8 @@ export default function CollectionOfCustomButtons(
           query: listUsers,
           variables,
         })
-      ).data.listUsers.items;
-      newCache.push(...result);
+      ).data.listUsers;
+      newCache.push(...result.items);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
@@ -1287,8 +1287,8 @@ export default function ListingCardCollection(
           query: listUntitledModels,
           variables,
         })
-      ).data.listUntitledModels.items;
-      newCache.push(...result);
+      ).data.listUntitledModels;
+      newCache.push(...result.items);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
@@ -1552,8 +1552,8 @@ export default function AuthorProfileCollection(
           query: listAuthors,
           variables,
         })
-      ).data.listAuthors.items;
-      newCache.push(...result);
+      ).data.listAuthors;
+      newCache.push(...result.items);
       newNext = result.nextToken;
     }
     const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -2068,38 +2068,35 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                       undefined,
                       factory.createPropertyAccessExpression(
                         factory.createPropertyAccessExpression(
-                          factory.createPropertyAccessExpression(
-                            factory.createParenthesizedExpression(
-                              factory.createAwaitExpression(
-                                factory.createCallExpression(
-                                  factory.createPropertyAccessExpression(
-                                    factory.createIdentifier('API'),
-                                    factory.createIdentifier('graphql'),
-                                  ),
-                                  undefined,
-                                  [
-                                    factory.createObjectLiteralExpression(
-                                      [
-                                        factory.createPropertyAssignment(
-                                          factory.createIdentifier('query'),
-                                          factory.createIdentifier(modelQuery),
-                                        ),
-                                        factory.createShorthandPropertyAssignment(
-                                          factory.createIdentifier('variables'),
-                                          undefined,
-                                        ),
-                                      ],
-                                      true,
-                                    ),
-                                  ],
+                          factory.createParenthesizedExpression(
+                            factory.createAwaitExpression(
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('API'),
+                                  factory.createIdentifier('graphql'),
                                 ),
+                                undefined,
+                                [
+                                  factory.createObjectLiteralExpression(
+                                    [
+                                      factory.createPropertyAssignment(
+                                        factory.createIdentifier('query'),
+                                        factory.createIdentifier(modelQuery),
+                                      ),
+                                      factory.createShorthandPropertyAssignment(
+                                        factory.createIdentifier('variables'),
+                                        undefined,
+                                      ),
+                                    ],
+                                    true,
+                                  ),
+                                ],
                               ),
                             ),
-                            factory.createIdentifier('data'),
                           ),
-                          factory.createIdentifier(modelQuery),
+                          factory.createIdentifier('data'),
                         ),
-                        factory.createIdentifier('items'),
+                        factory.createIdentifier(modelQuery),
                       ),
                     ),
                   ],
@@ -2113,7 +2110,14 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
                     factory.createIdentifier('push'),
                   ),
                   undefined,
-                  [factory.createSpreadElement(factory.createIdentifier('result'))],
+                  [
+                    factory.createSpreadElement(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier('result'),
+                        factory.createIdentifier('items'),
+                      ),
+                    ),
+                  ],
                 ),
               ),
               factory.createExpressionStatement(


### PR DESCRIPTION
## Problem

Response from list model had `items` property access which nextToken referenced. items and nextToken properties are siblings.

## Solution

move items property access off of result variable


## Verification
local app

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
