### PR TITLE
fix: add missing support for GraphQL collections without pagination

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -913,6 +913,7 @@ export default function AuthorProfileCollection(
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
   const pageSize = 8;
+  const isPaginated = false;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -933,7 +934,7 @@ export default function AuthorProfileCollection(
     const cacheUntil = page * pageSize + 1;
     const newCache = apiCache[instanceKey].slice();
     let newNext = nextToken[instanceKey];
-    while (newCache.length < cacheUntil && newNext != null) {
+    while ((newCache.length < cacheUntil || !isPaginated) && newNext != null) {
       setLoading(true);
       const variables: any = {
         limit: pageSize,
@@ -950,7 +951,9 @@ export default function AuthorProfileCollection(
       newCache.push(...result.items);
       newNext = result.nextToken;
     }
-    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    const cacheSlice = isPaginated
+      ? newCache.slice((page - 1) * pageSize, page * pageSize)
+      : newCache;
     setItems(cacheSlice);
     setHasMorePages(!!newNext);
     setLoading(false);
@@ -973,6 +976,7 @@ export default function AuthorProfileCollection(
         alignItems=\\"stretch\\"
         justifyContent=\\"stretch\\"
         itemsPerPage={pageSize}
+        isPaginated={!isApiPagination && isPaginated}
         items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
         {...getOverrideProps(overrides, \\"AuthorProfileCollection\\")}
         {...rest}
@@ -990,7 +994,7 @@ export default function AuthorProfileCollection(
           );
         }}
       </Collection>
-      {isApiPagination && (
+      {isApiPagination && isPaginated && (
         <Pagination
           currentPage={pageIndex}
           totalPages={maxViewed}
@@ -1075,6 +1079,7 @@ export default function CollectionOfCustomButtons(
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
   const pageSize = 6;
+  const isPaginated = true;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1095,7 +1100,7 @@ export default function CollectionOfCustomButtons(
     const cacheUntil = page * pageSize + 1;
     const newCache = apiCache[instanceKey].slice();
     let newNext = nextToken[instanceKey];
-    while (newCache.length < cacheUntil && newNext != null) {
+    while ((newCache.length < cacheUntil || !isPaginated) && newNext != null) {
       setLoading(true);
       const variables: any = {
         limit: pageSize,
@@ -1124,7 +1129,9 @@ export default function CollectionOfCustomButtons(
       newCache.push(...result.items);
       newNext = result.nextToken;
     }
-    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    const cacheSlice = isPaginated
+      ? newCache.slice((page - 1) * pageSize, page * pageSize)
+      : newCache;
     setItems(cacheSlice);
     setHasMorePages(!!newNext);
     setLoading(false);
@@ -1160,10 +1167,10 @@ export default function CollectionOfCustomButtons(
     <div>
       <Collection
         type=\\"list\\"
-        isPaginated={!isApiPagination}
         gap=\\"1.5rem\\"
         backgroundColor={backgroundColor}
         itemsPerPage={pageSize}
+        isPaginated={!isApiPagination && isPaginated}
         items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
         {...getOverrideProps(overrides, \\"CollectionOfCustomButtons\\")}
         {...rest}
@@ -1188,7 +1195,7 @@ export default function CollectionOfCustomButtons(
           );
         }}
       </Collection>
-      {isApiPagination && (
+      {isApiPagination && isPaginated && (
         <Pagination
           currentPage={pageIndex}
           totalPages={maxViewed}
@@ -1253,6 +1260,7 @@ export default function ListingCardCollection(
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
   const pageSize = 6;
+  const isPaginated = true;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1273,7 +1281,7 @@ export default function ListingCardCollection(
     const cacheUntil = page * pageSize + 1;
     const newCache = apiCache[instanceKey].slice();
     let newNext = nextToken[instanceKey];
-    while (newCache.length < cacheUntil && newNext != null) {
+    while ((newCache.length < cacheUntil || !isPaginated) && newNext != null) {
       setLoading(true);
       const variables: any = {
         limit: pageSize,
@@ -1290,7 +1298,9 @@ export default function ListingCardCollection(
       newCache.push(...result.items);
       newNext = result.nextToken;
     }
-    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    const cacheSlice = isPaginated
+      ? newCache.slice((page - 1) * pageSize, page * pageSize)
+      : newCache;
     setItems(cacheSlice);
     setHasMorePages(!!newNext);
     setLoading(false);
@@ -1307,12 +1317,12 @@ export default function ListingCardCollection(
     /* @ts-ignore: TS2322 */
     <div>
       <Collection
-        isPaginated={!isApiPagination}
         collectionType=\\"grid\\"
         type=\\"list\\"
         columns=\\"2\\"
         order=\\"left-to-right\\"
         itemsPerPage={pageSize}
+        isPaginated={!isApiPagination && isPaginated}
         items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
         {...getOverrideProps(overrides, \\"ListingCardCollection\\")}
         {...rest}
@@ -1333,7 +1343,7 @@ export default function ListingCardCollection(
           );
         }}
       </Collection>
-      {isApiPagination && (
+      {isApiPagination && isPaginated && (
         <Pagination
           currentPage={pageIndex}
           totalPages={maxViewed}
@@ -1397,6 +1407,7 @@ export default function ListingCardCollection(
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
   const pageSize = 6;
+  const isPaginated = true;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1417,7 +1428,9 @@ export default function ListingCardCollection(
     const cacheUntil = page * pageSize + 1;
     const newCache = apiCache[instanceKey].slice();
     let newNext = nextToken[instanceKey];
-    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    const cacheSlice = isPaginated
+      ? newCache.slice((page - 1) * pageSize, page * pageSize)
+      : newCache;
     setItems(cacheSlice);
     setHasMorePages(!!newNext);
     setLoading(false);
@@ -1435,8 +1448,8 @@ export default function ListingCardCollection(
     <div>
       <Collection
         type=\\"list\\"
-        isPaginated={!isApiPagination}
         itemsPerPage={pageSize}
+        isPaginated={!isApiPagination && isPaginated}
         items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
         {...getOverrideProps(overrides, \\"ListingCardCollection\\")}
         {...rest}
@@ -1453,7 +1466,7 @@ export default function ListingCardCollection(
           );
         }}
       </Collection>
-      {isApiPagination && (
+      {isApiPagination && isPaginated && (
         <Pagination
           currentPage={pageIndex}
           totalPages={maxViewed}
@@ -1518,6 +1531,7 @@ export default function AuthorProfileCollection(
   const [loading, setLoading] = React.useState(true);
   const [maxViewed, setMaxViewed] = React.useState(1);
   const pageSize = 8;
+  const isPaginated = false;
   React.useEffect(() => {
     nextToken[instanceKey] = \\"\\";
     apiCache[instanceKey] = [];
@@ -1538,7 +1552,7 @@ export default function AuthorProfileCollection(
     const cacheUntil = page * pageSize + 1;
     const newCache = apiCache[instanceKey].slice();
     let newNext = nextToken[instanceKey];
-    while (newCache.length < cacheUntil && newNext != null) {
+    while ((newCache.length < cacheUntil || !isPaginated) && newNext != null) {
       setLoading(true);
       const variables: any = {
         limit: pageSize,
@@ -1555,7 +1569,9 @@ export default function AuthorProfileCollection(
       newCache.push(...result.items);
       newNext = result.nextToken;
     }
-    const cacheSlice = newCache.slice((page - 1) * pageSize, page * pageSize);
+    const cacheSlice = isPaginated
+      ? newCache.slice((page - 1) * pageSize, page * pageSize)
+      : newCache;
     setItems(cacheSlice);
     setHasMorePages(!!newNext);
     setLoading(false);
@@ -1578,6 +1594,7 @@ export default function AuthorProfileCollection(
         alignItems=\\"stretch\\"
         justifyContent=\\"stretch\\"
         itemsPerPage={pageSize}
+        isPaginated={!isApiPagination && isPaginated}
         items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
         {...getOverrideProps(overrides, \\"AuthorProfileCollection\\")}
         {...rest}
@@ -1595,7 +1612,7 @@ export default function AuthorProfileCollection(
           );
         }}
       </Collection>
-      {isApiPagination && (
+      {isApiPagination && isPaginated && (
         <Pagination
           currentPage={pageIndex}
           totalPages={maxViewed}

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
@@ -66,22 +66,7 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
   private renderCollectionOpeningElement(itemsVariableName?: string): JsxOpeningElement {
     const propsArray = Object.entries(this.component.properties).reduce((acc: JsxAttribute[], [key, value]) => {
       if (this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
-        if (key === 'isPaginated') {
-          return [
-            ...acc,
-            factory.createJsxAttribute(
-              factory.createIdentifier('isPaginated'),
-              factory.createJsxExpression(
-                undefined,
-                factory.createPrefixUnaryExpression(
-                  ts.SyntaxKind.ExclamationToken,
-                  factory.createIdentifier('isApiPagination'),
-                ),
-              ),
-            ),
-          ];
-        }
-        if (key === 'itemsPerPage') {
+        if (key === 'isPaginated' || key === 'itemsPerPage') {
           return acc;
         }
       }
@@ -95,6 +80,20 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
         factory.createJsxAttribute(
           factory.createIdentifier('itemsPerPage'),
           factory.createJsxExpression(undefined, factory.createIdentifier('pageSize')),
+        ),
+        factory.createJsxAttribute(
+          factory.createIdentifier('isPaginated'),
+          factory.createJsxExpression(
+            undefined,
+            factory.createBinaryExpression(
+              factory.createPrefixUnaryExpression(
+                ts.SyntaxKind.ExclamationToken,
+                factory.createIdentifier('isApiPagination'),
+              ),
+              factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
+              factory.createIdentifier('isPaginated'),
+            ),
+          ),
         ),
       );
 
@@ -322,7 +321,11 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
           factory.createJsxExpression(
             undefined,
             factory.createBinaryExpression(
-              factory.createIdentifier('isApiPagination'),
+              factory.createBinaryExpression(
+                factory.createIdentifier('isApiPagination'),
+                factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
+                factory.createIdentifier('isPaginated'),
+              ),
               factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
               factory.createJsxSelfClosingElement(
                 factory.createIdentifier('Pagination'),


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->
The implementation for collections using GraphQL did not include support for not having the collection be paginated.
## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
Add a component level variable for pagination and update querying/rendering logic to incorporate checking this value
## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->
As part of this implementation, the `isPaginated` property on the underlying collection component is now always set where previously the property was only referenced if the component was configured to have pagination.
## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [ ] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
