### PR TITLE
chore: add dependencies to render config type

### DIFF
--- a/packages/codegen-ui-react/lib/react-render-config.ts
+++ b/packages/codegen-ui-react/lib/react-render-config.ts
@@ -27,6 +27,7 @@ export type ReactRenderConfig = FrameworkRenderConfig & {
   renderTypeDeclarations?: boolean;
   inlineSourceMap?: boolean;
   apiConfiguration?: GraphqlRenderConfig | DataStoreRenderConfig | NoApiRenderConfig;
+  dependencies?: { [key: string]: string };
 };
 
 export type GraphqlRenderConfig = {


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->

We need to generate backwards compatible code to support both v5 and v6 amplify js libraries.

## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

Update the render config to take in the current amplify project's dependencies that are required to determine which code to generate for the given project.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - only updates the interface. working code coming later. this unblocks work in other areas.
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
