### PR TITLE
chore: update commitlint config to allow deps-dev for dependabot updates

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ const {
 module.exports = {
   extends: ['@commitlint/config-conventional', '@commitlint/config-lerna-scopes'],
   rules: {
-    'scope-enum': async (context) => [2, 'always', [...(await getPackages(context)), 'release', 'deps']],
+    'scope-enum': async (context) => [2, 'always', [...(await getPackages(context)), 'release', 'deps', 'deps-dev']],
     'header-max-length': [2, 'always', 200],
   },
 };


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->
dependabot update failed commitlint because it used `(deps-dev)` in its commit message.

## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->
add `deps-dev` to the allowed list of scopes in the commitlint config

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - config only
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
