### PR TITLE
fix: join table related model name using incorrect casing

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -3149,7 +3149,6 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
-import { Tag } from \\"../API\\";
 import { fetchByPath, getOverrideProps, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { listTags } from \\"../graphql/queries\\";
@@ -3495,7 +3494,7 @@ export default function MovieCreateForm(props) {
                       movieMovieKey: movie.movieKey,
                       movietitle: movie.title,
                       moviegenre: movie.genre,
-                      tagId: Tag.id,
+                      tagId: tag.id,
                     },
                   },
                 })
@@ -5441,7 +5440,6 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
-import { Post } from \\"../API\\";
 import { fetchByPath, getOverrideProps, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import { listPosts } from \\"../graphql/queries\\";
@@ -5783,7 +5781,7 @@ export default function TagCreateForm(props) {
                   variables: {
                     input: {
                       tagID: tag.id,
-                      postID: Post.id,
+                      postID: post.id,
                     },
                   },
                 })
@@ -6768,7 +6766,6 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
-import { CPKClass } from \\"../API\\";
 import { fetchByPath, getOverrideProps, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import {
@@ -7207,7 +7204,7 @@ export default function CreateCPKTeacherForm(props) {
                   variables: {
                     input: {
                       cPKTeacherSpecialTeacherId: cPKTeacher.specialTeacherId,
-                      cPKClassSpecialClassId: CPKClass.specialClassId,
+                      cPKClassSpecialClassId: cpkClass.specialClassId,
                     },
                   },
                 })
@@ -20492,7 +20489,6 @@ import {
   TextField,
   useTheme,
 } from \\"@aws-amplify/ui-react\\";
-import { CompositeVet } from \\"../API\\";
 import { fetchByPath, getOverrideProps, validateField } from \\"./utils\\";
 import { API } from \\"aws-amplify\\";
 import {
@@ -21079,8 +21075,8 @@ export default function CreateCompositeDogForm(props) {
                     input: {
                       compositeDogName: compositeDog.name,
                       compositeDogdescription: compositeDog.description,
-                      compositeVetSpecialty: CompositeVet.specialty,
-                      compositeVetcity: CompositeVet.city,
+                      compositeVetSpecialty: compositeVet.specialty,
+                      compositeVetcity: compositeVet.city,
                     },
                   },
                 })

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -1044,7 +1044,7 @@ export const buildManyToManyRelationshipStatements = (
                                     savedModelName,
                                     thisModelPrimaryKeys,
                                     joinTableThisModelFields,
-                                    relatedModelName,
+                                    joinTableRelatedModelName,
                                     relatedModelPrimaryKeys,
                                     joinTableRelatedModelFields,
                                     importCollection,


### PR DESCRIPTION
## Problem

<!-- Why are we making this code change? -->

For graphql many many relationships, the onSubmit function has a reduce function to update the related model. This callback function was making a reference to the actual model instead of the reduce callback's parameter. One was lower case and the other was title cased.

## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

Use the same value that's being used to create the callbacks arguments.

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

No. 

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
