### PR TITLE
feat: amplify js v6 api support

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -550,6 +550,1220 @@ export default function CreateOwnerForm(props: CreateOwnerFormProps): React.Reac
 "
 `;
 
+exports[`amplify form renderer tests GraphQL form tests should 1:1 relationships without types file path - Create amplify js v6 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { generateClient } from \\"aws-amplify/api\\";
+import { listDogs } from \\"../graphql/queries\\";
+import { createOwner, updateDog, updateOwner } from \\"../graphql/mutations\\";
+const client = generateClient();
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  runValidationTasks,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    const { hasError } = runValidationTasks();
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button size=\\"small\\" variation=\\"link\\" onClick={addItem}>
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function CreateOwnerForm(props) {
+  const {
+    clearOnSuccess = true,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    name: \\"\\",
+    Dog: undefined,
+  };
+  const [name, setName] = React.useState(initialValues.name);
+  const [Dog, setDog] = React.useState(initialValues.Dog);
+  const [DogLoading, setDogLoading] = React.useState(false);
+  const [DogRecords, setDogRecords] = React.useState([]);
+  const autocompleteLength = 10;
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setName(initialValues.name);
+    setDog(initialValues.Dog);
+    setCurrentDogValue(undefined);
+    setCurrentDogDisplayValue(\\"\\");
+    setErrors({});
+  };
+  const [currentDogDisplayValue, setCurrentDogDisplayValue] =
+    React.useState(\\"\\");
+  const [currentDogValue, setCurrentDogValue] = React.useState(undefined);
+  const DogRef = React.createRef();
+  const getIDValue = {
+    Dog: (r) => JSON.stringify({ id: r?.id }),
+  };
+  const DogIdSet = new Set(
+    Array.isArray(Dog)
+      ? Dog.map((r) => getIDValue.Dog?.(r))
+      : getIDValue.Dog?.(Dog)
+  );
+  const getDisplayValue = {
+    Dog: (r) => \`\${r?.name ? r?.name + \\" - \\" : \\"\\"}\${r?.id}\`,
+  };
+  const validations = {
+    name: [{ type: \\"Required\\" }],
+    Dog: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  const fetchDogRecords = async (value) => {
+    setDogLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [{ name: { contains: value } }, { id: { contains: value } }],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await client.graphql({
+          query: listDogs.replaceAll(\\"__typename\\", \\"\\"),
+          variables,
+        })
+      )?.data?.listDogs?.items;
+      var loaded = result.filter(
+        (item) => !DogIdSet.has(getIDValue.Dog?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setDogRecords(newOptions.slice(0, autocompleteLength));
+    setDogLoading(false);
+  };
+  React.useEffect(() => {
+    fetchDogRecords(\\"\\");
+  }, []);
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          name,
+          Dog,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          const modelFieldsToSave = {
+            name: modelFields.name,
+            ownerDogId: modelFields?.Dog?.id,
+          };
+          const owner = (
+            await client.graphql({
+              query: createOwner.replaceAll(\\"__typename\\", \\"\\"),
+              variables: {
+                input: {
+                  ...modelFieldsToSave,
+                },
+              },
+            })
+          )?.data?.createOwner;
+          const promises = [];
+          const dogToLink = modelFields.Dog;
+          if (dogToLink) {
+            promises.push(
+              client.graphql({
+                query: updateDog.replaceAll(\\"__typename\\", \\"\\"),
+                variables: {
+                  input: {
+                    id: Dog.id,
+                    dogOwnerId: owner.id,
+                  },
+                },
+              })
+            );
+            const ownerToUnlink = await dogToLink.owner;
+            if (ownerToUnlink) {
+              promises.push(
+                client.graphql({
+                  query: updateOwner.replaceAll(\\"__typename\\", \\"\\"),
+                  variables: {
+                    input: {
+                      id: ownerToUnlink.id,
+                      ownerDogId: null,
+                    },
+                  },
+                })
+              );
+            }
+          }
+          await Promise.all(promises);
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+          if (clearOnSuccess) {
+            resetStateValues();
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"CreateOwnerForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Name\\"
+        isRequired={true}
+        isReadOnly={false}
+        value={name}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              name: value,
+              Dog,
+            };
+            const result = onChange(modelFields);
+            value = result?.name ?? value;
+          }
+          if (errors.name?.hasError) {
+            runValidationTasks(\\"name\\", value);
+          }
+          setName(value);
+        }}
+        onBlur={() => runValidationTasks(\\"name\\", name)}
+        errorMessage={errors.name?.errorMessage}
+        hasError={errors.name?.hasError}
+        {...getOverrideProps(overrides, \\"name\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              name,
+              Dog: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.Dog ?? value;
+          }
+          setDog(value);
+          setCurrentDogValue(undefined);
+          setCurrentDogDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentDogValue}
+        label={\\"Dog\\"}
+        items={Dog ? [Dog] : []}
+        hasError={errors?.Dog?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(\\"Dog\\", currentDogValue)
+        }
+        errorMessage={errors?.Dog?.errorMessage}
+        getBadgeText={getDisplayValue.Dog}
+        setFieldValue={(model) => {
+          setCurrentDogDisplayValue(model ? getDisplayValue.Dog(model) : \\"\\");
+          setCurrentDogValue(model);
+        }}
+        inputFieldRef={DogRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Dog\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Dog\\"
+          value={currentDogDisplayValue}
+          options={DogRecords.filter(
+            (r) => !DogIdSet.has(getIDValue.Dog?.(r))
+          ).map((r) => ({
+            id: getIDValue.Dog?.(r),
+            label: getDisplayValue.Dog?.(r),
+          }))}
+          isLoading={DogLoading}
+          onSelect={({ id, label }) => {
+            setCurrentDogValue(
+              DogRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentDogDisplayValue(label);
+            runValidationTasks(\\"Dog\\", label);
+          }}
+          onClear={() => {
+            setCurrentDogDisplayValue(\\"\\");
+          }}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchDogRecords(value);
+            if (errors.Dog?.hasError) {
+              runValidationTasks(\\"Dog\\", value);
+            }
+            setCurrentDogDisplayValue(value);
+            setCurrentDogValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"Dog\\", currentDogDisplayValue)}
+          errorMessage={errors.Dog?.errorMessage}
+          hasError={errors.Dog?.hasError}
+          ref={DogRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"Dog\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Clear\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          {...getOverrideProps(overrides, \\"ClearButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e?.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should 1:1 relationships without types file path - Create amplify js v6 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type CreateOwnerFormInputValues = {
+    name?: string;
+    Dog?: any;
+};
+export declare type CreateOwnerFormValidationValues = {
+    name?: ValidationFunction<string>;
+    Dog?: ValidationFunction<any>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type CreateOwnerFormOverridesProps = {
+    CreateOwnerFormGrid?: PrimitiveOverrideProps<GridProps>;
+    name?: PrimitiveOverrideProps<TextFieldProps>;
+    Dog?: PrimitiveOverrideProps<AutocompleteProps>;
+} & EscapeHatchProps;
+export declare type CreateOwnerFormProps = React.PropsWithChildren<{
+    overrides?: CreateOwnerFormOverridesProps | undefined | null;
+} & {
+    clearOnSuccess?: boolean;
+    onSubmit?: (fields: CreateOwnerFormInputValues) => CreateOwnerFormInputValues;
+    onSuccess?: (fields: CreateOwnerFormInputValues) => void;
+    onError?: (fields: CreateOwnerFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: CreateOwnerFormInputValues) => CreateOwnerFormInputValues;
+    onValidate?: CreateOwnerFormValidationValues;
+} & React.CSSProperties>;
+export default function CreateOwnerForm(props: CreateOwnerFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate a create form - amplify js v6 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextAreaField,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { generateClient } from \\"aws-amplify/api\\";
+import { createPost } from \\"../graphql/mutations\\";
+const client = generateClient();
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  runValidationTasks,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    const { hasError } = runValidationTasks();
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button size=\\"small\\" variation=\\"link\\" onClick={addItem}>
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function MyPostForm(props) {
+  const {
+    clearOnSuccess = true,
+    onSuccess,
+    onError,
+    onSubmit,
+    onCancel,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    caption: \\"\\",
+    username: \\"\\",
+    post_url: \\"\\",
+    metadata: \\"\\",
+    profile_url: \\"\\",
+    nonModelField: \\"\\",
+    nonModelFieldArray: [],
+  };
+  const [caption, setCaption] = React.useState(initialValues.caption);
+  const [username, setUsername] = React.useState(initialValues.username);
+  const [post_url, setPost_url] = React.useState(initialValues.post_url);
+  const [metadata, setMetadata] = React.useState(initialValues.metadata);
+  const [profile_url, setProfile_url] = React.useState(
+    initialValues.profile_url
+  );
+  const [nonModelField, setNonModelField] = React.useState(
+    initialValues.nonModelField
+  );
+  const [nonModelFieldArray, setNonModelFieldArray] = React.useState(
+    initialValues.nonModelFieldArray
+  );
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    setCaption(initialValues.caption);
+    setUsername(initialValues.username);
+    setPost_url(initialValues.post_url);
+    setMetadata(initialValues.metadata);
+    setProfile_url(initialValues.profile_url);
+    setNonModelField(initialValues.nonModelField);
+    setNonModelFieldArray(initialValues.nonModelFieldArray);
+    setCurrentNonModelFieldArrayValue(\\"\\");
+    setErrors({});
+  };
+  const [currentNonModelFieldArrayValue, setCurrentNonModelFieldArrayValue] =
+    React.useState(\\"\\");
+  const nonModelFieldArrayRef = React.createRef();
+  const validations = {
+    caption: [],
+    username: [],
+    post_url: [{ type: \\"URL\\" }],
+    metadata: [{ type: \\"JSON\\" }],
+    profile_url: [{ type: \\"URL\\" }],
+    nonModelField: [{ type: \\"JSON\\" }],
+    nonModelFieldArray: [{ type: \\"JSON\\" }],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          caption,
+          username,
+          post_url,
+          metadata,
+          profile_url,
+          nonModelField,
+          nonModelFieldArray,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(fieldName, item)
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(fieldName, modelFields[fieldName])
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          const modelFieldsToSave = {
+            caption: modelFields.caption,
+            username: modelFields.username,
+            post_url: modelFields.post_url,
+            metadata: modelFields.metadata,
+            profile_url: modelFields.profile_url,
+            nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
+              JSON.parse(s)
+            ),
+            nonModelField: modelFields.nonModelField
+              ? JSON.parse(modelFields.nonModelField)
+              : modelFields.nonModelField,
+          };
+          await client.graphql({
+            query: createPost.replaceAll(\\"__typename\\", \\"\\"),
+            variables: {
+              input: {
+                ...modelFieldsToSave,
+              },
+            },
+          });
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+          if (clearOnSuccess) {
+            resetStateValues();
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"MyPostForm\\")}
+      {...rest}
+    >
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Clear\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          {...getOverrideProps(overrides, \\"ClearButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Cancel\\"
+            type=\\"button\\"
+            onClick={() => {
+              onCancel && onCancel();
+            }}
+            {...getOverrideProps(overrides, \\"CancelButton\\")}
+          ></Button>
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={Object.values(errors).some((e) => e?.hasError)}
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+      <TextField
+        label=\\"Caption\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={caption}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              caption: value,
+              username,
+              post_url,
+              metadata,
+              profile_url,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.caption ?? value;
+          }
+          if (errors.caption?.hasError) {
+            runValidationTasks(\\"caption\\", value);
+          }
+          setCaption(value);
+        }}
+        onBlur={() => runValidationTasks(\\"caption\\", caption)}
+        errorMessage={errors.caption?.errorMessage}
+        hasError={errors.caption?.hasError}
+        {...getOverrideProps(overrides, \\"caption\\")}
+      ></TextField>
+      <TextField
+        label=\\"Username\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={username}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              caption,
+              username: value,
+              post_url,
+              metadata,
+              profile_url,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.username ?? value;
+          }
+          if (errors.username?.hasError) {
+            runValidationTasks(\\"username\\", value);
+          }
+          setUsername(value);
+        }}
+        onBlur={() => runValidationTasks(\\"username\\", username)}
+        errorMessage={errors.username?.errorMessage}
+        hasError={errors.username?.hasError}
+        {...getOverrideProps(overrides, \\"username\\")}
+      ></TextField>
+      <TextField
+        label=\\"Post url\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={post_url}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              caption,
+              username,
+              post_url: value,
+              metadata,
+              profile_url,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.post_url ?? value;
+          }
+          if (errors.post_url?.hasError) {
+            runValidationTasks(\\"post_url\\", value);
+          }
+          setPost_url(value);
+        }}
+        onBlur={() => runValidationTasks(\\"post_url\\", post_url)}
+        errorMessage={errors.post_url?.errorMessage}
+        hasError={errors.post_url?.hasError}
+        {...getOverrideProps(overrides, \\"post_url\\")}
+      ></TextField>
+      <TextAreaField
+        label=\\"Metadata\\"
+        isRequired={false}
+        isReadOnly={false}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              caption,
+              username,
+              post_url,
+              metadata: value,
+              profile_url,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.metadata ?? value;
+          }
+          if (errors.metadata?.hasError) {
+            runValidationTasks(\\"metadata\\", value);
+          }
+          setMetadata(value);
+        }}
+        onBlur={() => runValidationTasks(\\"metadata\\", metadata)}
+        errorMessage={errors.metadata?.errorMessage}
+        hasError={errors.metadata?.hasError}
+        {...getOverrideProps(overrides, \\"metadata\\")}
+      ></TextAreaField>
+      <TextField
+        label=\\"Profile url\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={profile_url}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              caption,
+              username,
+              post_url,
+              metadata,
+              profile_url: value,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.profile_url ?? value;
+          }
+          if (errors.profile_url?.hasError) {
+            runValidationTasks(\\"profile_url\\", value);
+          }
+          setProfile_url(value);
+        }}
+        onBlur={() => runValidationTasks(\\"profile_url\\", profile_url)}
+        errorMessage={errors.profile_url?.errorMessage}
+        hasError={errors.profile_url?.hasError}
+        {...getOverrideProps(overrides, \\"profile_url\\")}
+      ></TextField>
+      <TextAreaField
+        label=\\"Non model field\\"
+        isRequired={false}
+        isReadOnly={false}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              caption,
+              username,
+              post_url,
+              metadata,
+              profile_url,
+              nonModelField: value,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.nonModelField ?? value;
+          }
+          if (errors.nonModelField?.hasError) {
+            runValidationTasks(\\"nonModelField\\", value);
+          }
+          setNonModelField(value);
+        }}
+        onBlur={() => runValidationTasks(\\"nonModelField\\", nonModelField)}
+        errorMessage={errors.nonModelField?.errorMessage}
+        hasError={errors.nonModelField?.hasError}
+        {...getOverrideProps(overrides, \\"nonModelField\\")}
+      ></TextAreaField>
+      <ArrayField
+        onChange={async (items) => {
+          let values = items;
+          if (onChange) {
+            const modelFields = {
+              caption,
+              username,
+              post_url,
+              metadata,
+              profile_url,
+              nonModelField,
+              nonModelFieldArray: values,
+            };
+            const result = onChange(modelFields);
+            values = result?.nonModelFieldArray ?? values;
+          }
+          setNonModelFieldArray(values);
+          setCurrentNonModelFieldArrayValue(\\"\\");
+        }}
+        currentFieldValue={currentNonModelFieldArrayValue}
+        label={\\"Non model field array\\"}
+        items={nonModelFieldArray}
+        hasError={errors?.nonModelFieldArray?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(
+            \\"nonModelFieldArray\\",
+            currentNonModelFieldArrayValue
+          )
+        }
+        errorMessage={errors?.nonModelFieldArray?.errorMessage}
+        setFieldValue={setCurrentNonModelFieldArrayValue}
+        inputFieldRef={nonModelFieldArrayRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <TextAreaField
+          label=\\"Non model field array\\"
+          isRequired={false}
+          isReadOnly={false}
+          value={currentNonModelFieldArrayValue}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.nonModelFieldArray?.hasError) {
+              runValidationTasks(\\"nonModelFieldArray\\", value);
+            }
+            setCurrentNonModelFieldArrayValue(value);
+          }}
+          onBlur={() =>
+            runValidationTasks(
+              \\"nonModelFieldArray\\",
+              currentNonModelFieldArrayValue
+            )
+          }
+          errorMessage={errors.nonModelFieldArray?.errorMessage}
+          hasError={errors.nonModelFieldArray?.hasError}
+          ref={nonModelFieldArrayRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"nonModelFieldArray\\")}
+        ></TextAreaField>
+      </ArrayField>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate a create form - amplify js v6 2`] = `
+"import * as React from \\"react\\";
+import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type MyPostFormInputValues = {
+    caption?: string;
+    username?: string;
+    post_url?: string;
+    metadata?: string;
+    profile_url?: string;
+    nonModelField?: string;
+    nonModelFieldArray?: string[];
+};
+export declare type MyPostFormValidationValues = {
+    caption?: ValidationFunction<string>;
+    username?: ValidationFunction<string>;
+    post_url?: ValidationFunction<string>;
+    metadata?: ValidationFunction<string>;
+    profile_url?: ValidationFunction<string>;
+    nonModelField?: ValidationFunction<string>;
+    nonModelFieldArray?: ValidationFunction<string>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type MyPostFormOverridesProps = {
+    MyPostFormGrid?: PrimitiveOverrideProps<GridProps>;
+    caption?: PrimitiveOverrideProps<TextFieldProps>;
+    username?: PrimitiveOverrideProps<TextFieldProps>;
+    post_url?: PrimitiveOverrideProps<TextFieldProps>;
+    metadata?: PrimitiveOverrideProps<TextAreaFieldProps>;
+    profile_url?: PrimitiveOverrideProps<TextFieldProps>;
+    nonModelField?: PrimitiveOverrideProps<TextAreaFieldProps>;
+    nonModelFieldArray?: PrimitiveOverrideProps<TextAreaFieldProps>;
+} & EscapeHatchProps;
+export declare type MyPostFormProps = React.PropsWithChildren<{
+    overrides?: MyPostFormOverridesProps | undefined | null;
+} & {
+    clearOnSuccess?: boolean;
+    onSubmit?: (fields: MyPostFormInputValues) => MyPostFormInputValues;
+    onSuccess?: (fields: MyPostFormInputValues) => void;
+    onError?: (fields: MyPostFormInputValues, errorMessage: string) => void;
+    onCancel?: () => void;
+    onChange?: (fields: MyPostFormInputValues) => MyPostFormInputValues;
+    onValidate?: MyPostFormValidationValues;
+} & React.CSSProperties>;
+export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
+"
+`;
+
 exports[`amplify form renderer tests GraphQL form tests should generate a create form 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
@@ -7554,6 +8768,795 @@ export default function PostUpdateForm(props: PostUpdateFormProps): React.ReactE
 "
 `;
 
+exports[`amplify form renderer tests GraphQL form tests should generate a update form without relationships - amplify js v6 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextAreaField,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { generateClient } from \\"aws-amplify/api\\";
+import { getPost } from \\"../graphql/queries\\";
+import { updatePost } from \\"../graphql/mutations\\";
+const client = generateClient();
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  runValidationTasks,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    const { hasError } = runValidationTasks();
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button size=\\"small\\" variation=\\"link\\" onClick={addItem}>
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function MyPostForm(props) {
+  const {
+    id: idProp,
+    post: postModelProp,
+    onSuccess,
+    onError,
+    onSubmit,
+    onCancel,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    TextAreaFieldbbd63464: \\"\\",
+    caption: \\"\\",
+    username: \\"\\",
+    profile_url: \\"\\",
+    post_url: \\"\\",
+    metadata: \\"\\",
+    nonModelField: \\"\\",
+    nonModelFieldArray: [],
+  };
+  const [TextAreaFieldbbd63464, setTextAreaFieldbbd63464] = React.useState(
+    initialValues.TextAreaFieldbbd63464
+  );
+  const [caption, setCaption] = React.useState(initialValues.caption);
+  const [username, setUsername] = React.useState(initialValues.username);
+  const [profile_url, setProfile_url] = React.useState(
+    initialValues.profile_url
+  );
+  const [post_url, setPost_url] = React.useState(initialValues.post_url);
+  const [metadata, setMetadata] = React.useState(initialValues.metadata);
+  const [nonModelField, setNonModelField] = React.useState(
+    initialValues.nonModelField
+  );
+  const [nonModelFieldArray, setNonModelFieldArray] = React.useState(
+    initialValues.nonModelFieldArray
+  );
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    const cleanValues = postRecord
+      ? { ...initialValues, ...postRecord }
+      : initialValues;
+    setTextAreaFieldbbd63464(cleanValues.TextAreaFieldbbd63464);
+    setCaption(cleanValues.caption);
+    setUsername(cleanValues.username);
+    setProfile_url(cleanValues.profile_url);
+    setPost_url(cleanValues.post_url);
+    setMetadata(
+      typeof cleanValues.metadata === \\"string\\" || cleanValues.metadata === null
+        ? cleanValues.metadata
+        : JSON.stringify(cleanValues.metadata)
+    );
+    setNonModelField(
+      typeof cleanValues.nonModelField === \\"string\\" ||
+        cleanValues.nonModelField === null
+        ? cleanValues.nonModelField
+        : JSON.stringify(cleanValues.nonModelField)
+    );
+    setNonModelFieldArray(
+      cleanValues.nonModelFieldArray?.map((item) =>
+        typeof item === \\"string\\" ? item : JSON.stringify(item)
+      ) ?? []
+    );
+    setCurrentNonModelFieldArrayValue(\\"\\");
+    setErrors({});
+  };
+  const [postRecord, setPostRecord] = React.useState(postModelProp);
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = idProp
+        ? (
+            await client.graphql({
+              query: getPost.replaceAll(\\"__typename\\", \\"\\"),
+              variables: { id: idProp },
+            })
+          )?.data?.getPost
+        : postModelProp;
+      setPostRecord(record);
+    };
+    queryData();
+  }, [idProp, postModelProp]);
+  React.useEffect(resetStateValues, [postRecord]);
+  const [currentNonModelFieldArrayValue, setCurrentNonModelFieldArrayValue] =
+    React.useState(\\"\\");
+  const nonModelFieldArrayRef = React.createRef();
+  const validations = {
+    TextAreaFieldbbd63464: [],
+    caption: [],
+    username: [],
+    profile_url: [{ type: \\"URL\\" }],
+    post_url: [{ type: \\"URL\\" }],
+    metadata: [{ type: \\"JSON\\" }],
+    nonModelField: [{ type: \\"JSON\\" }],
+    nonModelFieldArray: [{ type: \\"JSON\\" }],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          TextAreaFieldbbd63464: TextAreaFieldbbd63464 ?? null,
+          caption: caption ?? null,
+          username: username ?? null,
+          profile_url: profile_url ?? null,
+          post_url: post_url ?? null,
+          metadata: metadata ?? null,
+          nonModelField: nonModelField ?? null,
+          nonModelFieldArray: nonModelFieldArray ?? null,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(fieldName, item)
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(fieldName, modelFields[fieldName])
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          const modelFieldsToSave = {
+            caption: modelFields.caption ?? null,
+            username: modelFields.username ?? null,
+            profile_url: modelFields.profile_url ?? null,
+            post_url: modelFields.post_url ?? null,
+            metadata: modelFields.metadata ?? null,
+            nonModelFieldArray: modelFields.nonModelFieldArray.map((s) =>
+              JSON.parse(s)
+            ),
+            nonModelField: modelFields.nonModelField
+              ? JSON.parse(modelFields.nonModelField)
+              : modelFields.nonModelField,
+          };
+          await client.graphql({
+            query: updatePost.replaceAll(\\"__typename\\", \\"\\"),
+            variables: {
+              input: {
+                id: postRecord.id,
+                ...modelFieldsToSave,
+              },
+            },
+          });
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"MyPostForm\\")}
+      {...rest}
+    >
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          isDisabled={!(idProp || postModelProp)}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Cancel\\"
+            type=\\"button\\"
+            onClick={() => {
+              onCancel && onCancel();
+            }}
+            {...getOverrideProps(overrides, \\"CancelButton\\")}
+          ></Button>
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={
+              !(idProp || postModelProp) ||
+              Object.values(errors).some((e) => e?.hasError)
+            }
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+      <TextAreaField
+        label=\\"Label\\"
+        value={TextAreaFieldbbd63464}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464: value,
+              caption,
+              username,
+              profile_url,
+              post_url,
+              metadata,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.TextAreaFieldbbd63464 ?? value;
+          }
+          if (errors.TextAreaFieldbbd63464?.hasError) {
+            runValidationTasks(\\"TextAreaFieldbbd63464\\", value);
+          }
+          setTextAreaFieldbbd63464(value);
+        }}
+        onBlur={() =>
+          runValidationTasks(\\"TextAreaFieldbbd63464\\", TextAreaFieldbbd63464)
+        }
+        errorMessage={errors.TextAreaFieldbbd63464?.errorMessage}
+        hasError={errors.TextAreaFieldbbd63464?.hasError}
+        {...getOverrideProps(overrides, \\"TextAreaFieldbbd63464\\")}
+      ></TextAreaField>
+      <TextField
+        label=\\"Caption\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={caption}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464,
+              caption: value,
+              username,
+              profile_url,
+              post_url,
+              metadata,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.caption ?? value;
+          }
+          if (errors.caption?.hasError) {
+            runValidationTasks(\\"caption\\", value);
+          }
+          setCaption(value);
+        }}
+        onBlur={() => runValidationTasks(\\"caption\\", caption)}
+        errorMessage={errors.caption?.errorMessage}
+        hasError={errors.caption?.hasError}
+        {...getOverrideProps(overrides, \\"caption\\")}
+      ></TextField>
+      <TextField
+        label=\\"Username\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={username}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464,
+              caption,
+              username: value,
+              profile_url,
+              post_url,
+              metadata,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.username ?? value;
+          }
+          if (errors.username?.hasError) {
+            runValidationTasks(\\"username\\", value);
+          }
+          setUsername(value);
+        }}
+        onBlur={() => runValidationTasks(\\"username\\", username)}
+        errorMessage={errors.username?.errorMessage}
+        hasError={errors.username?.hasError}
+        {...getOverrideProps(overrides, \\"username\\")}
+      ></TextField>
+      <TextField
+        label=\\"Profile url\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={profile_url}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464,
+              caption,
+              username,
+              profile_url: value,
+              post_url,
+              metadata,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.profile_url ?? value;
+          }
+          if (errors.profile_url?.hasError) {
+            runValidationTasks(\\"profile_url\\", value);
+          }
+          setProfile_url(value);
+        }}
+        onBlur={() => runValidationTasks(\\"profile_url\\", profile_url)}
+        errorMessage={errors.profile_url?.errorMessage}
+        hasError={errors.profile_url?.hasError}
+        {...getOverrideProps(overrides, \\"profile_url\\")}
+      ></TextField>
+      <TextField
+        label=\\"Post url\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={post_url}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464,
+              caption,
+              username,
+              profile_url,
+              post_url: value,
+              metadata,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.post_url ?? value;
+          }
+          if (errors.post_url?.hasError) {
+            runValidationTasks(\\"post_url\\", value);
+          }
+          setPost_url(value);
+        }}
+        onBlur={() => runValidationTasks(\\"post_url\\", post_url)}
+        errorMessage={errors.post_url?.errorMessage}
+        hasError={errors.post_url?.hasError}
+        {...getOverrideProps(overrides, \\"post_url\\")}
+      ></TextField>
+      <TextAreaField
+        label=\\"Metadata\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={metadata}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464,
+              caption,
+              username,
+              profile_url,
+              post_url,
+              metadata: value,
+              nonModelField,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.metadata ?? value;
+          }
+          if (errors.metadata?.hasError) {
+            runValidationTasks(\\"metadata\\", value);
+          }
+          setMetadata(value);
+        }}
+        onBlur={() => runValidationTasks(\\"metadata\\", metadata)}
+        errorMessage={errors.metadata?.errorMessage}
+        hasError={errors.metadata?.hasError}
+        {...getOverrideProps(overrides, \\"metadata\\")}
+      ></TextAreaField>
+      <TextAreaField
+        label=\\"Non model field\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={nonModelField}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464,
+              caption,
+              username,
+              profile_url,
+              post_url,
+              metadata,
+              nonModelField: value,
+              nonModelFieldArray,
+            };
+            const result = onChange(modelFields);
+            value = result?.nonModelField ?? value;
+          }
+          if (errors.nonModelField?.hasError) {
+            runValidationTasks(\\"nonModelField\\", value);
+          }
+          setNonModelField(value);
+        }}
+        onBlur={() => runValidationTasks(\\"nonModelField\\", nonModelField)}
+        errorMessage={errors.nonModelField?.errorMessage}
+        hasError={errors.nonModelField?.hasError}
+        {...getOverrideProps(overrides, \\"nonModelField\\")}
+      ></TextAreaField>
+      <ArrayField
+        onChange={async (items) => {
+          let values = items;
+          if (onChange) {
+            const modelFields = {
+              TextAreaFieldbbd63464,
+              caption,
+              username,
+              profile_url,
+              post_url,
+              metadata,
+              nonModelField,
+              nonModelFieldArray: values,
+            };
+            const result = onChange(modelFields);
+            values = result?.nonModelFieldArray ?? values;
+          }
+          setNonModelFieldArray(values);
+          setCurrentNonModelFieldArrayValue(\\"\\");
+        }}
+        currentFieldValue={currentNonModelFieldArrayValue}
+        label={\\"Non model field array\\"}
+        items={nonModelFieldArray}
+        hasError={errors?.nonModelFieldArray?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(
+            \\"nonModelFieldArray\\",
+            currentNonModelFieldArrayValue
+          )
+        }
+        errorMessage={errors?.nonModelFieldArray?.errorMessage}
+        setFieldValue={setCurrentNonModelFieldArrayValue}
+        inputFieldRef={nonModelFieldArrayRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <TextAreaField
+          label=\\"Non model field array\\"
+          isRequired={false}
+          isReadOnly={false}
+          value={currentNonModelFieldArrayValue}
+          onChange={(e) => {
+            let { value } = e.target;
+            if (errors.nonModelFieldArray?.hasError) {
+              runValidationTasks(\\"nonModelFieldArray\\", value);
+            }
+            setCurrentNonModelFieldArrayValue(value);
+          }}
+          onBlur={() =>
+            runValidationTasks(
+              \\"nonModelFieldArray\\",
+              currentNonModelFieldArrayValue
+            )
+          }
+          errorMessage={errors.nonModelFieldArray?.errorMessage}
+          hasError={errors.nonModelFieldArray?.hasError}
+          ref={nonModelFieldArrayRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"nonModelFieldArray\\")}
+        ></TextAreaField>
+      </ArrayField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          isDisabled={!(idProp || postModelProp)}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Cancel\\"
+            type=\\"button\\"
+            onClick={() => {
+              onCancel && onCancel();
+            }}
+            {...getOverrideProps(overrides, \\"CancelButton\\")}
+          ></Button>
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={
+              !(idProp || postModelProp) ||
+              Object.values(errors).some((e) => e?.hasError)
+            }
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate a update form without relationships - amplify js v6 2`] = `
+"import * as React from \\"react\\";
+import { GridProps, TextAreaFieldProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+import { Post } from \\"../API\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type MyPostFormInputValues = {
+    TextAreaFieldbbd63464?: string;
+    caption?: string;
+    username?: string;
+    profile_url?: string;
+    post_url?: string;
+    metadata?: string;
+    nonModelField?: string;
+    nonModelFieldArray?: string[];
+};
+export declare type MyPostFormValidationValues = {
+    TextAreaFieldbbd63464?: ValidationFunction<string>;
+    caption?: ValidationFunction<string>;
+    username?: ValidationFunction<string>;
+    profile_url?: ValidationFunction<string>;
+    post_url?: ValidationFunction<string>;
+    metadata?: ValidationFunction<string>;
+    nonModelField?: ValidationFunction<string>;
+    nonModelFieldArray?: ValidationFunction<string>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type MyPostFormOverridesProps = {
+    MyPostFormGrid?: PrimitiveOverrideProps<GridProps>;
+    TextAreaFieldbbd63464?: PrimitiveOverrideProps<TextAreaFieldProps>;
+    caption?: PrimitiveOverrideProps<TextFieldProps>;
+    username?: PrimitiveOverrideProps<TextFieldProps>;
+    profile_url?: PrimitiveOverrideProps<TextFieldProps>;
+    post_url?: PrimitiveOverrideProps<TextFieldProps>;
+    metadata?: PrimitiveOverrideProps<TextAreaFieldProps>;
+    nonModelField?: PrimitiveOverrideProps<TextAreaFieldProps>;
+    nonModelFieldArray?: PrimitiveOverrideProps<TextAreaFieldProps>;
+} & EscapeHatchProps;
+export declare type MyPostFormProps = React.PropsWithChildren<{
+    overrides?: MyPostFormOverridesProps | undefined | null;
+} & {
+    id?: string;
+    post?: Post;
+    onSubmit?: (fields: MyPostFormInputValues) => MyPostFormInputValues;
+    onSuccess?: (fields: MyPostFormInputValues) => void;
+    onError?: (fields: MyPostFormInputValues, errorMessage: string) => void;
+    onCancel?: () => void;
+    onChange?: (fields: MyPostFormInputValues) => MyPostFormInputValues;
+    onValidate?: MyPostFormValidationValues;
+} & React.CSSProperties>;
+export default function MyPostForm(props: MyPostFormProps): React.ReactElement;
+"
+`;
+
 exports[`amplify form renderer tests GraphQL form tests should generate a update form without relationships 1`] = `
 "/* eslint-disable */
 import * as React from \\"react\\";
@@ -9848,6 +11851,739 @@ export declare type CommentUpdateFormProps = React.PropsWithChildren<{
 } & {
     id?: string;
     comment?: Comment;
+    onSubmit?: (fields: CommentUpdateFormInputValues) => CommentUpdateFormInputValues;
+    onSuccess?: (fields: CommentUpdateFormInputValues) => void;
+    onError?: (fields: CommentUpdateFormInputValues, errorMessage: string) => void;
+    onChange?: (fields: CommentUpdateFormInputValues) => CommentUpdateFormInputValues;
+    onValidate?: CommentUpdateFormValidationValues;
+} & React.CSSProperties>;
+export default function CommentUpdateForm(props: CommentUpdateFormProps): React.ReactElement;
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate an update form with hasMany relationship without types file - amplify js v6 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import {
+  Autocomplete,
+  Badge,
+  Button,
+  Divider,
+  Flex,
+  Grid,
+  Icon,
+  ScrollView,
+  Text,
+  TextField,
+  useTheme,
+} from \\"@aws-amplify/ui-react\\";
+import { getOverrideProps } from \\"@aws-amplify/ui-react/internal\\";
+import { fetchByPath, validateField } from \\"./utils\\";
+import { generateClient } from \\"aws-amplify/api\\";
+import { getComment, getPost, listPosts } from \\"../graphql/queries\\";
+import { updateComment } from \\"../graphql/mutations\\";
+const client = generateClient();
+function ArrayField({
+  items = [],
+  onChange,
+  label,
+  inputFieldRef,
+  children,
+  hasError,
+  setFieldValue,
+  currentFieldValue,
+  defaultFieldValue,
+  lengthLimit,
+  getBadgeText,
+  runValidationTasks,
+  errorMessage,
+}) {
+  const labelElement = <Text>{label}</Text>;
+  const {
+    tokens: {
+      components: {
+        fieldmessages: { error: errorStyles },
+      },
+    },
+  } = useTheme();
+  const [selectedBadgeIndex, setSelectedBadgeIndex] = React.useState();
+  const [isEditing, setIsEditing] = React.useState();
+  React.useEffect(() => {
+    if (isEditing) {
+      inputFieldRef?.current?.focus();
+    }
+  }, [isEditing]);
+  const removeItem = async (removeIndex) => {
+    const newItems = items.filter((value, index) => index !== removeIndex);
+    await onChange(newItems);
+    setSelectedBadgeIndex(undefined);
+  };
+  const addItem = async () => {
+    const { hasError } = runValidationTasks();
+    if (
+      currentFieldValue !== undefined &&
+      currentFieldValue !== null &&
+      currentFieldValue !== \\"\\" &&
+      !hasError
+    ) {
+      const newItems = [...items];
+      if (selectedBadgeIndex !== undefined) {
+        newItems[selectedBadgeIndex] = currentFieldValue;
+        setSelectedBadgeIndex(undefined);
+      } else {
+        newItems.push(currentFieldValue);
+      }
+      await onChange(newItems);
+      setIsEditing(false);
+    }
+  };
+  const arraySection = (
+    <React.Fragment>
+      {!!items?.length && (
+        <ScrollView height=\\"inherit\\" width=\\"inherit\\" maxHeight={\\"7rem\\"}>
+          {items.map((value, index) => {
+            return (
+              <Badge
+                key={index}
+                style={{
+                  cursor: \\"pointer\\",
+                  alignItems: \\"center\\",
+                  marginRight: 3,
+                  marginTop: 3,
+                  backgroundColor:
+                    index === selectedBadgeIndex ? \\"#B8CEF9\\" : \\"\\",
+                }}
+                onClick={() => {
+                  setSelectedBadgeIndex(index);
+                  setFieldValue(items[index]);
+                  setIsEditing(true);
+                }}
+              >
+                {getBadgeText ? getBadgeText(value) : value.toString()}
+                <Icon
+                  style={{
+                    cursor: \\"pointer\\",
+                    paddingLeft: 3,
+                    width: 20,
+                    height: 20,
+                  }}
+                  viewBox={{ width: 20, height: 20 }}
+                  paths={[
+                    {
+                      d: \\"M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z\\",
+                      stroke: \\"black\\",
+                    },
+                  ]}
+                  ariaLabel=\\"button\\"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeItem(index);
+                  }}
+                />
+              </Badge>
+            );
+          })}
+        </ScrollView>
+      )}
+      <Divider orientation=\\"horizontal\\" marginTop={5} />
+    </React.Fragment>
+  );
+  if (lengthLimit !== undefined && items.length >= lengthLimit && !isEditing) {
+    return (
+      <React.Fragment>
+        {labelElement}
+        {arraySection}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      {labelElement}
+      {isEditing && children}
+      {!isEditing ? (
+        <>
+          <Button
+            onClick={() => {
+              setIsEditing(true);
+            }}
+          >
+            Add item
+          </Button>
+          {errorMessage && hasError && (
+            <Text color={errorStyles.color} fontSize={errorStyles.fontSize}>
+              {errorMessage}
+            </Text>
+          )}
+        </>
+      ) : (
+        <Flex justifyContent=\\"flex-end\\">
+          {(currentFieldValue || isEditing) && (
+            <Button
+              children=\\"Cancel\\"
+              type=\\"button\\"
+              size=\\"small\\"
+              onClick={() => {
+                setFieldValue(defaultFieldValue);
+                setIsEditing(false);
+                setSelectedBadgeIndex(undefined);
+              }}
+            ></Button>
+          )}
+          <Button size=\\"small\\" variation=\\"link\\" onClick={addItem}>
+            {selectedBadgeIndex !== undefined ? \\"Save\\" : \\"Add\\"}
+          </Button>
+        </Flex>
+      )}
+      {arraySection}
+    </React.Fragment>
+  );
+}
+export default function CommentUpdateForm(props) {
+  const {
+    id: idProp,
+    comment: commentModelProp,
+    onSuccess,
+    onError,
+    onSubmit,
+    onValidate,
+    onChange,
+    overrides,
+    ...rest
+  } = props;
+  const initialValues = {
+    content: \\"\\",
+    postID: undefined,
+    Post: undefined,
+    post: \\"\\",
+  };
+  const [content, setContent] = React.useState(initialValues.content);
+  const [postID, setPostID] = React.useState(initialValues.postID);
+  const [postIDLoading, setPostIDLoading] = React.useState(false);
+  const [postIDRecords, setPostIDRecords] = React.useState([]);
+  const [selectedPostIDRecords, setSelectedPostIDRecords] = React.useState([]);
+  const [Post, setPost] = React.useState(initialValues.Post);
+  const [PostLoading, setPostLoading] = React.useState(false);
+  const [PostRecords, setPostRecords] = React.useState([]);
+  const [post1, setPost1] = React.useState(initialValues.post);
+  const autocompleteLength = 10;
+  const [errors, setErrors] = React.useState({});
+  const resetStateValues = () => {
+    const cleanValues = commentRecord
+      ? { ...initialValues, ...commentRecord, postID, Post }
+      : initialValues;
+    setContent(cleanValues.content);
+    setPostID(cleanValues.postID);
+    setCurrentPostIDValue(undefined);
+    setCurrentPostIDDisplayValue(\\"\\");
+    setPost(cleanValues.Post);
+    setCurrentPostValue(undefined);
+    setCurrentPostDisplayValue(\\"\\");
+    setPost1(cleanValues.post);
+    setErrors({});
+  };
+  const [commentRecord, setCommentRecord] = React.useState(commentModelProp);
+  React.useEffect(() => {
+    const queryData = async () => {
+      const record = idProp
+        ? (
+            await client.graphql({
+              query: getComment.replaceAll(\\"__typename\\", \\"\\"),
+              variables: { id: idProp },
+            })
+          )?.data?.getComment
+        : commentModelProp;
+      const postIDRecord = record ? record.postID : undefined;
+      const postRecord = postIDRecord
+        ? (
+            await client.graphql({
+              query: getPost.replaceAll(\\"__typename\\", \\"\\"),
+              variables: { id: postIDRecord },
+            })
+          )?.data?.getPost
+        : undefined;
+      setPostID(postIDRecord);
+      setSelectedPostIDRecords([postRecord]);
+      const PostRecord = record ? await record.Post : undefined;
+      setPost(PostRecord);
+      setCommentRecord(record);
+    };
+    queryData();
+  }, [idProp, commentModelProp]);
+  React.useEffect(resetStateValues, [commentRecord, postID, Post]);
+  const [currentPostIDDisplayValue, setCurrentPostIDDisplayValue] =
+    React.useState(\\"\\");
+  const [currentPostIDValue, setCurrentPostIDValue] = React.useState(undefined);
+  const postIDRef = React.createRef();
+  const [currentPostDisplayValue, setCurrentPostDisplayValue] =
+    React.useState(\\"\\");
+  const [currentPostValue, setCurrentPostValue] = React.useState(undefined);
+  const PostRef = React.createRef();
+  const getIDValue = {
+    Post: (r) => JSON.stringify({ id: r?.id }),
+  };
+  const PostIdSet = new Set(
+    Array.isArray(Post)
+      ? Post.map((r) => getIDValue.Post?.(r))
+      : getIDValue.Post?.(Post)
+  );
+  const getDisplayValue = {
+    postID: (r) => \`\${r?.title ? r?.title + \\" - \\" : \\"\\"}\${r?.id}\`,
+    Post: (r) => \`\${r?.title ? r?.title + \\" - \\" : \\"\\"}\${r?.id}\`,
+  };
+  const validations = {
+    content: [],
+    postID: [{ type: \\"Required\\" }],
+    Post: [],
+    post: [],
+  };
+  const runValidationTasks = async (
+    fieldName,
+    currentValue,
+    getDisplayValue
+  ) => {
+    const value =
+      currentValue && getDisplayValue
+        ? getDisplayValue(currentValue)
+        : currentValue;
+    let validationResponse = validateField(value, validations[fieldName]);
+    const customValidator = fetchByPath(onValidate, fieldName);
+    if (customValidator) {
+      validationResponse = await customValidator(value, validationResponse);
+    }
+    setErrors((errors) => ({ ...errors, [fieldName]: validationResponse }));
+    return validationResponse;
+  };
+  const fetchPostIDRecords = async (value) => {
+    setPostIDLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [{ title: { contains: value } }, { id: { contains: value } }],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await client.graphql({
+          query: listPosts.replaceAll(\\"__typename\\", \\"\\"),
+          variables,
+        })
+      )?.data?.listPosts?.items;
+      var loaded = result.filter((item) => postID !== item.id);
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setPostIDRecords(newOptions.slice(0, autocompleteLength));
+    setPostIDLoading(false);
+  };
+  const fetchPostRecords = async (value) => {
+    setPostLoading(true);
+    const newOptions = [];
+    let newNext = \\"\\";
+    while (newOptions.length < autocompleteLength && newNext != null) {
+      const variables = {
+        limit: autocompleteLength * 5,
+        filter: {
+          or: [{ title: { contains: value } }, { id: { contains: value } }],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await client.graphql({
+          query: listPosts.replaceAll(\\"__typename\\", \\"\\"),
+          variables,
+        })
+      )?.data?.listPosts?.items;
+      var loaded = result.filter(
+        (item) => !PostIdSet.has(getIDValue.Post?.(item))
+      );
+      newOptions.push(...loaded);
+      newNext = result.nextToken;
+    }
+    setPostRecords(newOptions.slice(0, autocompleteLength));
+    setPostLoading(false);
+  };
+  React.useEffect(() => {
+    fetchPostIDRecords(\\"\\");
+    fetchPostRecords(\\"\\");
+  }, []);
+  return (
+    <Grid
+      as=\\"form\\"
+      rowGap=\\"15px\\"
+      columnGap=\\"15px\\"
+      padding=\\"20px\\"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        let modelFields = {
+          content: content ?? null,
+          postID,
+          Post: Post ?? null,
+          post: post ?? null,
+        };
+        const validationResponses = await Promise.all(
+          Object.keys(validations).reduce((promises, fieldName) => {
+            if (Array.isArray(modelFields[fieldName])) {
+              promises.push(
+                ...modelFields[fieldName].map((item) =>
+                  runValidationTasks(
+                    fieldName,
+                    item,
+                    getDisplayValue[fieldName]
+                  )
+                )
+              );
+              return promises;
+            }
+            promises.push(
+              runValidationTasks(
+                fieldName,
+                modelFields[fieldName],
+                getDisplayValue[fieldName]
+              )
+            );
+            return promises;
+          }, [])
+        );
+        if (validationResponses.some((r) => r.hasError)) {
+          return;
+        }
+        if (onSubmit) {
+          modelFields = onSubmit(modelFields);
+        }
+        try {
+          Object.entries(modelFields).forEach(([key, value]) => {
+            if (typeof value === \\"string\\" && value === \\"\\") {
+              modelFields[key] = null;
+            }
+          });
+          const modelFieldsToSave = {
+            content: modelFields.content ?? null,
+            postID: modelFields.postID,
+            postCommentsId: modelFields?.Post?.id ?? null,
+          };
+          await client.graphql({
+            query: updateComment.replaceAll(\\"__typename\\", \\"\\"),
+            variables: {
+              input: {
+                id: commentRecord.id,
+                ...modelFieldsToSave,
+              },
+            },
+          });
+          if (onSuccess) {
+            onSuccess(modelFields);
+          }
+        } catch (err) {
+          if (onError) {
+            const messages = err.errors.map((e) => e.message).join(\\"\\\\n\\");
+            onError(modelFields, messages);
+          }
+        }
+      }}
+      {...getOverrideProps(overrides, \\"CommentUpdateForm\\")}
+      {...rest}
+    >
+      <TextField
+        label=\\"Content\\"
+        isRequired={false}
+        isReadOnly={false}
+        value={content}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              content: value,
+              postID,
+              Post,
+              post: post1,
+            };
+            const result = onChange(modelFields);
+            value = result?.content ?? value;
+          }
+          if (errors.content?.hasError) {
+            runValidationTasks(\\"content\\", value);
+          }
+          setContent(value);
+        }}
+        onBlur={() => runValidationTasks(\\"content\\", content)}
+        errorMessage={errors.content?.errorMessage}
+        hasError={errors.content?.hasError}
+        {...getOverrideProps(overrides, \\"content\\")}
+      ></TextField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              content,
+              postID: value,
+              Post,
+              post: post1,
+            };
+            const result = onChange(modelFields);
+            value = result?.postID ?? value;
+          }
+          setPostID(value);
+          setCurrentPostIDValue(undefined);
+        }}
+        currentFieldValue={currentPostIDValue}
+        label={\\"Post id\\"}
+        items={postID ? [postID] : []}
+        hasError={errors?.postID?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(\\"postID\\", currentPostIDValue)
+        }
+        errorMessage={errors?.postID?.errorMessage}
+        getBadgeText={(value) =>
+          value
+            ? getDisplayValue.postID(
+                postIDRecords.find((r) => r.id === value) ??
+                  selectedPostIDRecords.find((r) => r.id === value)
+              )
+            : \\"\\"
+        }
+        setFieldValue={(value) => {
+          setCurrentPostIDDisplayValue(
+            value
+              ? getDisplayValue.postID(
+                  postIDRecords.find((r) => r.id === value) ??
+                    selectedPostIDRecords.find((r) => r.id === value)
+                )
+              : \\"\\"
+          );
+          setCurrentPostIDValue(value);
+          const selectedRecord = postIDRecords.find((r) => r.id === value);
+          if (selectedRecord) {
+            setSelectedPostIDRecords([selectedRecord]);
+          }
+        }}
+        inputFieldRef={postIDRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Post id\\"
+          isRequired={true}
+          isReadOnly={false}
+          placeholder=\\"Search Post\\"
+          value={currentPostIDDisplayValue}
+          options={postIDRecords
+            .filter(
+              (r, i, arr) =>
+                arr.findIndex((member) => member?.id === r?.id) === i
+            )
+            .map((r) => ({
+              id: r?.id,
+              label: getDisplayValue.postID?.(r),
+            }))}
+          isLoading={postIDLoading}
+          onSelect={({ id, label }) => {
+            setCurrentPostIDValue(id);
+            setCurrentPostIDDisplayValue(label);
+            runValidationTasks(\\"postID\\", label);
+          }}
+          onClear={() => {
+            setCurrentPostIDDisplayValue(\\"\\");
+          }}
+          defaultValue={postID}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchPostIDRecords(value);
+            if (errors.postID?.hasError) {
+              runValidationTasks(\\"postID\\", value);
+            }
+            setCurrentPostIDDisplayValue(value);
+            setCurrentPostIDValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"postID\\", currentPostIDValue)}
+          errorMessage={errors.postID?.errorMessage}
+          hasError={errors.postID?.hasError}
+          ref={postIDRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"postID\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <ArrayField
+        lengthLimit={1}
+        onChange={async (items) => {
+          let value = items[0];
+          if (onChange) {
+            const modelFields = {
+              content,
+              postID,
+              Post: value,
+              post: post1,
+            };
+            const result = onChange(modelFields);
+            value = result?.Post ?? value;
+          }
+          setPost(value);
+          setCurrentPostValue(undefined);
+          setCurrentPostDisplayValue(\\"\\");
+        }}
+        currentFieldValue={currentPostValue}
+        label={\\"Post\\"}
+        items={Post ? [Post] : []}
+        hasError={errors?.Post?.hasError}
+        runValidationTasks={async () =>
+          await runValidationTasks(\\"Post\\", currentPostValue)
+        }
+        errorMessage={errors?.Post?.errorMessage}
+        getBadgeText={getDisplayValue.Post}
+        setFieldValue={(model) => {
+          setCurrentPostDisplayValue(model ? getDisplayValue.Post(model) : \\"\\");
+          setCurrentPostValue(model);
+        }}
+        inputFieldRef={PostRef}
+        defaultFieldValue={\\"\\"}
+      >
+        <Autocomplete
+          label=\\"Post\\"
+          isRequired={false}
+          isReadOnly={false}
+          placeholder=\\"Search Post\\"
+          value={currentPostDisplayValue}
+          options={PostRecords.filter(
+            (r) => !PostIdSet.has(getIDValue.Post?.(r))
+          ).map((r) => ({
+            id: getIDValue.Post?.(r),
+            label: getDisplayValue.Post?.(r),
+          }))}
+          isLoading={PostLoading}
+          onSelect={({ id, label }) => {
+            setCurrentPostValue(
+              PostRecords.find((r) =>
+                Object.entries(JSON.parse(id)).every(
+                  ([key, value]) => r[key] === value
+                )
+              )
+            );
+            setCurrentPostDisplayValue(label);
+            runValidationTasks(\\"Post\\", label);
+          }}
+          onClear={() => {
+            setCurrentPostDisplayValue(\\"\\");
+          }}
+          defaultValue={Post}
+          onChange={(e) => {
+            let { value } = e.target;
+            fetchPostRecords(value);
+            if (errors.Post?.hasError) {
+              runValidationTasks(\\"Post\\", value);
+            }
+            setCurrentPostDisplayValue(value);
+            setCurrentPostValue(undefined);
+          }}
+          onBlur={() => runValidationTasks(\\"Post\\", currentPostDisplayValue)}
+          errorMessage={errors.Post?.errorMessage}
+          hasError={errors.Post?.hasError}
+          ref={PostRef}
+          labelHidden={true}
+          {...getOverrideProps(overrides, \\"Post\\")}
+        ></Autocomplete>
+      </ArrayField>
+      <TextField
+        label=\\"Label\\"
+        value={post1}
+        onChange={(e) => {
+          let { value } = e.target;
+          if (onChange) {
+            const modelFields = {
+              content,
+              postID,
+              Post,
+              post: value,
+            };
+            const result = onChange(modelFields);
+            value = result?.post ?? value;
+          }
+          if (errors.post?.hasError) {
+            runValidationTasks(\\"post\\", value);
+          }
+          setPost1(value);
+        }}
+        onBlur={() => runValidationTasks(\\"post\\", post1)}
+        errorMessage={errors.post?.errorMessage}
+        hasError={errors.post?.hasError}
+        {...getOverrideProps(overrides, \\"post\\")}
+      ></TextField>
+      <Flex
+        justifyContent=\\"space-between\\"
+        {...getOverrideProps(overrides, \\"CTAFlex\\")}
+      >
+        <Button
+          children=\\"Reset\\"
+          type=\\"reset\\"
+          onClick={(event) => {
+            event.preventDefault();
+            resetStateValues();
+          }}
+          isDisabled={!(idProp || commentModelProp)}
+          {...getOverrideProps(overrides, \\"ResetButton\\")}
+        ></Button>
+        <Flex
+          gap=\\"15px\\"
+          {...getOverrideProps(overrides, \\"RightAlignCTASubFlex\\")}
+        >
+          <Button
+            children=\\"Submit\\"
+            type=\\"submit\\"
+            variation=\\"primary\\"
+            isDisabled={
+              !(idProp || commentModelProp) ||
+              Object.values(errors).some((e) => e?.hasError)
+            }
+            {...getOverrideProps(overrides, \\"SubmitButton\\")}
+          ></Button>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+"
+`;
+
+exports[`amplify form renderer tests GraphQL form tests should generate an update form with hasMany relationship without types file - amplify js v6 2`] = `
+"import * as React from \\"react\\";
+import { AutocompleteProps, GridProps, TextFieldProps } from \\"@aws-amplify/ui-react\\";
+import { EscapeHatchProps } from \\"@aws-amplify/ui-react/internal\\";
+export declare type ValidationResponse = {
+    hasError: boolean;
+    errorMessage?: string;
+};
+export declare type ValidationFunction<T> = (value: T, validationResponse: ValidationResponse) => ValidationResponse | Promise<ValidationResponse>;
+export declare type CommentUpdateFormInputValues = {
+    content?: string;
+    postID?: string;
+    Post?: any;
+    post?: string;
+};
+export declare type CommentUpdateFormValidationValues = {
+    content?: ValidationFunction<string>;
+    postID?: ValidationFunction<string>;
+    Post?: ValidationFunction<any>;
+    post?: ValidationFunction<string>;
+};
+export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
+export declare type CommentUpdateFormOverridesProps = {
+    CommentUpdateFormGrid?: PrimitiveOverrideProps<GridProps>;
+    content?: PrimitiveOverrideProps<TextFieldProps>;
+    postID?: PrimitiveOverrideProps<AutocompleteProps>;
+    Post?: PrimitiveOverrideProps<AutocompleteProps>;
+    post?: PrimitiveOverrideProps<TextFieldProps>;
+} & EscapeHatchProps;
+export declare type CommentUpdateFormProps = React.PropsWithChildren<{
+    overrides?: CommentUpdateFormOverridesProps | undefined | null;
+} & {
+    id?: string;
+    comment?: any;
     onSubmit?: (fields: CommentUpdateFormInputValues) => CommentUpdateFormInputValues;
     onSuccess?: (fields: CommentUpdateFormInputValues) => void;
     onError?: (fields: CommentUpdateFormInputValues, errorMessage: string) => void;

--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react.test.ts.snap
@@ -151,6 +151,59 @@ export default function UpdateCustomerButton(
 }
 `;
 
+exports[`amplify render tests actions GraphQL DataStoreCreateItem - amplify js v6 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { generateClient } from \\"aws-amplify/api\\";
+import { createCustomer } from \\"../graphql/mutations\\";
+import { Customer } from \\"../API\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { Button, ButtonProps } from \\"@aws-amplify/ui-react\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type CreateCustomerButtonOverridesProps = {
+  CreateCustomerButton?: PrimitiveOverrideProps<ButtonProps>;
+} & EscapeHatchProps;
+export type CreateCustomerButtonProps = React.PropsWithChildren<
+  Partial<ButtonProps> & {
+    overrides?: CreateCustomerButtonOverridesProps | undefined | null;
+  }
+>;
+const client = generateClient();
+export default function CreateCustomerButton(
+  props: CreateCustomerButtonProps
+): React.ReactElement {
+  const { overrides, ...rest } = props;
+  const createCustomerButtonOnClick = async () => {
+    await client.graphql({
+      query: createCustomer.replaceAll(\\"__typename\\", \\"\\"),
+      variables: {
+        input: {
+          firstName: \\"Din\\",
+          lastName: \\"Djarin\\",
+        },
+      },
+    });
+  };
+  return (
+    /* @ts-ignore: TS2322 */
+    <Button
+      children=\\"Create\\"
+      onClick={() => {
+        createCustomerButtonOnClick();
+      }}
+      {...getOverrideProps(overrides, \\"CreateCustomerButton\\")}
+      {...rest}
+    ></Button>
+  );
+}
+"
+`;
+
 exports[`amplify render tests actions GraphQL DataStoreCreateItem 1`] = `
 Object {
   "componentText": "/* eslint-disable */
@@ -991,6 +1044,208 @@ export default function AuthorProfileCollection(
               key={item.id}
               {...(overrideItems && overrideItems({ item, index }))}
             ></AuthorProfile>
+          );
+        }}
+      </Collection>
+      {isApiPagination && isPaginated && (
+        <Pagination
+          currentPage={pageIndex}
+          totalPages={maxViewed}
+          hasMorePages={hasMorePages}
+          onNext={handleNextPage}
+          onPrevious={handlePreviousPage}
+          onChange={jumpToPage}
+        />
+      )}
+    </div>
+  );
+}
+"
+`;
+
+exports[`amplify render tests collection GraphQL should render collection with data binding - amplify js v6 1`] = `
+"/* eslint-disable */
+import * as React from \\"react\\";
+import { UserPreferences } from \\"../API\\";
+import { listUserPreferences, listUsers } from \\"../graphql/queries\\";
+import {
+  EscapeHatchProps,
+  getOverrideProps,
+  useDataStoreBinding,
+} from \\"@aws-amplify/ui-react/internal\\";
+import { generateClient } from \\"aws-amplify/api\\";
+import {
+  Button,
+  ButtonProps,
+  Collection,
+  CollectionProps,
+  Flex,
+  FlexProps,
+  Pagination,
+  Placeholder,
+} from \\"@aws-amplify/ui-react\\";
+import { MyFlexProps } from \\"./MyFlex\\";
+
+export declare type PrimitiveOverrideProps<T> = Partial<T> &
+  React.DOMAttributes<HTMLDivElement>;
+export declare type CollectionOfCustomButtonsOverridesProps = {
+  CollectionOfCustomButtons?: PrimitiveOverrideProps<CollectionProps>;
+  MyFlex?: PrimitiveOverrideProps<FlexProps>;
+  MyButton?: PrimitiveOverrideProps<ButtonProps>;
+} & EscapeHatchProps;
+export type CollectionOfCustomButtonsProps = React.PropsWithChildren<
+  Partial<CollectionProps<any>> & {
+    width?: Number;
+    backgroundColor?: String;
+    buttonColor?: UserPreferences;
+    buttonEnabled?: UserPreferences;
+    items?: any[];
+    overrideItems?: (collectionItem: {
+      item: any;
+      index: number;
+    }) => MyFlexProps;
+  } & {
+    overrides?: CollectionOfCustomButtonsOverridesProps | undefined | null;
+  }
+>;
+
+const nextToken = {};
+const apiCache = {};
+const client = generateClient();
+export default function CollectionOfCustomButtons(
+  props: CollectionOfCustomButtonsProps
+): React.ReactElement {
+  const {
+    width,
+    backgroundColor,
+    buttonColor: buttonColorProp,
+    buttonEnabled: buttonEnabledProp,
+    items: itemsProp,
+    overrideItems,
+    overrides,
+    ...rest
+  } = props;
+  const [pageIndex, setPageIndex] = React.useState(1);
+  const [hasMorePages, setHasMorePages] = React.useState(true);
+  const [items, setItems] = React.useState([]);
+  const [isApiPagination, setIsApiPagination] = React.useState(false);
+  const [instanceKey, setInstanceKey] = React.useState(\\"newGuid\\");
+  const [loading, setLoading] = React.useState(true);
+  const [maxViewed, setMaxViewed] = React.useState(1);
+  const pageSize = 6;
+  const isPaginated = true;
+  React.useEffect(() => {
+    nextToken[instanceKey] = \\"\\";
+    apiCache[instanceKey] = [];
+  }, [instanceKey]);
+  React.useEffect(() => {
+    setIsApiPagination(!!!itemsProp);
+  }, [itemsProp]);
+  const handlePreviousPage = () => {
+    setPageIndex(pageIndex - 1);
+  };
+  const handleNextPage = () => {
+    setPageIndex(pageIndex + 1);
+  };
+  const jumpToPage = (pageNum?: number) => {
+    setPageIndex(pageNum!);
+  };
+  const loadPage = async (page: number) => {
+    const cacheUntil = page * pageSize + 1;
+    const newCache = apiCache[instanceKey].slice();
+    let newNext = nextToken[instanceKey];
+    while ((newCache.length < cacheUntil || !isPaginated) && newNext != null) {
+      setLoading(true);
+      const variables: any = {
+        limit: pageSize,
+        filter: {
+          and: [
+            { age: { gt: \\"10\\" } },
+            { lastName: { beginsWith: \\"L\\" } },
+            {
+              and: [
+                { date: { ge: \\"2022-03-10\\" } },
+                { date: { le: \\"2023-03-11\\" } },
+              ],
+            },
+          ],
+        },
+      };
+      if (newNext) {
+        variables[\\"nextToken\\"] = newNext;
+      }
+      const result = (
+        await client.graphql({
+          query: listUsers.replaceAll(\\"__typename\\", \\"\\"),
+          variables,
+        })
+      ).data.listUsers;
+      newCache.push(...result.items);
+      newNext = result.nextToken;
+    }
+    const cacheSlice = isPaginated
+      ? newCache.slice((page - 1) * pageSize, page * pageSize)
+      : newCache;
+    setItems(cacheSlice);
+    setHasMorePages(!!newNext);
+    setLoading(false);
+    apiCache[instanceKey] = newCache;
+    nextToken[instanceKey] = newNext;
+  };
+  React.useEffect(() => {
+    loadPage(pageIndex);
+  }, [pageIndex]);
+  React.useEffect(() => {
+    setMaxViewed(Math.max(maxViewed, pageIndex));
+  }, [pageIndex, maxViewed, setMaxViewed]);
+  const buttonColorFilterObj = { userID: { eq: \\"user@email.com\\" } };
+  const buttonColorDataStore = client.graphql({
+    query: listUserPreferences.replaceAll(\\"__typename\\", \\"\\"),
+    variables: { ...buttonColorFilterObj },
+  }).items[0];
+  const buttonColor =
+    buttonColorProp !== undefined ? buttonColorProp : buttonColorDataStore;
+  const buttonEnabledFilterObj = {
+    and: [{ date: { ge: \\"2022-03-10\\" } }, { date: { le: \\"2023-03-11\\" } }],
+  };
+  const buttonEnabledDataStore = client.graphql({
+    query: listUserPreferences.replaceAll(\\"__typename\\", \\"\\"),
+    variables: { ...buttonEnabledFilterObj },
+  }).items[0];
+  const buttonEnabled =
+    buttonEnabledProp !== undefined
+      ? buttonEnabledProp
+      : buttonEnabledDataStore;
+  return (
+    /* @ts-ignore: TS2322 */
+    <div>
+      <Collection
+        type=\\"list\\"
+        gap=\\"1.5rem\\"
+        backgroundColor={backgroundColor}
+        itemsPerPage={pageSize}
+        isPaginated={!isApiPagination && isPaginated}
+        items={itemsProp || (loading ? new Array(pageSize).fill({}) : items)}
+        {...getOverrideProps(overrides, \\"CollectionOfCustomButtons\\")}
+        {...rest}
+      >
+        {(item, index) => {
+          if (loading) {
+            return <Placeholder key={index} size=\\"large\\" />;
+          }
+          return (
+            <Flex
+              key={item.id}
+              {...(overrideItems && overrideItems({ item, index }))}
+            >
+              <Button
+                labelWidth={width}
+                backgroundColor={buttonColor?.favoriteColor}
+                disabled={isDisabled}
+                children={item.username || \\"hspain@gmail.com\\"}
+                {...(overrideItems && overrideItems({ item, index }))}
+              ></Button>
+            </Flex>
           );
         }}
       </Collection>

--- a/packages/codegen-ui-react/lib/__tests__/helpers/index.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/helpers/index.test.ts
@@ -1,0 +1,71 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { getAmplifyJSVersionToRender } from '../../helpers/amplify-js-versioning';
+import { AMPLIFY_JS_V5, AMPLIFY_JS_V6 } from '../../utils/constants';
+
+let isAmplifyJSV6Enabled = false;
+
+describe('Helpers', () => {
+  beforeEach(() => {
+    isAmplifyJSV6Enabled = false;
+  });
+
+  it('should return v5 if aws-amplify dependency is undefined', () => {
+    expect(getAmplifyJSVersionToRender({}, { isAmplifyJSV6Enabled })).toBe(AMPLIFY_JS_V5);
+  });
+
+  it('should return v6 if aws-amplify dependency is v6 but v6 is disabled', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': '^6.0.0' }, { isAmplifyJSV6Enabled })).toBe(AMPLIFY_JS_V6);
+  });
+
+  it('should return v5 if aws-amplify dependency is v5 and v6 is enabled', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': '^5.0.0' }, { isAmplifyJSV6Enabled: true })).toBe(
+      AMPLIFY_JS_V5,
+    );
+  });
+
+  it('should return v5 if aws-amplify dependency is v5', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': '^5.0.2' }, { isAmplifyJSV6Enabled })).toBe(AMPLIFY_JS_V5);
+  });
+
+  it('should return v5 if aws-amplify dependency is latest but v6 is disabled', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': 'latest' }, { isAmplifyJSV6Enabled })).toBe(AMPLIFY_JS_V5);
+  });
+
+  it('should return v6 if aws-amplify dependency is latest and v6 is enabled', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': 'latest' }, { isAmplifyJSV6Enabled: true })).toBe(
+      AMPLIFY_JS_V6,
+    );
+  });
+
+  it('should return v6 if aws-amplify dependency is v6 and v6 is enabled', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': '^6.0.2' }, { isAmplifyJSV6Enabled: true })).toBe(
+      AMPLIFY_JS_V6,
+    );
+  });
+
+  it('should return v5 if aws-amplify dependency is a v5 tagged release', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': '^5.0.2-beta' }, { isAmplifyJSV6Enabled: true })).toBe(
+      AMPLIFY_JS_V5,
+    );
+  });
+
+  it('should return v6 if aws-amplify dependency is a v6 tagged release and v6 is enabled', () => {
+    expect(getAmplifyJSVersionToRender({ 'aws-amplify': '^6.0.2-beta' }, { isAmplifyJSV6Enabled: true })).toBe(
+      AMPLIFY_JS_V6,
+    );
+  });
+});

--- a/packages/codegen-ui-react/lib/__tests__/react-studio-dependency-provider.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/react-studio-dependency-provider.test.ts
@@ -19,6 +19,9 @@ import { ReactRequiredDependencyProvider } from '..';
 describe('ReactStudioDependencyProvider', () => {
   const requiredDependencies = new ReactRequiredDependencyProvider().getRequiredDependencies(false);
   const requiredDependenciesWithStorageManager = new ReactRequiredDependencyProvider().getRequiredDependencies(true);
+  const requiredDependenciesWithAmplifyJSV6 = new ReactRequiredDependencyProvider().getRequiredDependencies(true, {
+    dependencies: { 'aws-amplify': '^6.0.0' },
+  });
 
   describe('getRequiredDependencies', () => {
     it('has required dependencies', () => {
@@ -48,6 +51,14 @@ describe('ReactStudioDependencyProvider', () => {
     it('includes ui-react-storage if user is using StorageManager', () => {
       expect(
         requiredDependenciesWithStorageManager.filter((dep) => dep.dependencyName === '@aws-amplify/ui-react-storage'),
+      ).toBeTruthy();
+    });
+
+    it('includes amplify js v6 semver range', () => {
+      expect(
+        requiredDependenciesWithAmplifyJSV6.filter(
+          (dep) => dep.supportedSemVerPattern === '>=6.0.0 <7.0.0' && dep.dependencyName === '@aws-amplify/ui-react',
+        ),
       ).toBeTruthy();
     });
   });

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -733,6 +733,24 @@ describe('amplify form renderer tests', () => {
       expect(declaration).toMatchSnapshot();
     });
 
+    it('should generate a create form - amplify js v6', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/post-datastore-create',
+        'datastore/post',
+        { ...defaultCLIRenderConfig, ...rendererConfigWithGraphQL, dependencies: { 'aws-amplify': '^6.0.0' } },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      expect(componentText).not.toContain('import { API } from "aws-amplify";');
+      expect(componentText).not.toContain(`await API.graphql`);
+      expect(componentText).toContain('import { generateClient } from "aws-amplify/api";');
+      expect(componentText).toContain(`const client = generateClient();`);
+      expect(componentText).toContain(`await client.graphql`);
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
+
     it('should generate a update form without relationships', () => {
       const { componentText, declaration } = generateWithAmplifyFormRenderer(
         'forms/post-datastore-update',
@@ -751,6 +769,34 @@ describe('amplify form renderer tests', () => {
 
       // should call updatePost mutation onSubmit
       expect(componentText).toContain(`await API.graphql`);
+      expect(componentText).toContain(`query: updatePost.replaceAll("__typename", ""),`);
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
+
+    it('should generate a update form without relationships - amplify js v6', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/post-datastore-update',
+        'datastore/post',
+        { ...defaultCLIRenderConfig, ...rendererConfigWithGraphQL, dependencies: { 'aws-amplify': '^6.0.0' } },
+        { isNonModelSupported: true, isRelationshipSupported: false },
+      );
+
+      // check import for graphql operations
+      expect(componentText).not.toContain('import { API } from "aws-amplify";');
+      expect(componentText).not.toContain(`await API.graphql`);
+
+      expect(componentText).toContain('import { generateClient } from "aws-amplify/api";');
+      expect(componentText).toContain(`const client = generateClient();`);
+      expect(componentText).toContain('import { getPost } from "../graphql/queries";');
+      expect(componentText).toContain('import { updatePost } from "../graphql/mutations";');
+
+      // should not have DataStore.save call
+      expect(componentText).not.toContain('await DataStore.save(');
+
+      // should call updatePost mutation onSubmit
+      expect(componentText).toContain(`await client.graphql`);
       expect(componentText).toContain(`query: updatePost.replaceAll("__typename", ""),`);
 
       expect(componentText).toMatchSnapshot();
@@ -802,6 +848,28 @@ describe('amplify form renderer tests', () => {
       expect(componentText).not.toContain('DataStore');
 
       expect(componentText).toContain('await API.graphql({');
+      expect(componentText).toContain('query: updateComment');
+
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
+
+    it('should generate an update form with hasMany relationship without types file - amplify js v6', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/relationships/update-comment',
+        'datastore/relationships/has-many-comment',
+        { ...defaultCLIRenderConfig, ...noTypesFileConfig, dependencies: { 'aws-amplify': '^6.0.0' } },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      // check for import statement for graphql operation
+      expect(componentText).not.toContain('DataStore');
+      expect(componentText).not.toContain('import { API } from "aws-amplify";');
+      expect(componentText).not.toContain(`await API.graphql`);
+
+      expect(componentText).toContain('import { generateClient } from "aws-amplify/api";');
+      expect(componentText).toContain(`const client = generateClient();`);
+      expect(componentText).toContain('await client.graphql({');
       expect(componentText).toContain('query: updateComment');
 
       expect(componentText).toMatchSnapshot();
@@ -1119,6 +1187,25 @@ describe('amplify form renderer tests', () => {
 
       expect(componentText).not.toContain('cannot be unlinked because');
       expect(componentText).not.toContain('cannot be linked to ');
+      expect(componentText).toMatchSnapshot();
+      expect(declaration).toMatchSnapshot();
+    });
+
+    it('should 1:1 relationships without types file path - Create amplify js v6', () => {
+      const { componentText, declaration } = generateWithAmplifyFormRenderer(
+        'forms/owner-dog-create',
+        'datastore/dog-owner-required',
+        { ...defaultCLIRenderConfig, ...noTypesFileConfig, dependencies: { 'aws-amplify': '^6.0.0' } },
+        { isNonModelSupported: true, isRelationshipSupported: true },
+      );
+
+      expect(componentText).not.toContain('import { API } from "aws-amplify";');
+      expect(componentText).not.toContain(`await API.graphql`);
+      expect(componentText).not.toContain('cannot be unlinked because');
+      expect(componentText).not.toContain('cannot be linked to ');
+      expect(componentText).toContain('import { generateClient } from "aws-amplify/api";');
+      expect(componentText).toContain(`const client = generateClient();`);
+      expect(componentText).toContain('await client.graphql({');
       expect(componentText).toMatchSnapshot();
       expect(declaration).toMatchSnapshot();
     });

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react.test.ts
@@ -198,6 +198,19 @@ describe('amplify render tests', () => {
         expect(generatedCode.componentText).toMatchSnapshot();
       });
 
+      it('should render collection with data binding - amplify js v6', () => {
+        const { componentText } = generateWithAmplifyRenderer('collectionWithBinding', {
+          ...rendererConfigWithGraphQL,
+          dependencies: { 'aws-amplify': '^6.0.0' },
+        });
+        expect(componentText).not.toContain('import { API } from "aws-amplify";');
+        expect(componentText).not.toContain(`await API.graphql`);
+        expect(componentText).toContain('import { generateClient } from "aws-amplify/api";');
+        expect(componentText).toContain(`await client.graphql`);
+
+        expect(componentText).toMatchSnapshot();
+      });
+
       it('should render collection without data binding', () => {
         const generatedCode = generateWithAmplifyRenderer('collectionWithoutBinding', rendererConfigWithGraphQL);
         expect(generatedCode.componentText).toMatchSnapshot();
@@ -448,6 +461,18 @@ describe('amplify render tests', () => {
         expect(
           generateWithAmplifyRenderer('workflow/dataStoreCreateItem', rendererConfigWithGraphQL),
         ).toMatchSnapshot();
+      });
+
+      it('DataStoreCreateItem - amplify js v6', () => {
+        const { componentText } = generateWithAmplifyRenderer('workflow/dataStoreCreateItem', {
+          ...rendererConfigWithGraphQL,
+          dependencies: { 'aws-amplify': '^6.0.0' },
+        });
+        expect(componentText).toMatchSnapshot();
+        expect(componentText).not.toContain('import { API } from "aws-amplify";');
+        expect(componentText).not.toContain(`await API.graphql`);
+        expect(componentText).toContain('import { generateClient } from "aws-amplify/api";');
+        expect(componentText).toContain(`await client.graphql`);
       });
 
       it('DataStoreUpdateItem', () => {

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
@@ -36,6 +36,7 @@ import { buildOpeningElementProperties } from '../react-component-render-helper'
 import { ImportCollection, ImportValue } from '../imports';
 import { DataApiKind, ReactRenderConfig } from '../react-render-config';
 import { defaultRenderConfig } from '../react-studio-template-renderer-helper';
+import { getAmplifyJSAPIImport } from '../helpers/amplify-js-versioning';
 
 export default class CollectionRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -57,7 +58,9 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
     this.importCollection.addImport('@aws-amplify/ui-react', this.component.componentType);
 
     if (this.renderConfig.apiConfiguration?.dataApi === 'GraphQL') {
-      this.importCollection.addMappedImport(ImportValue.API, ImportValue.PAGINATION, ImportValue.PLACEHOLDER);
+      const mappedImport = getAmplifyJSAPIImport(this.renderConfig.dependencies);
+      this.importCollection.addMappedImport(mappedImport);
+      this.importCollection.addMappedImport(ImportValue.PAGINATION, ImportValue.PLACEHOLDER);
     }
 
     return element;

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -34,7 +34,7 @@ import {
 } from 'typescript';
 import { ReactComponentRenderer } from '../react-component-renderer';
 import { buildFormLayoutProperties, buildOpeningElementProperties } from '../react-component-render-helper';
-import { ImportCollection, ImportSource, ImportValue } from '../imports';
+import { ImportCollection, ImportSource } from '../imports';
 import { buildExpression } from '../forms';
 import { onSubmitValidationRun, buildModelFieldObject } from '../forms/form-renderer-helper';
 import { hasTokenReference } from '../utils/forms/layout-helpers';
@@ -43,6 +43,7 @@ import { isModelDataType } from '../forms/form-renderer-helper/render-checkers';
 import { replaceEmptyStringStatement } from '../forms/form-renderer-helper/cta-props';
 import { ReactRenderConfig } from '../react-render-config';
 import { defaultRenderConfig } from '../react-studio-template-renderer-helper';
+import { getAmplifyJSAPIImport } from '../helpers/amplify-js-versioning';
 
 export default class FormRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -71,7 +72,8 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
 
     this.importCollection.addImport('@aws-amplify/ui-react', this.component.componentType);
     if (this.form.dataType.dataSourceType === 'DataStore' && this.isRenderingGraphQL()) {
-      this.importCollection.addMappedImport(ImportValue.API);
+      const mappedImport = getAmplifyJSAPIImport();
+      this.importCollection.addMappedImport(mappedImport);
     } else if (this.form.dataType.dataSourceType === 'DataStore') {
       this.importCollection.addImport('aws-amplify', 'DataStore');
     }
@@ -166,6 +168,7 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
                 dataSchemaMetadata,
                 this.importCollection,
                 'apiConfiguration' in this.renderConfig ? this.renderConfig.apiConfiguration?.dataApi : undefined,
+                this.renderConfig.dependencies,
               ),
               // call onSuccess hook if it exists
               factory.createIfStatement(

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/bidirectional-relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/bidirectional-relationship.ts
@@ -91,6 +91,7 @@ function unlinkModelRecordExpression({
   associatedFields,
   importCollection,
   dataApi,
+  renderConfigDependencies,
 }: {
   modelName: string;
   primaryKeys: string[];
@@ -99,6 +100,7 @@ function unlinkModelRecordExpression({
   associatedFields: string[];
   importCollection: ImportCollection;
   dataApi?: DataApiKind;
+  renderConfigDependencies?: { [key: string]: string };
 }) {
   if (dataApi === 'GraphQL') {
     const inputs = [
@@ -117,7 +119,16 @@ function unlinkModelRecordExpression({
       factory.createCallExpression(
         factory.createPropertyAccessExpression(factory.createIdentifier('promises'), factory.createIdentifier('push')),
         undefined,
-        [getGraphqlCallExpression(ActionType.UPDATE, modelName, importCollection, { inputs })],
+        [
+          getGraphqlCallExpression(
+            ActionType.UPDATE,
+            modelName,
+            importCollection,
+            { inputs },
+            undefined,
+            renderConfigDependencies,
+          ),
+        ],
       ),
     );
   }
@@ -267,6 +278,7 @@ function linkModelRecordExpression({
   associatedPrimaryKeys,
   associatedFieldsBiDirectionalWith,
   dataApi,
+  renderConfigDependencies,
 }: {
   importedRelatedModelName: string;
   relatedRecordToLink: string;
@@ -278,6 +290,7 @@ function linkModelRecordExpression({
   associatedPrimaryKeys: string[];
   associatedFieldsBiDirectionalWith: string[];
   dataApi?: DataApiKind;
+  renderConfigDependencies?: { [key: string]: string };
 }) {
   if (dataApi === 'GraphQL') {
     const inputs = [
@@ -299,7 +312,16 @@ function linkModelRecordExpression({
       factory.createCallExpression(
         factory.createPropertyAccessExpression(factory.createIdentifier('promises'), factory.createIdentifier('push')),
         undefined,
-        [getGraphqlCallExpression(ActionType.UPDATE, importedRelatedModelName, importCollection, { inputs })],
+        [
+          getGraphqlCallExpression(
+            ActionType.UPDATE,
+            importedRelatedModelName,
+            importCollection,
+            { inputs },
+            undefined,
+            renderConfigDependencies,
+          ),
+        ],
       ),
     );
   }
@@ -374,6 +396,7 @@ export function getBiDirectionalRelationshipStatements({
   savedRecordName,
   thisModelPrimaryKeys,
   dataApi,
+  renderConfigDependencies,
 }: {
   formActionType: 'create' | 'update';
   dataSchema: GenericDataSchema;
@@ -383,6 +406,7 @@ export function getBiDirectionalRelationshipStatements({
   savedRecordName: string;
   thisModelPrimaryKeys: string[];
   dataApi?: DataApiKind;
+  renderConfigDependencies?: { [key: string]: string };
 }) {
   const getFieldBiDirectionalWithReturnValue = getFieldBiDirectionalWith({
     modelName,
@@ -474,6 +498,7 @@ export function getBiDirectionalRelationshipStatements({
                     associatedFields: associatedFieldsBiDirectionalWith,
                     importCollection,
                     dataApi,
+                    renderConfigDependencies,
                   }),
             ],
             true,
@@ -561,6 +586,7 @@ export function getBiDirectionalRelationshipStatements({
               associatedPrimaryKeys: fieldBiDirectionalWithPrimaryKeys,
               associatedFieldsBiDirectionalWith,
               dataApi,
+              renderConfigDependencies,
             }),
             factory.createVariableStatement(
               undefined,
@@ -605,6 +631,7 @@ export function getBiDirectionalRelationshipStatements({
                         associatedFields,
                         importCollection,
                         dataApi,
+                        renderConfigDependencies,
                       }),
                 ],
                 true,

--- a/packages/codegen-ui-react/lib/helpers/amplify-js-versioning.ts
+++ b/packages/codegen-ui-react/lib/helpers/amplify-js-versioning.ts
@@ -1,0 +1,69 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import semverGte from 'semver/functions/gte';
+import semverValid from 'semver/functions/valid';
+import semverCoerce from 'semver/functions/coerce';
+import { AMPLIFY_JS_V6 } from '../utils/constants';
+import { ImportValue } from '../imports';
+
+export function isAmplifyJSV6RenderingEnabled(): boolean {
+  return false;
+}
+
+export function getLatestAmplifyJSV6RenderingEnabled(
+  isAmplifyJSV6Enabled: boolean = isAmplifyJSV6RenderingEnabled(),
+): string {
+  if (isAmplifyJSV6Enabled) {
+    return '6.0.0';
+  }
+  return '5.0.0';
+}
+
+export function getAmplifyJSVersionToRender(
+  dependencies: { [key: string]: string } = {},
+  { isAmplifyJSV6Enabled }: { isAmplifyJSV6Enabled: boolean } = {
+    isAmplifyJSV6Enabled: isAmplifyJSV6RenderingEnabled(),
+  },
+) {
+  const awsAmplifyVersion = dependencies['aws-amplify'];
+  // semver will error on a 'latest' value so do this first
+  if (awsAmplifyVersion === 'latest') {
+    return getLatestAmplifyJSV6RenderingEnabled(isAmplifyJSV6Enabled);
+  }
+  // Allows to use tagged releases
+  // e.g. semver.valid(semver.coerce('42.6.7.9.3-alpha')) // '42.6.7'
+  const sanitizedVersion = semverValid(semverCoerce(awsAmplifyVersion));
+
+  if (sanitizedVersion) {
+    // check if >= 6
+    if (semverGte(sanitizedVersion, '6.0.0')) {
+      return '6.0.0';
+    }
+  }
+  // If there isn't a version for aws-amplify in the project
+  // then this is an older version of the project not running latest
+  // cli, so default to 5
+  // If there is a version and it's 5 return 5
+  // If the version is 6 but v6 isn't enabled yet, return 5
+  return '5.0.0';
+}
+
+export function getAmplifyJSAPIImport(renderConfigDependencies: { [key: string]: string } = {}) {
+  if (getAmplifyJSVersionToRender(renderConfigDependencies) === AMPLIFY_JS_V6) {
+    return ImportValue.GENERATE_CLIENT;
+  }
+  return ImportValue.API;
+}

--- a/packages/codegen-ui-react/lib/imports/import-collection.ts
+++ b/packages/codegen-ui-react/lib/imports/import-collection.ts
@@ -132,6 +132,10 @@ export class ImportCollection {
     this.#collection.delete(packageImport);
   }
 
+  hasPackage(packageName: string) {
+    return this.#collection.has(packageName);
+  }
+
   getMappedAlias(packageName: string, importName: string) {
     return this.importAlias.get(packageName)?.get(importName) || importName;
   }

--- a/packages/codegen-ui-react/lib/imports/import-mapping.ts
+++ b/packages/codegen-ui-react/lib/imports/import-mapping.ts
@@ -23,6 +23,7 @@ export enum ImportSource {
   LOCAL_SCHEMA = '../models/schema',
   UTILS = './utils',
   AMPLIFY = 'aws-amplify',
+  AMPLIFY_API = 'aws-amplify/api',
 }
 
 export enum ImportValue {
@@ -55,6 +56,7 @@ export enum ImportValue {
   API = 'API',
   PAGINATION = 'Pagination',
   PLACEHOLDER = 'Placeholder',
+  GENERATE_CLIENT = 'generateClient',
 }
 
 export const ImportMapping: Record<ImportValue, ImportSource> = {
@@ -86,4 +88,5 @@ export const ImportMapping: Record<ImportValue, ImportSource> = {
   [ImportValue.API]: ImportSource.AMPLIFY,
   [ImportValue.PAGINATION]: ImportSource.UI_REACT,
   [ImportValue.PLACEHOLDER]: ImportSource.UI_REACT,
+  [ImportValue.GENERATE_CLIENT]: ImportSource.AMPLIFY_API,
 };

--- a/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
+++ b/packages/codegen-ui-react/lib/react-required-dependency-provider.ts
@@ -14,17 +14,23 @@
   limitations under the License.
  */
 import { RequiredDependency, RequiredDependencyProvider } from '@aws-amplify/codegen-ui';
+import { getAmplifyJSVersionToRender } from './helpers/amplify-js-versioning';
+import { AMPLIFY_JS_V5 } from './utils/constants';
 
 type SemVerRequiredDependency = RequiredDependency & {
   supportedSemVerPattern: string;
 };
 
 export class ReactRequiredDependencyProvider extends RequiredDependencyProvider<SemVerRequiredDependency> {
-  getRequiredDependencies(hasStorageManager?: boolean): SemVerRequiredDependency[] {
+  getRequiredDependencies(
+    hasStorageManager?: boolean,
+    config?: { dependencies: { [key: string]: string } },
+  ): SemVerRequiredDependency[] {
+    const amplifyJSVersion = getAmplifyJSVersionToRender(config?.dependencies);
     const dependencies = [
       {
         dependencyName: '@aws-amplify/ui-react',
-        supportedSemVerPattern: '^4.6.0',
+        supportedSemVerPattern: amplifyJSVersion === AMPLIFY_JS_V5 ? '>=4.6.0  <6.0.0' : '>=6.0.0 <7.0.0',
         reason: 'Required to leverage Amplify UI primitives, and Amplify Studio component helper functions.',
       },
       {

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
@@ -314,3 +314,21 @@ export const createHookStatement = (variableName: string, methodName: string, pr
     ),
   );
 };
+
+// const client = generateClient();
+export const getAmplifyJSClientGenerator = () => {
+  return factory.createVariableStatement(
+    undefined,
+    factory.createVariableDeclarationList(
+      [
+        factory.createVariableDeclaration(
+          factory.createIdentifier('client'),
+          undefined,
+          undefined,
+          factory.createCallExpression(factory.createIdentifier('generateClient'), undefined, []),
+        ),
+      ],
+      ts.NodeFlags.Const,
+    ),
+  );
+};

--- a/packages/codegen-ui-react/lib/utils/constants.ts
+++ b/packages/codegen-ui-react/lib/utils/constants.ts
@@ -18,3 +18,7 @@ export const COMPOSITE_PRIMARY_KEY_PROP_NAME = 'id';
 export const STORAGE_FILE_KEY = 'key';
 
 export const STORAGE_FILE_ALGO_TYPE = 'SHA-1';
+
+export const AMPLIFY_JS_V5 = '5.0.0';
+
+export const AMPLIFY_JS_V6 = '6.0.0';

--- a/packages/codegen-ui-react/lib/workflow/action.ts
+++ b/packages/codegen-ui-react/lib/workflow/action.ts
@@ -120,13 +120,14 @@ export function buildUseActionStatement(
   identifier: string,
   importCollection: ImportCollection,
   apiKind: DataApiKind = 'DataStore',
+  renderConfigDependencies?: { [key: string]: string },
 ): Statement {
   if (isMutationAction(action)) {
     return buildMutationActionStatement(componentMetadata, action, identifier);
   }
 
   if (isDataAction(action) && apiKind === 'GraphQL') {
-    return buildGraphqlCallback(componentMetadata, action, identifier, importCollection);
+    return buildGraphqlCallback(componentMetadata, action, identifier, importCollection, renderConfigDependencies);
   }
 
   const actionHookImportValue = getActionHookImportValue(action.action);
@@ -156,6 +157,7 @@ export function buildGraphqlCallback(
   action: DataAction,
   identifier: string,
   importCollection: ImportCollection,
+  renderConfigDependencies?: { [key: string]: string },
 ) {
   const inputKeys = [];
 
@@ -194,6 +196,8 @@ export function buildGraphqlCallback(
                       action.parameters.model,
                       importCollection,
                       { inputs: inputKeys },
+                      undefined,
+                      renderConfigDependencies,
                     ),
                   ),
                 ),

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -28,14 +28,14 @@
     "@types/pluralize": "^0.0.29",
     "@types/react": "^17.0.4",
     "@types/semver": "^7.3.9",
-    "pascalcase": "1.0.0",
-    "semver": "^7.3.5"
+    "pascalcase": "1.0.0"
   },
   "dependencies": {
     "@aws-amplify/codegen-ui": "2.15.9",
     "@typescript/vfs": "~1.3.5",
     "pluralize": "^8.0.0",
-    "typescript": "<=4.5.0"
+    "typescript": "<=4.5.0",
+    "semver": "^7.5.4"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/codegen-ui/lib/required-dependency-provider.ts
+++ b/packages/codegen-ui/lib/required-dependency-provider.ts
@@ -19,5 +19,8 @@ export type RequiredDependency = {
 };
 
 export abstract class RequiredDependencyProvider<DependencyType extends RequiredDependency> {
-  abstract getRequiredDependencies(hasStorageManager?: boolean): DependencyType[];
+  abstract getRequiredDependencies(
+    hasStorageManager?: boolean,
+    config?: { dependencies: { [key: string]: string } },
+  ): DependencyType[];
 }


### PR DESCRIPTION
## Problem

we are updating our renderers to support the new amplify js v6 updates to the API category.

## Solution

The changes involve updating the import statement to 
```
import { generateClient } from "aws-amplify/api";
const client = generateClient();
```
and api graphql operations to 

```
const response = await client.graphql({
      query: mutations.createTodo,
      variables: {
        input: {
          name: `Name ${Date.now()}`,
          description: `Description ${Date.now()}`,
        },
      },
    });
```

## Additional Notes

The change in the api code generation is triggered by passing in a dependencies object to the renderer. In the current state if the dependencies object as a 'aws-amplify' dependency that has a value of >=6.0.0, the v6 API code will be generated. Otherwise, the code will continue to generate the current v5 compatible code.

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
