### PR TITLE
chore(release): v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.16.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.9...v2.16.0) (2023-09-28)
+
+### Bug Fixes
+
+- exclude \_\_typename metadata property when querying for form data ([1062bf8](https://github.com/aws-amplify/amplify-codegen-ui/commit/1062bf807014fe3e76e7ceccfd82984ffc014832))
+
+### Features
+
+- update dependency versioning helpers ([#1099](https://github.com/aws-amplify/amplify-codegen-ui/issues/1099)) ([f848597](https://github.com/aws-amplify/amplify-codegen-ui/commit/f84859717fbf4acedcd645ca20ee24c294808ab2))
+
 ## [2.15.9](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.8...v2.15.9) (2023-09-06)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "exact": true,
-  "version": "2.15.9",
+  "version": "2.16.0",
   "command": {
     "version": {
       "message": "chore(release): %s"

--- a/packages/codegen-ui-golden-files/CHANGELOG.md
+++ b/packages/codegen-ui-golden-files/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.16.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.9...v2.16.0) (2023-09-28)
+
+**Note:** Version bump only for package @aws-amplify/codegen-ui-golden-files
+
 ## [2.15.9](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.8...v2.15.9) (2023-09-06)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui-golden-files

--- a/packages/codegen-ui-golden-files/package-lock.json
+++ b/packages/codegen-ui-golden-files/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws-amplify/codegen-ui-golden-files",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws-amplify/codegen-ui-golden-files",
-      "version": "2.15.9",
+      "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/datastore": "^3.12.12",

--- a/packages/codegen-ui-golden-files/package.json
+++ b/packages/codegen-ui-golden-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-golden-files",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "description": "Models of outputs to customer project",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",
@@ -11,7 +11,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.15.9",
+    "@aws-amplify/codegen-ui": "2.16.0",
     "@aws-amplify/datastore": "^3.12.12",
     "@aws-amplify/ui-react": "^3.5.7",
     "aws-amplify": "^4.3.37",

--- a/packages/codegen-ui-react/CHANGELOG.md
+++ b/packages/codegen-ui-react/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.16.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.9...v2.16.0) (2023-09-28)
+
+### Bug Fixes
+
+- exclude \_\_typename metadata property when querying for form data ([1062bf8](https://github.com/aws-amplify/amplify-codegen-ui/commit/1062bf807014fe3e76e7ceccfd82984ffc014832))
+
+### Features
+
+- update dependency versioning helpers ([#1099](https://github.com/aws-amplify/amplify-codegen-ui/issues/1099)) ([f848597](https://github.com/aws-amplify/amplify-codegen-ui/commit/f84859717fbf4acedcd645ca20ee24c294808ab2))
+
 ## [2.15.9](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.8...v2.15.9) (2023-09-06)
 
 ### Bug Fixes

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws-amplify/codegen-ui-react",
-      "version": "2.15.9",
+      "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/codegen-ui": "2.15.9",
+        "@aws-amplify/codegen-ui": "2.16.0",
         "@typescript/vfs": "~1.3.5",
         "pluralize": "^8.0.0",
         "semver": "^7.5.4",

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "description": "Amplify UI React code generation implementation",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -31,11 +31,11 @@
     "pascalcase": "1.0.0"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.15.9",
+    "@aws-amplify/codegen-ui": "2.16.0",
     "@typescript/vfs": "~1.3.5",
     "pluralize": "^8.0.0",
-    "typescript": "<=4.5.0",
-    "semver": "^7.5.4"
+    "semver": "^7.5.4",
+    "typescript": "<=4.5.0"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",

--- a/packages/codegen-ui/CHANGELOG.md
+++ b/packages/codegen-ui/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.16.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.9...v2.16.0) (2023-09-28)
+
+### Features
+
+- update dependency versioning helpers ([#1099](https://github.com/aws-amplify/amplify-codegen-ui/issues/1099)) ([f848597](https://github.com/aws-amplify/amplify-codegen-ui/commit/f84859717fbf4acedcd645ca20ee24c294808ab2))
+
 ## [2.15.9](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.8...v2.15.9) (2023-09-06)
 
 ### Bug Fixes

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws-amplify/codegen-ui",
-      "version": "2.15.9",
+      "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "change-case": "^4.1.2",

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "description": "generic component code generation interface definitions",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",

--- a/packages/test-generator/CHANGELOG.md
+++ b/packages/test-generator/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.16.0](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.9...v2.16.0) (2023-09-28)
+
+### Bug Fixes
+
+- exclude \_\_typename metadata property when querying for form data ([1062bf8](https://github.com/aws-amplify/amplify-codegen-ui/commit/1062bf807014fe3e76e7ceccfd82984ffc014832))
+
 ## [2.15.9](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.15.8...v2.15.9) (2023-09-06)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui-test-generator

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws-amplify/codegen-ui-test-generator",
-      "version": "2.15.9",
+      "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/codegen-ui": "2.15.9",
-        "@aws-amplify/codegen-ui-react": "2.15.9",
+        "@aws-amplify/codegen-ui": "2.16.0",
+        "@aws-amplify/codegen-ui-react": "2.16.0",
         "@types/node": "^15.12.1",
         "loglevel": "^1.7.1",
         "typescript": "^4.2.4"

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "2.15.9",
+  "version": "2.16.0",
   "description": "Test generator with sample JSON files",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -19,8 +19,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.15.9",
-    "@aws-amplify/codegen-ui-react": "2.15.9",
+    "@aws-amplify/codegen-ui": "2.16.0",
+    "@aws-amplify/codegen-ui-react": "2.16.0",
     "@types/node": "^15.12.1",
     "loglevel": "^1.7.1",
     "typescript": "^4.2.4"


### PR DESCRIPTION
## Problem

We need to release the version helpers so that the amplify cli can use them to know which warning messages to show the user if they need to install amplify js v5 or v6 packages.

## Solution

This release has the changes needed.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - (provide a reason) release PR
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
