### PR TITLE
fix: use itemesPerPage for graphql collection query limit

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -912,7 +912,7 @@ export default function AuthorProfileCollection(
   const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
-  const pageSize = 4;
+  const pageSize = 8;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -968,7 +968,6 @@ export default function AuthorProfileCollection(
     <div>
       <Collection
         type=\\"list\\"
-        itemsPerPage={6}
         templateColumns=\\"1fr 1fr\\"
         autoFlow=\\"row\\"
         alignItems=\\"stretch\\"
@@ -1075,7 +1074,7 @@ export default function CollectionOfCustomButtons(
   const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
-  const pageSize = 4;
+  const pageSize = 6;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1253,7 +1252,7 @@ export default function ListingCardCollection(
   const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
-  const pageSize = 4;
+  const pageSize = 6;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1397,7 +1396,7 @@ export default function ListingCardCollection(
   const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
-  const pageSize = 4;
+  const pageSize = 6;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1518,7 +1517,7 @@ export default function AuthorProfileCollection(
   const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
-  const pageSize = 4;
+  const pageSize = 8;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1574,7 +1573,6 @@ export default function AuthorProfileCollection(
     <div>
       <Collection
         type=\\"list\\"
-        itemsPerPage={6}
         templateColumns=\\"1fr 1fr\\"
         autoFlow=\\"row\\"
         alignItems=\\"stretch\\"
@@ -1662,7 +1660,7 @@ export default function AuthorProfileCollection(
     /* @ts-ignore: TS2322 */
     <Collection
       type=\\"list\\"
-      itemsPerPage={6}
+      itemsPerPage={8}
       templateColumns=\\"1fr 1fr\\"
       autoFlow=\\"row\\"
       alignItems=\\"stretch\\"
@@ -2470,7 +2468,7 @@ export default function AuthorProfileCollection(
     /* @ts-ignore: TS2322 */
     <Collection
       type=\\"list\\"
-      itemsPerPage={6}
+      itemsPerPage={8}
       templateColumns=\\"1fr 1fr\\"
       autoFlow=\\"row\\"
       alignItems=\\"stretch\\"

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
@@ -64,21 +64,29 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
   }
 
   private renderCollectionOpeningElement(itemsVariableName?: string): JsxOpeningElement {
-    const propsArray = Object.entries(this.component.properties).map(([key, value]) => {
-      if (key === 'isPaginated' && this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
-        return factory.createJsxAttribute(
-          factory.createIdentifier('isPaginated'),
-          factory.createJsxExpression(
-            undefined,
-            factory.createPrefixUnaryExpression(
-              ts.SyntaxKind.ExclamationToken,
-              factory.createIdentifier('isApiPagination'),
+    const propsArray = Object.entries(this.component.properties).reduce((acc: JsxAttribute[], [key, value]) => {
+      if (this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
+        if (key === 'isPaginated') {
+          return [
+            ...acc,
+            factory.createJsxAttribute(
+              factory.createIdentifier('isPaginated'),
+              factory.createJsxExpression(
+                undefined,
+                factory.createPrefixUnaryExpression(
+                  ts.SyntaxKind.ExclamationToken,
+                  factory.createIdentifier('isApiPagination'),
+                ),
+              ),
             ),
-          ),
-        );
+          ];
+        }
+        if (key === 'itemsPerPage') {
+          return acc;
+        }
       }
-      return buildOpeningElementProperties(this.componentMetadata, value, key);
-    });
+      return [...acc, buildOpeningElementProperties(this.componentMetadata, value, key)];
+    }, []);
 
     let itemsAttribute: JsxAttribute;
 

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -78,6 +78,7 @@ import {
   addBindingPropertiesImports,
   getComponentPropName,
   getConditionalOperandExpression,
+  isFixedPropertyWithValue,
   parseNumberOperand,
 } from './react-component-render-helper';
 import {
@@ -1653,8 +1654,13 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       statements.push(buildUseStateExpression(state.name, state.default));
     });
 
-    // const pageSize = 4;
-    statements.push(buildInitConstVariableExpression('pageSize', factory.createNumericLiteral('4')));
+    // const pageSize = 6;
+    let pageSize = 6;
+    if (isFixedPropertyWithValue(component.properties.itemsPerPage)) {
+      const num = Number(component.properties.itemsPerPage.value);
+      pageSize = Number.isNaN(num) ? pageSize : num;
+    }
+    statements.push(buildInitConstVariableExpression('pageSize', factory.createNumericLiteral(pageSize)));
 
     /*
       React.useEffect(() => {

--- a/packages/codegen-ui/example-schemas/authorCollectionComponent.json
+++ b/packages/codegen-ui/example-schemas/authorCollectionComponent.json
@@ -7,7 +7,7 @@
       "value": "list"
     },
     "itemsPerPage": {
-      "value": "6",
+      "value": "8",
       "type": "number"
     },
     "templateColumns": {


### PR DESCRIPTION
## Problem

Graphql collection is using a constant page size of 4.

## Solution

Use the itemsPerPage component property, fallback to 6

## Verification
local app

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
