### PR TITLE
feat: move amplify js v6 to latest

### DIFF
--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install test app dependencies
         working-directory: e2e-test-app
         run: |
-          npm i aws-amplify @aws-amplify/ui-react
+          npm i aws-amplify@^5.0.0 @aws-amplify/ui-react@^5.0.0
           npm i --save-dev cypress
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -110,7 +110,7 @@ jobs:
       - name: Install test app dependencies
         working-directory: e2e-test-app
         run: |
-          npm i aws-amplify @aws-amplify/ui-react
+          npm i aws-amplify@^5.0.0 @aws-amplify/ui-react@^5.0.0
           npm i --save-dev cypress
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install test app dependencies
         working-directory: e2e-test-app
         run: |
-          npm i aws-amplify@^5.0.0 @aws-amplify/ui-react^5.0.0
+          npm i aws-amplify@^5.0.0 @aws-amplify/ui-react@^5.0.0
           npm i --save-dev cypress
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -152,7 +152,7 @@ jobs:
       - name: Install test app dependencies
         working-directory: e2e-test-app
         run: |
-          npm i aws-amplify@^6.0.0 @aws-amplify/ui-react^6.0.0
+          npm i aws-amplify@^6.0.0 @aws-amplify/ui-react@^6.0.0
           npm i --save-dev cypress
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
-  amplify-cli-tests:
+  amplify-cli-tests-v5:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Studio Codegen
@@ -59,7 +59,7 @@ jobs:
       - name: Install test app dependencies
         working-directory: e2e-test-app
         run: |
-          npm i aws-amplify @aws-amplify/ui-react
+          npm i aws-amplify@^5.0.0 @aws-amplify/ui-react^5.0.0
           npm i --save-dev cypress
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -104,6 +104,99 @@ jobs:
         with:
           name: cypress-videos
           path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/e2e-test-app/cypress/videos
+
+  amplify-cli-tests-v6:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Studio Codegen
+        uses: actions/checkout@v2
+        with:
+          path: amplify-codegen-ui
+          repository: aws-amplify/amplify-codegen-ui
+      - name: Checkout Amplify CLI
+        uses: actions/checkout@v2
+        with:
+          path: amplify-cli
+          repository: aws-amplify/amplify-cli
+      - name: Setup Node.js LTS/gallium
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/gallium
+      - name: Build amplify-codegen-ui
+        working-directory: amplify-codegen-ui
+        run: |
+          npm ci
+          npx lerna bootstrap
+          npm run build
+      - name: Package amplify-codegen-ui
+        working-directory: amplify-codegen-ui
+        run: npx lerna exec npm pack
+      - name: Build amplify-cli
+        working-directory: amplify-cli
+        run: |
+          yarn install
+          yarn setup-dev
+      - name: Install updated codegen libraries
+        working-directory: amplify-cli/packages/amplify-util-uibuilder
+        run: |
+          yarn add ../../../amplify-codegen-ui/packages/codegen-ui/aws-amplify-codegen-ui-*.tgz
+          yarn add ../../../amplify-codegen-ui/packages/codegen-ui-react/aws-amplify-codegen-ui-react-*.tgz
+      - name: Build amplify-cli with updated codegen libraries
+        working-directory: amplify-cli
+        run: |
+          yarn install
+          yarn build
+          echo "$HOME/work/amplify-codegen-ui/amplify-codegen-ui/amplify-cli/.bin" >> $GITHUB_PATH
+      - name: Create a test react app
+        run: npx create-react-app e2e-test-app
+      - name: Install test app dependencies
+        working-directory: e2e-test-app
+        run: |
+          npm i aws-amplify@^6.0.0 @aws-amplify/ui-react^6.0.0
+          npm i --save-dev cypress
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.E2E_TEST_ROLE_ARN }}
+          aws-region: us-west-2
+      - name: Create temp AWS credentials file
+        working-directory: e2e-test-app
+        run: |
+          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID && \
+          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY && \
+          aws configure set aws_session_token $AWS_SESSION_TOKEN && \
+          aws configure set default.region $AWS_REGION
+      - name: Run CLI Pull in test app
+        working-directory: e2e-test-app
+        run: |
+          FORCE_RENDER=1 amplify-dev pull --appId ${{ secrets.E2E_TEST_APP_ID }} --envName staging -y --providers "{\
+            \"awscloudformation\":{\
+              \"configLevel\":\"project\",\
+              \"useProfile\":true,\
+              \"profileName\":\"default\",\
+            }\
+          }"
+      - name: Write test files
+        working-directory: e2e-test-app
+        run: cp -r ../amplify-codegen-ui/packages/test-generator/e2e-test-templates-amplify-js-v6/. .
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        with:
+          working-directory: e2e-test-app
+          install: false
+          start: npm start
+          wait-on: 'http://localhost:3000'
+          wait-on-timeout: 120
+          config-file: cypress.config.js
+        env:
+          REACT_APP_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+          REACT_APP_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+      - name: Upload Cypress videos
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-videos
+          path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/e2e-test-app-v6/cypress/videos
 
   functional-tests:
     runs-on: ubuntu-latest

--- a/packages/codegen-ui-react/lib/helpers/amplify-js-versioning.ts
+++ b/packages/codegen-ui-react/lib/helpers/amplify-js-versioning.ts
@@ -20,7 +20,7 @@ import { AMPLIFY_JS_V5, AMPLIFY_JS_V6 } from '../utils/constants';
 import { ImportValue } from '../imports';
 
 export function isAmplifyJSV6RenderingEnabled(): boolean {
-  return false;
+  return true;
 }
 
 export function getLatestAmplifyJSV6RenderingEnabled(

--- a/packages/test-generator/e2e-test-templates-amplify-js-v6/.eslintrc.js
+++ b/packages/test-generator/e2e-test-templates-amplify-js-v6/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rules: {
+    'import/no-unresolved': 'off',
+    'import/no-extraneous-dependencies': 'off',
+    'import/extensions': 'off',
+  },
+};

--- a/packages/test-generator/e2e-test-templates-amplify-js-v6/cypress.config.js
+++ b/packages/test-generator/e2e-test-templates-amplify-js-v6/cypress.config.js
@@ -1,0 +1,23 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    supportFile: false,
+  },
+});

--- a/packages/test-generator/e2e-test-templates-amplify-js-v6/cypress/.eslintrc.js
+++ b/packages/test-generator/e2e-test-templates-amplify-js-v6/cypress/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['plugin:cypress/recommended'],
+};

--- a/packages/test-generator/e2e-test-templates-amplify-js-v6/cypress/e2e/e2e-tests.cy.js
+++ b/packages/test-generator/e2e-test-templates-amplify-js-v6/cypress/e2e/e2e-tests.cy.js
@@ -1,0 +1,28 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+describe('e2e-tests', () => {
+  before(() => {
+    cy.visit('localhost:3000');
+  });
+
+  it('renders datastore collection', () => {
+    // wait to log in
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(4000);
+    cy.get('#blogPosts').contains('Working on E2E Tests');
+  });
+});

--- a/packages/test-generator/e2e-test-templates-amplify-js-v6/src/App.js
+++ b/packages/test-generator/e2e-test-templates-amplify-js-v6/src/App.js
@@ -38,7 +38,7 @@ function App() {
       return;
     }
     initialized.current = true;
-    signIn(process.env.REACT_APP_USER_EMAIL, process.env.REACT_APP_USER_PASSWORD).then(() => {
+    signIn({ username: process.env.REACT_APP_USER_EMAIL, password: process.env.REACT_APP_USER_PASSWORD }).then(() => {
       setIsLoggedIn(true);
     });
   }, []);

--- a/packages/test-generator/e2e-test-templates-amplify-js-v6/src/App.js
+++ b/packages/test-generator/e2e-test-templates-amplify-js-v6/src/App.js
@@ -17,7 +17,7 @@ import { Amplify } from 'aws-amplify';
 import { signIn } from 'aws-amplify/auth';
 import { DataStore, AuthModeStrategyType } from 'aws-amplify/datastore';
 import '@aws-amplify/ui-react/styles.css';
-import { AmplifyProvider } from '@aws-amplify/ui-react';
+import { ThemeProvider } from '@aws-amplify/ui-react';
 import { useEffect, useRef, useState } from 'react';
 import amplifyconfig from './amplifyconfiguration.json';
 import { BlogPosts } from './ui-components';
@@ -45,9 +45,9 @@ function App() {
 
   if (isLoggedIn) {
     return (
-      <AmplifyProvider>
+      <ThemeProvider>
         <BlogPosts id="blogPosts" />
-      </AmplifyProvider>
+      </ThemeProvider>
     );
   }
 

--- a/packages/test-generator/e2e-test-templates-amplify-js-v6/src/App.js
+++ b/packages/test-generator/e2e-test-templates-amplify-js-v6/src/App.js
@@ -1,0 +1,57 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import { Amplify } from 'aws-amplify';
+import { signIn } from 'aws-amplify/auth';
+import { DataStore, AuthModeStrategyType } from 'aws-amplify/datastore';
+import '@aws-amplify/ui-react/styles.css';
+import { AmplifyProvider } from '@aws-amplify/ui-react';
+import { useEffect, useRef, useState } from 'react';
+import amplifyconfig from './amplifyconfiguration.json';
+import { BlogPosts } from './ui-components';
+
+Amplify.configure(amplifyconfig);
+DataStore.configure({
+  DataStore: {
+    authModeStrategyType: AuthModeStrategyType.MULTI_AUTH,
+  },
+});
+
+function App() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (initialized.current) {
+      return;
+    }
+    initialized.current = true;
+    signIn(process.env.REACT_APP_USER_EMAIL, process.env.REACT_APP_USER_PASSWORD).then(() => {
+      setIsLoggedIn(true);
+    });
+  }, []);
+
+  if (isLoggedIn) {
+    return (
+      <AmplifyProvider>
+        <BlogPosts id="blogPosts" />
+      </AmplifyProvider>
+    );
+  }
+
+  return null;
+}
+
+export default App;

--- a/packages/test-generator/lib/generators/GenerateTestApp.ts
+++ b/packages/test-generator/lib/generators/GenerateTestApp.ts
@@ -16,6 +16,12 @@
 import { ModuleKind, ScriptTarget, ScriptKind } from '@aws-amplify/codegen-ui-react/dist/lib/react-render-config';
 import { NodeTestGenerator } from './NodeTestGenerator';
 
+const { DEPENDENCIES } = process.env;
+
+if (!DEPENDENCIES) {
+  throw new Error('DEPENDENCIES env var not found');
+}
+
 const GOLDEN_COMPONENTS = [
   'GoldenBasicComponent',
   'GoldenCollectionWithDataBindingAndPagination',
@@ -68,6 +74,7 @@ const jsxGenerator = new NodeTestGenerator({
     target: ScriptTarget.ES2020,
     script: ScriptKind.JSX,
     renderTypeDeclarations: true,
+    dependencies: JSON.parse(DEPENDENCIES),
   },
   outputConfigOverride: {
     outputPathDir: INTEG_TEST_PATH,

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -14,8 +14,8 @@
         "typescript": "^4.2.4"
       },
       "devDependencies": {
-        "@aws-amplify/datastore": "^4.0.0",
-        "@aws-amplify/ui-react": "^4.6.0",
+        "@aws-amplify/datastore": "^5.0.0",
+        "@aws-amplify/ui-react": "^5.0.0",
         "@aws-amplify/ui-react-storage": "^1.1.0",
         "cypress": "12.0.2",
         "eslint-plugin-cypress": "2.12.1",
@@ -54,6 +54,25 @@
         "uuid": "^3.2.1"
       }
     },
+    "node_modules/@aws-amplify/analytics/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
     "node_modules/@aws-amplify/analytics/node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
@@ -69,6 +88,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.4.5.tgz",
       "integrity": "sha512-mZMIR3w1PiUP5S41Z1j5SL5h/aY1dConndLwC7eOE4GHoGSlFUjZdrsTTRFEH8uFAg6CJ0nj/Ww8pEL+MU5FlQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-amplify/api-graphql": "3.4.11",
         "@aws-amplify/api-rest": "3.5.5",
@@ -80,6 +100,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-3.4.11.tgz",
       "integrity": "sha512-brvExeD2IRnQZbcWqFeDP5xfM1ANgtsZMGGzW75Tmw4gKCQPlYcBb/mQXTVsa7AJfIgxLrSYmhlu7drTTtyBnQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-amplify/api-rest": "3.5.5",
         "@aws-amplify/auth": "5.6.5",
@@ -92,46 +113,12 @@
         "zen-observable-ts": "0.8.19"
       }
     },
-    "node_modules/@aws-amplify/api-rest": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.5.5.tgz",
-      "integrity": "sha512-tGR5yLoIC0gPcI8VyAbd7dZ8GdFMz/EEU7aG0HsAsg46Oig5VTtKa8xWV8w+dWXjzr9I2/jkpZtDfRD57PqiBg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-amplify/core": "5.8.5",
-        "axios": "0.26.0",
-        "tslib": "^1.8.0",
-        "url": "0.11.0"
-      }
-    },
-    "node_modules/@aws-amplify/auth": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.5.tgz",
-      "integrity": "sha512-NkBbYe3kV4LXj/VBeh0/HTZCNjhs8gB1frfJ2r1ZG3j+Q3taeKV4jhZcM1SyRbFh5ZGHiVSJPVefgBPi7UXBrw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-amplify/core": "5.8.5",
-        "amazon-cognito-identity-js": "6.3.6",
-        "buffer": "4.9.2",
-        "tslib": "^1.8.0",
-        "url": "0.11.0"
-      }
-    },
-    "node_modules/@aws-amplify/cache": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.11.tgz",
-      "integrity": "sha512-o8ju6RAbGOv8MXDJuLM2Fc5yl23pLfp1jdijlMjxBn+uXonV3B7YCtpJtjj3MW6RUY0xEZrz7fEfTp9Pa1Y7+Q==",
-      "dev": true,
-      "dependencies": {
-        "@aws-amplify/core": "5.8.5",
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-amplify/core": {
+    "node_modules/@aws-amplify/api-graphql/node_modules/@aws-amplify/core": {
       "version": "5.8.5",
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
       "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "1.2.2",
         "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -145,24 +132,278 @@
         "zen-observable-ts": "0.8.19"
       }
     },
-    "node_modules/@aws-amplify/datastore": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.5.tgz",
-      "integrity": "sha512-q+5hYvPD5Y4zAximOUQY9bokZ0L2VDmqbbCjwd7rbq0qZS4cjcaMTeRk5HqxSA+HBCn4L17bqJ3z3GHCe+JZIA==",
+    "node_modules/@aws-amplify/api-rest": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.5.5.tgz",
+      "integrity": "sha512-tGR5yLoIC0gPcI8VyAbd7dZ8GdFMz/EEU7aG0HsAsg46Oig5VTtKa8xWV8w+dWXjzr9I2/jkpZtDfRD57PqiBg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-amplify/core": "5.8.5",
+        "axios": "0.26.0",
+        "tslib": "^1.8.0",
+        "url": "0.11.0"
+      }
+    },
+    "node_modules/@aws-amplify/api-rest/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/@aws-amplify/auth": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.5.tgz",
+      "integrity": "sha512-NkBbYe3kV4LXj/VBeh0/HTZCNjhs8gB1frfJ2r1ZG3j+Q3taeKV4jhZcM1SyRbFh5ZGHiVSJPVefgBPi7UXBrw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-amplify/core": "5.8.5",
+        "amazon-cognito-identity-js": "6.3.6",
+        "buffer": "4.9.2",
+        "tslib": "^1.8.0",
+        "url": "0.11.0"
+      }
+    },
+    "node_modules/@aws-amplify/auth/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/@aws-amplify/cache": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.11.tgz",
+      "integrity": "sha512-o8ju6RAbGOv8MXDJuLM2Fc5yl23pLfp1jdijlMjxBn+uXonV3B7YCtpJtjj3MW6RUY0xEZrz7fEfTp9Pa1Y7+Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-amplify/core": "5.8.5",
+        "tslib": "^1.8.0"
+      }
+    },
+    "node_modules/@aws-amplify/cache/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/@aws-amplify/core": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.2.tgz",
+      "integrity": "sha512-PzOBZbelbOFhNRCj+PpV0lzWPEInB3TN8Yp0aNj8u+qy2+je8L3EQIPSw367KB3Ix69XhWzd9uLd6W2/ZDGk+Q==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/api": "5.4.5",
-        "@aws-amplify/auth": "5.6.5",
-        "@aws-amplify/core": "5.8.5",
-        "@aws-amplify/pubsub": "5.5.5",
-        "amazon-cognito-identity-js": "6.3.6",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/types": "3.398.0",
+        "@smithy/util-hex-encoding": "2.0.0",
+        "@types/uuid": "^9.0.0",
+        "js-cookie": "^3.0.5",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/core/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/core/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/core/node_modules/@aws-sdk/types": {
+      "version": "3.398.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
+      "integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.2.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/core/node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@aws-amplify/core/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@aws-amplify/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-amplify/data-schema-types": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.4.2.tgz",
+      "integrity": "sha512-ip5U1FisKxCAgIupo5FxoJVsWedKOl1UIJrUOpMWBtSnhCeVDJerNyaH7Su5YxmOX4ZpG7SAMF9qwF5C1zIKgg==",
+      "dev": true,
+      "dependencies": {
+        "rxjs": "^7.8.1"
+      }
+    },
+    "node_modules/@aws-amplify/datastore": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.2.tgz",
+      "integrity": "sha512-GWYhEBHrHZsugUriY5cTs0TXMQ9vzaibOhnXxE9LZlYCHaMAAzq15rspVt4wxD6hZgCyS3PX1qqeSudT/anf8g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/api": "6.0.2",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
-        "ulid": "2.3.0",
-        "uuid": "3.4.0",
-        "zen-observable-ts": "0.8.19",
-        "zen-push": "0.2.1"
+        "rxjs": "^7.8.1",
+        "ulid": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.2.tgz",
+      "integrity": "sha512-YhZa1jP9gh1Mfu73/x0TSz4CNMWbSdepQDjbyseRQGxwBRKQOG//bIcjup9LgCqmZlpwCbAOQdfPgAsReTFtHQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/api-graphql": "4.0.2",
+        "@aws-amplify/api-rest": "4.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api-graphql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.2.tgz",
+      "integrity": "sha512-2GRyvGYq9qCGUb/d9t5letHcTKAgCAvmqZN3Y2MyYWXRD+TwGTW/R8CM+N7uC/9j7S7cPQd09H9bDOH56Otekg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/api-rest": "4.0.2",
+        "@aws-amplify/core": "6.0.2",
+        "@aws-amplify/data-schema-types": "^0.4.2",
+        "@aws-sdk/types": "3.387.0",
+        "graphql": "15.8.0",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api-rest": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.2.tgz",
+      "integrity": "sha512-pMNkndD1TJw7/Epeu59Izx67aol8mz55SjtskQT2awIhMFh/J1S2tbkkZ1jZAzKb8oS9jg/+4llRJCEQN/3mdg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@aws-amplify/core": "^6.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/@aws-sdk/types": {
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
+      "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-amplify/geo": {
@@ -177,6 +418,25 @@
         "@turf/boolean-clockwise": "6.5.0",
         "camelcase-keys": "6.2.2",
         "tslib": "^1.8.0"
+      }
+    },
+    "node_modules/@aws-amplify/geo/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
       }
     },
     "node_modules/@aws-amplify/interactions": {
@@ -195,6 +455,25 @@
         "tslib": "^1.8.0"
       }
     },
+    "node_modules/@aws-amplify/interactions/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
     "node_modules/@aws-amplify/notifications": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-1.6.5.tgz",
@@ -207,6 +486,25 @@
         "@aws-amplify/rtn-push-notification": "1.1.7",
         "lodash": "^4.17.21",
         "uuid": "^3.2.1"
+      }
+    },
+    "node_modules/@aws-amplify/notifications/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
       }
     },
     "node_modules/@aws-amplify/predictions": {
@@ -230,11 +528,31 @@
         "uuid": "^3.2.1"
       }
     },
+    "node_modules/@aws-amplify/predictions/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
     "node_modules/@aws-amplify/pubsub": {
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.5.5.tgz",
       "integrity": "sha512-hRKMDxZrYA7srdTAhLbgluqKsm8zyoP6vOcXpx75Lut9OUfEEP5AixR4D4cyqX0B/0Ji1lRl9T7aUBcMFfFvCw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-amplify/auth": "5.6.5",
         "@aws-amplify/cache": "5.1.11",
@@ -244,6 +562,25 @@
         "tslib": "^1.8.0",
         "url": "0.11.0",
         "uuid": "^3.2.1",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/@aws-amplify/pubsub/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
         "zen-observable-ts": "0.8.19"
       }
     },
@@ -270,6 +607,25 @@
         "tslib": "^1.8.0"
       }
     },
+    "node_modules/@aws-amplify/storage/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
     "node_modules/@aws-amplify/ui": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-5.6.0.tgz",
@@ -292,13 +648,13 @@
       }
     },
     "node_modules/@aws-amplify/ui-react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-4.6.0.tgz",
-      "integrity": "sha512-dbzyTaIJqAp8otbrvqH6gsyKp/IT2gZYHSB49KaMdtOf64QCGj2Q3NGHhMvXhTDB8JUCUAgTkgFaM6u9HKSoDQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-5.3.2.tgz",
+      "integrity": "sha512-CzLUb7acrXroDHloKhjOWZwLAjFfaj7F1L/HpxcG9x3hV6klwvaECgN8qthDeI675XtHQNx48Pfk2DRrViXL0w==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/ui": "5.6.0",
-        "@aws-amplify/ui-react-core": "2.1.19",
+        "@aws-amplify/ui": "5.8.1",
+        "@aws-amplify/ui-react-core": "2.1.33",
         "@radix-ui/react-accordion": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-dropdown-menu": "1.0.0",
@@ -308,17 +664,12 @@
         "classnames": "2.3.1",
         "deepmerge": "4.2.2",
         "lodash": "4.17.21",
-        "mapbox-gl": "1.13.1",
-        "maplibre-gl": "2.1.9",
-        "maplibre-gl-js-amplify": "3.0.5",
         "qrcode": "1.5.0",
         "react-generate-context": "1.0.1",
-        "react-map-gl": "7.0.15",
-        "tinycolor2": "1.4.2",
         "tslib": "2.4.1"
       },
       "peerDependencies": {
-        "aws-amplify": ">= 5.0.1",
+        "aws-amplify": "^5.0.1",
         "react": ">= 16.14.0",
         "react-dom": ">= 16.14.0"
       },
@@ -391,11 +742,108 @@
         }
       }
     },
+    "node_modules/@aws-amplify/ui-react-storage/node_modules/@aws-amplify/ui-react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-4.6.0.tgz",
+      "integrity": "sha512-dbzyTaIJqAp8otbrvqH6gsyKp/IT2gZYHSB49KaMdtOf64QCGj2Q3NGHhMvXhTDB8JUCUAgTkgFaM6u9HKSoDQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/ui": "5.6.0",
+        "@aws-amplify/ui-react-core": "2.1.19",
+        "@radix-ui/react-accordion": "1.0.0",
+        "@radix-ui/react-direction": "1.0.0",
+        "@radix-ui/react-dropdown-menu": "1.0.0",
+        "@radix-ui/react-slider": "1.0.0",
+        "@radix-ui/react-tabs": "1.0.0",
+        "@xstate/react": "3.0.0",
+        "classnames": "2.3.1",
+        "deepmerge": "4.2.2",
+        "lodash": "4.17.21",
+        "mapbox-gl": "1.13.1",
+        "maplibre-gl": "2.1.9",
+        "maplibre-gl-js-amplify": "3.0.5",
+        "qrcode": "1.5.0",
+        "react-generate-context": "1.0.1",
+        "react-map-gl": "7.0.15",
+        "tinycolor2": "1.4.2",
+        "tslib": "2.4.1"
+      },
+      "peerDependencies": {
+        "aws-amplify": ">= 5.0.1",
+        "react": ">= 16.14.0",
+        "react-dom": ">= 16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-amplify": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aws-amplify/ui-react-storage/node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
+    },
+    "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/ui": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-5.8.1.tgz",
+      "integrity": "sha512-f7CYveXr3QzkWCjEcIzXe2ywoAc+j3cux7CBh/hS1X64dfleS8AhgHgnf1eJ+CQqNzEF51rZIJ8lrR62KBPAIQ==",
+      "dev": true,
+      "dependencies": {
+        "csstype": "^3.1.1",
+        "lodash": "4.17.21",
+        "style-dictionary": "3.7.1",
+        "tslib": "2.4.1"
+      },
+      "peerDependencies": {
+        "aws-amplify": "^5.0.1",
+        "xstate": "^4.33.6"
+      },
+      "peerDependenciesMeta": {
+        "xstate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/ui-react-core": {
+      "version": "2.1.33",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-2.1.33.tgz",
+      "integrity": "sha512-4f+8713lRy/qzFSAwVAhboVsui9qiQE5Mu3AX9AO6VlUtTdqPAY+RZWNqojZyWmLISm/Y4wHZRhvYe5/6x1Mgw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/ui": "5.8.1",
+        "@xstate/react": "3.0.1",
+        "lodash": "4.17.21",
+        "xstate": "^4.33.6"
+      },
+      "peerDependencies": {
+        "aws-amplify": "^5.0.1",
+        "react": ">= 16.14.0"
+      }
+    },
+    "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/ui-react-core/node_modules/@xstate/react": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.0.1.tgz",
+      "integrity": "sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==",
+      "dev": true,
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@xstate/fsm": "^2.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "xstate": "^4.33.0"
+      },
+      "peerDependenciesMeta": {
+        "@xstate/fsm": {
+          "optional": true
+        },
+        "xstate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@aws-amplify/ui-react/node_modules/tslib": {
       "version": "2.4.1",
@@ -459,6 +907,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
       "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -468,6 +917,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
       "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.2.2",
@@ -483,6 +933,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
       "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^1.2.2",
         "@aws-sdk/types": "^3.1.0",
@@ -494,6 +945,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
       "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -503,6 +955,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
       "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -514,6 +967,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
       "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -527,6 +981,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.6.1.tgz",
       "integrity": "sha512-QOxIDnlVTpnwJ26Gap6RGz61cDLH6TKrIp30VqwdMeT1pCGy8mn9rWln6XA+ymkofHy/08RfpGp+VN4axwd4Lw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
@@ -569,6 +1024,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
       "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       }
@@ -577,13 +1033,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@aws-sdk/client-comprehend": {
       "version": "3.6.1",
@@ -4961,6 +5419,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
       "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -4975,6 +5434,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
       "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -4989,6 +5449,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
       "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5003,6 +5464,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
       "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -5018,6 +5480,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
       "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.6.1",
         "@aws-sdk/credential-provider-imds": "3.6.1",
@@ -5037,6 +5500,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
       "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-ini": "3.6.1",
         "@aws-sdk/property-provider": "3.6.1",
@@ -5322,6 +5786,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
       "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/querystring-builder": "3.6.1",
@@ -5335,6 +5800,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
       "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-buffer-from": "3.6.1",
@@ -5349,6 +5815,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
       "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5359,6 +5826,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
       "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -5393,6 +5861,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
       "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5453,6 +5922,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
       "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5467,6 +5937,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
       "integrity": "sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5526,6 +5997,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
       "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/service-error-classification": "3.6.1",
@@ -5681,6 +6153,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
       "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5694,6 +6167,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
       "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/signature-v4": "3.6.1",
@@ -5709,6 +6183,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
       "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -5721,6 +6196,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
       "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5735,6 +6211,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
       "integrity": "sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -5750,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
       "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.6.1",
         "@aws-sdk/protocol-http": "3.6.1",
@@ -5766,6 +6244,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
       "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5779,6 +6258,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
       "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5792,6 +6272,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
       "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-uri-escape": "3.6.1",
@@ -5806,6 +6287,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
       "integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5819,6 +6301,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
       "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -5828,6 +6311,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
       "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -5840,6 +6324,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
       "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5856,6 +6341,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
       "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5870,6 +6356,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
       "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -5879,6 +6366,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.6.1.tgz",
       "integrity": "sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5890,6 +6378,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz",
       "integrity": "sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5905,6 +6394,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
       "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       }
@@ -5914,6 +6404,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
       "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -5927,6 +6418,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
       "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       }
@@ -5936,6 +6428,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
       "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -5948,6 +6441,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
       "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "tslib": "^1.8.0"
@@ -6224,6 +6718,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
       "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -6236,6 +6731,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.295.0.tgz",
       "integrity": "sha512-d/s+zhUx5Kh4l/ecMP/TBjzp1GR/g89Q4nWH6+wH5WgdHsK+LG+vmsk6mVNuP/8wsCofYG4NBqp5Ulbztbm9QA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -6247,7 +6743,8 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@aws-sdk/util-middleware": {
       "version": "3.186.0",
@@ -6274,6 +6771,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
       "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -6286,6 +6784,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
       "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "bowser": "^2.11.0",
@@ -6297,6 +6796,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
       "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -6311,6 +6811,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -6319,13 +6820,15 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@aws-sdk/util-utf8-node": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
       "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -8995,9 +9498,9 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-draw": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.1.tgz",
-      "integrity": "sha512-g6F49KZagF9269/IoF6vZJeail6qtoc5mVF3eVRikNT7UFnY0QASfe2y53mgE99s6GrHdpV+PZuFxaL71hkMhg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.3.tgz",
+      "integrity": "sha512-03qIJgyGmm0IoTZbV/cfODru9jRGogi4LcQ3maxIJDKccq1gY3ofgt2UYPkeU143ElxitZahEythNQv1NpsLhg==",
       "dev": true,
       "dependencies": {
         "@mapbox/geojson-area": "^0.2.2",
@@ -10819,12 +11322,29 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/@smithy/types": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
       "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -10836,8 +11356,63 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
       "dev": true,
-      "peer": true
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/@turf/along": {
       "version": "6.5.0",
@@ -11047,12 +11622,13 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "version": "7946.0.13",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
+      "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==",
       "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -11083,15 +11659,15 @@
       }
     },
     "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
       "dev": true
     },
     "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-      "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "*",
@@ -11100,9 +11676,9 @@
       }
     },
     "node_modules/@types/mapbox-gl": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.10.tgz",
-      "integrity": "sha512-nMVEcu9bAcenvx6oPWubQSPevsekByjOfKjlkr+8P91vawtkxTnopDoXXq1Qn/f4cg3zt0Z2W9DVsVsKRNXJTw==",
+      "version": "2.7.18",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.18.tgz",
+      "integrity": "sha512-3Yq4v8IdigSs2oD70dRJuWY/6PoW9i6MyXOx8DvJNc6CuSXRMleVdNiFYa5E0w6tSCfL+b+cGau5Em09MIujtQ==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "*"
@@ -11118,6 +11694,7 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
       "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -11128,6 +11705,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11138,9 +11716,9 @@
       }
     },
     "node_modules/@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "dev": true
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -11161,6 +11739,12 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -11304,6 +11888,7 @@
       "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.6.tgz",
       "integrity": "sha512-kBq+GE6OkLrxtFj3ZduIOlKBFYeOqZK3EhxbDBkv476UTvy+uwfR0tlriTq2QzNdnvlQAjBIXnXuOM7DwR1UEQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "1.2.2",
         "buffer": "4.9.2",
@@ -11719,6 +12304,53 @@
         "tslib": "^2.0.0"
       }
     },
+    "node_modules/aws-amplify/node_modules/@aws-amplify/core": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/aws-amplify/node_modules/@aws-amplify/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/aws-amplify/node_modules/@aws-amplify/datastore": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.5.tgz",
+      "integrity": "sha512-q+5hYvPD5Y4zAximOUQY9bokZ0L2VDmqbbCjwd7rbq0qZS4cjcaMTeRk5HqxSA+HBCn4L17bqJ3z3GHCe+JZIA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-amplify/api": "5.4.5",
+        "@aws-amplify/auth": "5.6.5",
+        "@aws-amplify/core": "5.8.5",
+        "@aws-amplify/pubsub": "5.5.5",
+        "amazon-cognito-identity-js": "6.3.6",
+        "buffer": "4.9.2",
+        "idb": "5.0.6",
+        "immer": "9.0.6",
+        "ulid": "2.3.0",
+        "uuid": "3.4.0",
+        "zen-observable-ts": "0.8.19",
+        "zen-push": "0.2.1"
+      }
+    },
     "node_modules/aws-amplify/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -11746,6 +12378,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
       "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.8"
       }
@@ -11995,7 +12628,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -12790,6 +13424,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13867,7 +14502,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
       "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -14109,6 +14745,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -15051,6 +15688,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
       "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
@@ -15294,7 +15932,8 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
@@ -16977,6 +17616,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
       "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -17871,6 +18511,7 @@
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -18093,6 +18734,7 @@
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
       "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-base64-decode": "^1.0.0"
       },
@@ -18112,6 +18754,7 @@
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
       "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -18552,9 +19195,9 @@
       "dev": true
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -19843,7 +20486,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/traverse": {
       "version": "0.6.7",
@@ -19858,7 +20502,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -19974,7 +20619,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -20051,6 +20697,7 @@
       "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
       "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/cookie": "^0.3.3",
         "cookie": "^0.4.0"
@@ -20216,6 +20863,7 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -20225,7 +20873,8 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -20338,6 +20987,7 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
+      "peer": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -20408,7 +21058,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/wgs84": {
       "version": "0.0.0",
@@ -20428,6 +21079,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -20438,6 +21090,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
       "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "buffer": "^5.4.3",
         "punycode": "^2.1.1",
@@ -20466,6 +21119,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -20476,6 +21130,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
       "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -20702,13 +21357,15 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/zen-observable-ts": {
       "version": "0.8.19",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
       "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
@@ -20719,6 +21376,7 @@
       "resolved": "https://registry.npmjs.org/zen-push/-/zen-push-0.2.1.tgz",
       "integrity": "sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "zen-observable": "^0.7.0"
       }
@@ -20727,7 +21385,8 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
       "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     }
   },
   "dependencies": {
@@ -20760,6 +21419,25 @@
         "uuid": "^3.2.1"
       },
       "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        },
         "@aws-sdk/util-utf8-browser": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
@@ -20777,6 +21455,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.4.5.tgz",
       "integrity": "sha512-mZMIR3w1PiUP5S41Z1j5SL5h/aY1dConndLwC7eOE4GHoGSlFUjZdrsTTRFEH8uFAg6CJ0nj/Ww8pEL+MU5FlQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-amplify/api-graphql": "3.4.11",
         "@aws-amplify/api-rest": "3.5.5",
@@ -20788,6 +21467,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-3.4.11.tgz",
       "integrity": "sha512-brvExeD2IRnQZbcWqFeDP5xfM1ANgtsZMGGzW75Tmw4gKCQPlYcBb/mQXTVsa7AJfIgxLrSYmhlu7drTTtyBnQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-amplify/api-rest": "3.5.5",
         "@aws-amplify/auth": "5.6.5",
@@ -20798,6 +21478,27 @@
         "tslib": "^1.8.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/api-rest": {
@@ -20805,11 +21506,33 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.5.5.tgz",
       "integrity": "sha512-tGR5yLoIC0gPcI8VyAbd7dZ8GdFMz/EEU7aG0HsAsg46Oig5VTtKa8xWV8w+dWXjzr9I2/jkpZtDfRD57PqiBg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-amplify/core": "5.8.5",
         "axios": "0.26.0",
         "tslib": "^1.8.0",
         "url": "0.11.0"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/auth": {
@@ -20817,12 +21540,34 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.5.tgz",
       "integrity": "sha512-NkBbYe3kV4LXj/VBeh0/HTZCNjhs8gB1frfJ2r1ZG3j+Q3taeKV4jhZcM1SyRbFh5ZGHiVSJPVefgBPi7UXBrw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-amplify/core": "5.8.5",
         "amazon-cognito-identity-js": "6.3.6",
         "buffer": "4.9.2",
         "tslib": "^1.8.0",
         "url": "0.11.0"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/cache": {
@@ -20830,47 +21575,182 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.11.tgz",
       "integrity": "sha512-o8ju6RAbGOv8MXDJuLM2Fc5yl23pLfp1jdijlMjxBn+uXonV3B7YCtpJtjj3MW6RUY0xEZrz7fEfTp9Pa1Y7+Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-amplify/core": "5.8.5",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/core": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
-      "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.2.tgz",
+      "integrity": "sha512-PzOBZbelbOFhNRCj+PpV0lzWPEInB3TN8Yp0aNj8u+qy2+je8L3EQIPSw367KB3Ix69XhWzd9uLd6W2/ZDGk+Q==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-js": "1.2.2",
-        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
-        "@aws-sdk/types": "3.6.1",
-        "@aws-sdk/util-hex-encoding": "3.6.1",
-        "@types/node-fetch": "2.6.4",
-        "isomorphic-unfetch": "^3.0.0",
-        "react-native-url-polyfill": "^1.3.0",
-        "tslib": "^1.8.0",
-        "universal-cookie": "^4.0.4",
-        "zen-observable-ts": "0.8.19"
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/types": "3.398.0",
+        "@smithy/util-hex-encoding": "2.0.0",
+        "@types/uuid": "^9.0.0",
+        "js-cookie": "^3.0.5",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "@aws-crypto/sha256-js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^5.2.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.398.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
+          "integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^2.2.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "js-cookie": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+          "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-amplify/data-schema-types": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.4.2.tgz",
+      "integrity": "sha512-ip5U1FisKxCAgIupo5FxoJVsWedKOl1UIJrUOpMWBtSnhCeVDJerNyaH7Su5YxmOX4ZpG7SAMF9qwF5C1zIKgg==",
+      "dev": true,
+      "requires": {
+        "rxjs": "^7.8.1"
       }
     },
     "@aws-amplify/datastore": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.5.tgz",
-      "integrity": "sha512-q+5hYvPD5Y4zAximOUQY9bokZ0L2VDmqbbCjwd7rbq0qZS4cjcaMTeRk5HqxSA+HBCn4L17bqJ3z3GHCe+JZIA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.2.tgz",
+      "integrity": "sha512-GWYhEBHrHZsugUriY5cTs0TXMQ9vzaibOhnXxE9LZlYCHaMAAzq15rspVt4wxD6hZgCyS3PX1qqeSudT/anf8g==",
       "dev": true,
       "requires": {
-        "@aws-amplify/api": "5.4.5",
-        "@aws-amplify/auth": "5.6.5",
-        "@aws-amplify/core": "5.8.5",
-        "@aws-amplify/pubsub": "5.5.5",
-        "amazon-cognito-identity-js": "6.3.6",
+        "@aws-amplify/api": "6.0.2",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
-        "ulid": "2.3.0",
-        "uuid": "3.4.0",
-        "zen-observable-ts": "0.8.19",
-        "zen-push": "0.2.1"
+        "rxjs": "^7.8.1",
+        "ulid": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-amplify/api": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.2.tgz",
+          "integrity": "sha512-YhZa1jP9gh1Mfu73/x0TSz4CNMWbSdepQDjbyseRQGxwBRKQOG//bIcjup9LgCqmZlpwCbAOQdfPgAsReTFtHQ==",
+          "dev": true,
+          "requires": {
+            "@aws-amplify/api-graphql": "4.0.2",
+            "@aws-amplify/api-rest": "4.0.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-amplify/api-graphql": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.2.tgz",
+          "integrity": "sha512-2GRyvGYq9qCGUb/d9t5letHcTKAgCAvmqZN3Y2MyYWXRD+TwGTW/R8CM+N7uC/9j7S7cPQd09H9bDOH56Otekg==",
+          "dev": true,
+          "requires": {
+            "@aws-amplify/api-rest": "4.0.2",
+            "@aws-amplify/core": "6.0.2",
+            "@aws-amplify/data-schema-types": "^0.4.2",
+            "@aws-sdk/types": "3.387.0",
+            "graphql": "15.8.0",
+            "rxjs": "^7.8.1",
+            "tslib": "^2.5.0",
+            "uuid": "^9.0.0"
+          }
+        },
+        "@aws-amplify/api-rest": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.2.tgz",
+          "integrity": "sha512-pMNkndD1TJw7/Epeu59Izx67aol8mz55SjtskQT2awIhMFh/J1S2tbkkZ1jZAzKb8oS9jg/+4llRJCEQN/3mdg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.387.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
+          "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
+          "dev": true,
+          "requires": {
+            "@smithy/types": "^2.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "dev": true
+        }
       }
     },
     "@aws-amplify/geo": {
@@ -20885,6 +21765,27 @@
         "@turf/boolean-clockwise": "6.5.0",
         "camelcase-keys": "6.2.2",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/interactions": {
@@ -20901,6 +21802,27 @@
         "fflate": "0.7.3",
         "pako": "2.0.4",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/notifications": {
@@ -20915,6 +21837,27 @@
         "@aws-amplify/rtn-push-notification": "1.1.7",
         "lodash": "^4.17.21",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/predictions": {
@@ -20936,6 +21879,27 @@
         "buffer": "4.9.2",
         "tslib": "^1.8.0",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/pubsub": {
@@ -20943,6 +21907,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.5.5.tgz",
       "integrity": "sha512-hRKMDxZrYA7srdTAhLbgluqKsm8zyoP6vOcXpx75Lut9OUfEEP5AixR4D4cyqX0B/0Ji1lRl9T7aUBcMFfFvCw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-amplify/auth": "5.6.5",
         "@aws-amplify/cache": "5.1.11",
@@ -20953,6 +21918,27 @@
         "url": "0.11.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/rtn-push-notification": {
@@ -20976,6 +21962,27 @@
         "events": "^3.1.0",
         "fast-xml-parser": "^4.2.5",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          }
+        }
       }
     },
     "@aws-amplify/ui": {
@@ -20999,13 +22006,13 @@
       }
     },
     "@aws-amplify/ui-react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-4.6.0.tgz",
-      "integrity": "sha512-dbzyTaIJqAp8otbrvqH6gsyKp/IT2gZYHSB49KaMdtOf64QCGj2Q3NGHhMvXhTDB8JUCUAgTkgFaM6u9HKSoDQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-5.3.2.tgz",
+      "integrity": "sha512-CzLUb7acrXroDHloKhjOWZwLAjFfaj7F1L/HpxcG9x3hV6klwvaECgN8qthDeI675XtHQNx48Pfk2DRrViXL0w==",
       "dev": true,
       "requires": {
-        "@aws-amplify/ui": "5.6.0",
-        "@aws-amplify/ui-react-core": "2.1.19",
+        "@aws-amplify/ui": "5.8.1",
+        "@aws-amplify/ui-react-core": "2.1.33",
         "@radix-ui/react-accordion": "1.0.0",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-dropdown-menu": "1.0.0",
@@ -21015,16 +22022,47 @@
         "classnames": "2.3.1",
         "deepmerge": "4.2.2",
         "lodash": "4.17.21",
-        "mapbox-gl": "1.13.1",
-        "maplibre-gl": "2.1.9",
-        "maplibre-gl-js-amplify": "3.0.5",
         "qrcode": "1.5.0",
         "react-generate-context": "1.0.1",
-        "react-map-gl": "7.0.15",
-        "tinycolor2": "1.4.2",
         "tslib": "2.4.1"
       },
       "dependencies": {
+        "@aws-amplify/ui": {
+          "version": "5.8.1",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-5.8.1.tgz",
+          "integrity": "sha512-f7CYveXr3QzkWCjEcIzXe2ywoAc+j3cux7CBh/hS1X64dfleS8AhgHgnf1eJ+CQqNzEF51rZIJ8lrR62KBPAIQ==",
+          "dev": true,
+          "requires": {
+            "csstype": "^3.1.1",
+            "lodash": "4.17.21",
+            "style-dictionary": "3.7.1",
+            "tslib": "2.4.1"
+          }
+        },
+        "@aws-amplify/ui-react-core": {
+          "version": "2.1.33",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-2.1.33.tgz",
+          "integrity": "sha512-4f+8713lRy/qzFSAwVAhboVsui9qiQE5Mu3AX9AO6VlUtTdqPAY+RZWNqojZyWmLISm/Y4wHZRhvYe5/6x1Mgw==",
+          "dev": true,
+          "requires": {
+            "@aws-amplify/ui": "5.8.1",
+            "@xstate/react": "3.0.1",
+            "lodash": "4.17.21",
+            "xstate": "^4.33.6"
+          },
+          "dependencies": {
+            "@xstate/react": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.0.1.tgz",
+              "integrity": "sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==",
+              "dev": true,
+              "requires": {
+                "use-isomorphic-layout-effect": "^1.0.0",
+                "use-sync-external-store": "^1.0.0"
+              }
+            }
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -21071,6 +22109,33 @@
         "tslib": "2.4.1"
       },
       "dependencies": {
+        "@aws-amplify/ui-react": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-4.6.0.tgz",
+          "integrity": "sha512-dbzyTaIJqAp8otbrvqH6gsyKp/IT2gZYHSB49KaMdtOf64QCGj2Q3NGHhMvXhTDB8JUCUAgTkgFaM6u9HKSoDQ==",
+          "dev": true,
+          "requires": {
+            "@aws-amplify/ui": "5.6.0",
+            "@aws-amplify/ui-react-core": "2.1.19",
+            "@radix-ui/react-accordion": "1.0.0",
+            "@radix-ui/react-direction": "1.0.0",
+            "@radix-ui/react-dropdown-menu": "1.0.0",
+            "@radix-ui/react-slider": "1.0.0",
+            "@radix-ui/react-tabs": "1.0.0",
+            "@xstate/react": "3.0.0",
+            "classnames": "2.3.1",
+            "deepmerge": "4.2.2",
+            "lodash": "4.17.21",
+            "mapbox-gl": "1.13.1",
+            "maplibre-gl": "2.1.9",
+            "maplibre-gl-js-amplify": "3.0.5",
+            "qrcode": "1.5.0",
+            "react-generate-context": "1.0.1",
+            "react-map-gl": "7.0.15",
+            "tinycolor2": "1.4.2",
+            "tslib": "2.4.1"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -21130,6 +22195,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
       "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       }
@@ -21139,6 +22205,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
       "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.2.2",
@@ -21154,6 +22221,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
       "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/util": "^1.2.2",
         "@aws-sdk/types": "^3.1.0",
@@ -21165,6 +22233,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
       "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       }
@@ -21174,6 +22243,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
       "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -21185,6 +22255,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
       "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -21195,6 +22266,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.6.1.tgz",
       "integrity": "sha512-QOxIDnlVTpnwJ26Gap6RGz61cDLH6TKrIp30VqwdMeT1pCGy8mn9rWln6XA+ymkofHy/08RfpGp+VN4axwd4Lw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
@@ -21234,6 +22306,7 @@
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
           "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "tslib": "^1.8.0"
           },
@@ -21242,15 +22315,17 @@
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-              "dev": true
+              "dev": true,
+              "peer": true
             }
           }
         },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-          "dev": true
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -25096,6 +26171,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
       "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25107,6 +26183,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
       "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25118,6 +26195,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
       "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25129,6 +26207,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
       "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -25141,6 +26220,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
       "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.6.1",
         "@aws-sdk/credential-provider-imds": "3.6.1",
@@ -25157,6 +26237,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
       "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-ini": "3.6.1",
         "@aws-sdk/property-provider": "3.6.1",
@@ -25404,6 +26485,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
       "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/querystring-builder": "3.6.1",
@@ -25417,6 +26499,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
       "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-buffer-from": "3.6.1",
@@ -25428,6 +26511,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
       "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -25438,6 +26522,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
       "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -25471,6 +26556,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
       "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25521,6 +26607,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
       "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25532,6 +26619,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
       "integrity": "sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -25581,6 +26669,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
       "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/service-error-classification": "3.6.1",
@@ -25708,6 +26797,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
       "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -25718,6 +26808,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
       "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/signature-v4": "3.6.1",
@@ -25730,6 +26821,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
       "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -25739,6 +26831,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
       "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25750,6 +26843,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
       "integrity": "sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -25762,6 +26856,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
       "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.6.1",
         "@aws-sdk/protocol-http": "3.6.1",
@@ -25775,6 +26870,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
       "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -25785,6 +26881,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
       "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -25795,6 +26892,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
       "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-uri-escape": "3.6.1",
@@ -25806,6 +26904,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
       "integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -25815,13 +26914,15 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
       "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
       "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -25831,6 +26932,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
       "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25844,6 +26946,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
       "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25854,13 +26957,15 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
       "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@aws-sdk/url-parser": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.6.1.tgz",
       "integrity": "sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25872,6 +26977,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz",
       "integrity": "sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -25884,6 +26990,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
       "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -25893,6 +27000,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
       "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -25903,6 +27011,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
       "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -25912,6 +27021,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
       "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -25921,6 +27031,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
       "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "tslib": "^1.8.0"
@@ -26152,6 +27263,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
       "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -26161,6 +27273,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.295.0.tgz",
       "integrity": "sha512-d/s+zhUx5Kh4l/ecMP/TBjzp1GR/g89Q4nWH6+wH5WgdHsK+LG+vmsk6mVNuP/8wsCofYG4NBqp5Ulbztbm9QA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       },
@@ -26169,7 +27282,8 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
           "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -26197,6 +27311,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
       "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -26206,6 +27321,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
       "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "bowser": "^2.11.0",
@@ -26217,6 +27333,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
       "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26228,6 +27345,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       },
@@ -26236,7 +27354,8 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
           "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -26245,6 +27364,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
       "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -28224,9 +29344,9 @@
       "dev": true
     },
     "@mapbox/mapbox-gl-draw": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.1.tgz",
-      "integrity": "sha512-g6F49KZagF9269/IoF6vZJeail6qtoc5mVF3eVRikNT7UFnY0QASfe2y53mgE99s6GrHdpV+PZuFxaL71hkMhg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.3.tgz",
+      "integrity": "sha512-03qIJgyGmm0IoTZbV/cfODru9jRGogi4LcQ3maxIJDKccq1gY3ofgt2UYPkeU143ElxitZahEythNQv1NpsLhg==",
       "dev": true,
       "requires": {
         "@mapbox/geojson-area": "^0.2.2",
@@ -29709,12 +30829,11 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
-    "@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+    "@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       },
@@ -29723,8 +30842,77 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true,
-          "peer": true
+          "dev": true
+        }
+      }
+    },
+    "@smithy/types": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "dev": true,
+      "requires": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
         }
       }
     },
@@ -29891,12 +31079,13 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "version": "7946.0.13",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
+      "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
@@ -29927,15 +31116,15 @@
       }
     },
     "@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
       "dev": true
     },
     "@types/mapbox__vector-tile": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-      "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "dev": true,
       "requires": {
         "@types/geojson": "*",
@@ -29944,9 +31133,9 @@
       }
     },
     "@types/mapbox-gl": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.10.tgz",
-      "integrity": "sha512-nMVEcu9bAcenvx6oPWubQSPevsekByjOfKjlkr+8P91vawtkxTnopDoXXq1Qn/f4cg3zt0Z2W9DVsVsKRNXJTw==",
+      "version": "2.7.18",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.18.tgz",
+      "integrity": "sha512-3Yq4v8IdigSs2oD70dRJuWY/6PoW9i6MyXOx8DvJNc6CuSXRMleVdNiFYa5E0w6tSCfL+b+cGau5Em09MIujtQ==",
       "dev": true,
       "requires": {
         "@types/geojson": "*"
@@ -29962,6 +31151,7 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
       "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -29972,6 +31162,7 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
           "dev": true,
+          "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -29981,9 +31172,9 @@
       }
     },
     "@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "dev": true
     },
     "@types/sinonjs__fake-timers": {
@@ -30004,6 +31195,12 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true,
       "peer": true
+    },
+    "@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.24",
@@ -30113,6 +31310,7 @@
       "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.6.tgz",
       "integrity": "sha512-kBq+GE6OkLrxtFj3ZduIOlKBFYeOqZK3EhxbDBkv476UTvy+uwfR0tlriTq2QzNdnvlQAjBIXnXuOM7DwR1UEQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-js": "1.2.2",
         "buffer": "4.9.2",
@@ -30441,6 +31639,55 @@
         "tslib": "^2.0.0"
       },
       "dependencies": {
+        "@aws-amplify/core": {
+          "version": "5.8.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.5.tgz",
+          "integrity": "sha512-R7zB+VUyNRT/7GCfBfWOIz2vy70VbHNfhotbdyo02ZVcc4vyXt+tsdZvvMSm1SB5uQ411jiAfDmTvOzLOIaJsA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+            "@aws-sdk/types": "3.6.1",
+            "@aws-sdk/util-hex-encoding": "3.6.1",
+            "@types/node-fetch": "2.6.4",
+            "isomorphic-unfetch": "^3.0.0",
+            "react-native-url-polyfill": "^1.3.0",
+            "tslib": "^1.8.0",
+            "universal-cookie": "^4.0.4",
+            "zen-observable-ts": "0.8.19"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true,
+              "peer": true
+            }
+          }
+        },
+        "@aws-amplify/datastore": {
+          "version": "4.7.5",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.5.tgz",
+          "integrity": "sha512-q+5hYvPD5Y4zAximOUQY9bokZ0L2VDmqbbCjwd7rbq0qZS4cjcaMTeRk5HqxSA+HBCn4L17bqJ3z3GHCe+JZIA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@aws-amplify/api": "5.4.5",
+            "@aws-amplify/auth": "5.6.5",
+            "@aws-amplify/core": "5.8.5",
+            "@aws-amplify/pubsub": "5.5.5",
+            "amazon-cognito-identity-js": "6.3.6",
+            "buffer": "4.9.2",
+            "idb": "5.0.6",
+            "immer": "9.0.6",
+            "ulid": "2.3.0",
+            "uuid": "3.4.0",
+            "zen-observable-ts": "0.8.19",
+            "zen-push": "0.2.1"
+          }
+        },
         "tslib": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -30467,6 +31714,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
       "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "dev": true,
+      "peer": true,
       "requires": {
         "follow-redirects": "^1.14.8"
       }
@@ -30668,7 +31916,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -31316,7 +32565,8 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -32175,7 +33425,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
       "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -32368,7 +33619,8 @@
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
       "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -33084,6 +34336,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
       "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
@@ -33286,7 +34539,8 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "js-sdsl": {
       "version": "4.4.0",
@@ -34712,6 +35966,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
       "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -35416,7 +36671,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -35580,6 +36836,7 @@
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
       "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-base64-decode": "^1.0.0"
       }
@@ -35596,6 +36853,7 @@
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
       "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "whatwg-url-without-unicode": "8.0.0-3"
       }
@@ -35928,9 +37186,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -37007,7 +38265,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "traverse": {
       "version": "0.6.7",
@@ -37019,7 +38278,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -37102,7 +38362,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -37163,6 +38424,7 @@
       "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
       "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/cookie": "^0.3.3",
         "cookie": "^0.4.0"
@@ -37298,6 +38560,7 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -37307,7 +38570,8 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -37385,7 +38649,8 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "vary": {
       "version": "1.1.2",
@@ -37447,7 +38712,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "wgs84": {
       "version": "0.0.0",
@@ -37467,6 +38733,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -37477,6 +38744,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
       "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
       "dev": true,
+      "peer": true,
       "requires": {
         "buffer": "^5.4.3",
         "punycode": "^2.1.1",
@@ -37488,6 +38756,7 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
           "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -37497,7 +38766,8 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -37676,13 +38946,15 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "zen-observable-ts": {
       "version": "0.8.19",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
       "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
@@ -37693,6 +38965,7 @@
       "resolved": "https://registry.npmjs.org/zen-push/-/zen-push-0.2.1.tgz",
       "integrity": "sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "zen-observable": "^0.7.0"
       },
@@ -37701,7 +38974,8 @@
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
           "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     }

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -14,7 +14,7 @@
         "typescript": "^4.2.4"
       },
       "devDependencies": {
-        "@aws-amplify/datastore": "^5.0.0",
+        "@aws-amplify/datastore": "^4.0.0",
         "@aws-amplify/ui-react": "^5.0.0",
         "@aws-amplify/ui-react-storage": "^1.1.0",
         "cypress": "12.0.2",
@@ -228,183 +228,166 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.2.tgz",
-      "integrity": "sha512-PzOBZbelbOFhNRCj+PpV0lzWPEInB3TN8Yp0aNj8u+qy2+je8L3EQIPSw367KB3Ix69XhWzd9uLd6W2/ZDGk+Q==",
+      "version": "5.8.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.6.tgz",
+      "integrity": "sha512-fDu4aduCagJb8uwQd+S0FBhuYgCgnpwfRsmO0/t01h68JR+KS3Cny0pQa7Qzk6cW/HY3rtPLELOqbdF6doA6oA==",
       "dev": true,
       "dependencies": {
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/util-hex-encoding": "2.0.0",
-        "@types/uuid": "^9.0.0",
-        "js-cookie": "^3.0.5",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.5.0",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/core/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/core/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-amplify/core/node_modules/@aws-sdk/types": {
-      "version": "3.398.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
-      "integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.2.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/core/node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@aws-amplify/core/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
-    "node_modules/@aws-amplify/core/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-amplify/data-schema-types": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.4.2.tgz",
-      "integrity": "sha512-ip5U1FisKxCAgIupo5FxoJVsWedKOl1UIJrUOpMWBtSnhCeVDJerNyaH7Su5YxmOX4ZpG7SAMF9qwF5C1zIKgg==",
-      "dev": true,
-      "dependencies": {
-        "rxjs": "^7.8.1"
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.2.tgz",
-      "integrity": "sha512-GWYhEBHrHZsugUriY5cTs0TXMQ9vzaibOhnXxE9LZlYCHaMAAzq15rspVt4wxD6hZgCyS3PX1qqeSudT/anf8g==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.6.tgz",
+      "integrity": "sha512-vuozosYTmWUgYzR9tqBaP1CyusPQG9/caDeqQkHCDogqJRHIkWG9INon/EUZQu4bR7W5/V8y1Dv2bLqUJSUWZA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/api": "6.0.2",
+        "@aws-amplify/api": "5.4.6",
+        "@aws-amplify/auth": "5.6.6",
+        "@aws-amplify/core": "5.8.6",
+        "@aws-amplify/pubsub": "5.5.6",
+        "amazon-cognito-identity-js": "6.3.7",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
-        "rxjs": "^7.8.1",
-        "ulid": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "ulid": "2.3.0",
+        "uuid": "3.4.0",
+        "zen-observable-ts": "0.8.19",
+        "zen-push": "0.2.1"
       }
     },
     "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.2.tgz",
-      "integrity": "sha512-YhZa1jP9gh1Mfu73/x0TSz4CNMWbSdepQDjbyseRQGxwBRKQOG//bIcjup9LgCqmZlpwCbAOQdfPgAsReTFtHQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.4.6.tgz",
+      "integrity": "sha512-Wn9kQJ/uf0CYW1zoBueaCsoF5v3wJZpMxkpdEBYwD10GqhSt5baoghq2oW72JyDrGS8Hfq71o4a2vpXiIL/8hg==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.0.2",
-        "@aws-amplify/api-rest": "4.0.2",
-        "tslib": "^2.5.0"
+        "@aws-amplify/api-graphql": "3.4.12",
+        "@aws-amplify/api-rest": "3.5.6",
+        "tslib": "^1.8.0"
       }
     },
     "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api-graphql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.2.tgz",
-      "integrity": "sha512-2GRyvGYq9qCGUb/d9t5letHcTKAgCAvmqZN3Y2MyYWXRD+TwGTW/R8CM+N7uC/9j7S7cPQd09H9bDOH56Otekg==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-3.4.12.tgz",
+      "integrity": "sha512-lEKXl0hM7nyulCRUQNIQ6I0+DCD16hR+V4XUdMmVgnlVnPVows5H17wM/Hu24lX84G1jFi/i14umH8+qvpk1fQ==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/api-rest": "4.0.2",
-        "@aws-amplify/core": "6.0.2",
-        "@aws-amplify/data-schema-types": "^0.4.2",
-        "@aws-sdk/types": "3.387.0",
+        "@aws-amplify/api-rest": "3.5.6",
+        "@aws-amplify/auth": "5.6.6",
+        "@aws-amplify/cache": "5.1.12",
+        "@aws-amplify/core": "5.8.6",
+        "@aws-amplify/pubsub": "5.5.6",
         "graphql": "15.8.0",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.5.0",
-        "uuid": "^9.0.0"
+        "tslib": "^1.8.0",
+        "uuid": "^3.2.1",
+        "zen-observable-ts": "0.8.19"
       }
     },
     "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/api-rest": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.2.tgz",
-      "integrity": "sha512-pMNkndD1TJw7/Epeu59Izx67aol8mz55SjtskQT2awIhMFh/J1S2tbkkZ1jZAzKb8oS9jg/+4llRJCEQN/3mdg==",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.5.6.tgz",
+      "integrity": "sha512-WAv7q05G2ypE59ebVMvIih5aTIi+jOTu+ApkEI/E5mNM2Lj33TnaOrM5Vt2oja0aHT37AQHvIF1gYYf6gF1iRQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "peerDependencies": {
-        "@aws-amplify/core": "^6.0.0"
+        "@aws-amplify/core": "5.8.6",
+        "axios": "1.6.0",
+        "tslib": "^1.8.0",
+        "url": "0.11.0"
       }
     },
-    "node_modules/@aws-amplify/datastore/node_modules/@aws-sdk/types": {
-      "version": "3.387.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
-      "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
+    "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/auth": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.6.tgz",
+      "integrity": "sha512-v4qiOTW7dTObEoHPjQMl0diL+E7KKk6HrKd1O+roE9f93U1ZDbcIkeY5Yih+I/U8VbS+hQ5D9oHyFbeLZWsDcg==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^2.1.0",
-        "tslib": "^2.5.0"
+        "@aws-amplify/core": "5.8.6",
+        "amazon-cognito-identity-js": "6.3.7",
+        "buffer": "4.9.2",
+        "tslib": "^1.8.0",
+        "url": "0.11.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/cache": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.12.tgz",
+      "integrity": "sha512-bOhkqABOUehPCWy5x5XHMHfJtuQ7tBOGD7gAhDo6leY1O7NIHjDBto+U6FZmCE2bS8u/QcgJ94PRZ1E5/3rsng==",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/core": "5.8.6",
+        "tslib": "^1.8.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/@aws-amplify/pubsub": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.5.6.tgz",
+      "integrity": "sha512-IxM2hjGwLQm2ICFKyr2jdpLVje5Z/m0wsLD0laDfF441NkGwSP1AEpds1I5ozAJ18ETsnxRS/6731H+nSdLVgQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-amplify/auth": "5.6.6",
+        "@aws-amplify/cache": "5.1.12",
+        "@aws-amplify/core": "5.8.6",
+        "buffer": "4.9.2",
+        "graphql": "15.8.0",
+        "tslib": "^1.8.0",
+        "url": "0.11.0",
+        "uuid": "^3.2.1",
+        "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/amazon-cognito-identity-js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.7.tgz",
+      "integrity": "sha512-tSjnM7KyAeOZ7UMah+oOZ6cW4Gf64FFcc7BE2l7MTcp7ekAPrXaCbpcW2xEpH1EiDS4cPcAouHzmCuc2tr72vQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "buffer": "4.9.2",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 6"
       }
     },
-    "node_modules/@aws-amplify/datastore/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+    "node_modules/@aws-amplify/datastore/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
-    },
-    "node_modules/@aws-amplify/datastore/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@aws-amplify/geo": {
       "version": "2.3.5",
@@ -907,7 +890,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
       "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -917,7 +899,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
       "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.2.2",
@@ -933,7 +914,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
       "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^1.2.2",
         "@aws-sdk/types": "^3.1.0",
@@ -945,7 +925,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
       "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -955,7 +934,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
       "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -967,7 +945,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
       "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -981,7 +958,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.6.1.tgz",
       "integrity": "sha512-QOxIDnlVTpnwJ26Gap6RGz61cDLH6TKrIp30VqwdMeT1pCGy8mn9rWln6XA+ymkofHy/08RfpGp+VN4axwd4Lw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
@@ -1024,7 +1000,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
       "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       }
@@ -1033,15 +1008,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-sdk/client-comprehend": {
       "version": "3.6.1",
@@ -5419,7 +5392,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
       "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5434,7 +5406,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
       "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5449,7 +5420,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
       "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5464,7 +5434,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
       "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -5480,7 +5449,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
       "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.6.1",
         "@aws-sdk/credential-provider-imds": "3.6.1",
@@ -5500,7 +5468,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
       "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-ini": "3.6.1",
         "@aws-sdk/property-provider": "3.6.1",
@@ -5786,7 +5753,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
       "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/querystring-builder": "3.6.1",
@@ -5800,7 +5766,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
       "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-buffer-from": "3.6.1",
@@ -5815,7 +5780,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
       "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5826,7 +5790,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
       "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -5861,7 +5824,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
       "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5922,7 +5884,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
       "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -5937,7 +5898,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
       "integrity": "sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -5997,7 +5957,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
       "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/service-error-classification": "3.6.1",
@@ -6153,7 +6112,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
       "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -6167,7 +6125,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
       "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/signature-v4": "3.6.1",
@@ -6183,7 +6140,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
       "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -6196,7 +6152,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
       "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -6211,7 +6166,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
       "integrity": "sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -6227,7 +6181,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
       "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.6.1",
         "@aws-sdk/protocol-http": "3.6.1",
@@ -6244,7 +6197,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
       "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -6258,7 +6210,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
       "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -6272,7 +6223,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
       "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-uri-escape": "3.6.1",
@@ -6287,7 +6237,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
       "integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -6301,7 +6250,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
       "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -6311,7 +6259,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
       "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -6324,7 +6271,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
       "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -6341,7 +6287,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
       "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -6356,7 +6301,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
       "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -6366,7 +6310,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.6.1.tgz",
       "integrity": "sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -6378,7 +6321,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz",
       "integrity": "sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -6394,7 +6336,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
       "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       }
@@ -6404,7 +6345,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
       "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -6418,7 +6358,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
       "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       }
@@ -6428,7 +6367,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
       "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -6441,7 +6379,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
       "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "tslib": "^1.8.0"
@@ -6718,7 +6655,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
       "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -6731,7 +6667,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.295.0.tgz",
       "integrity": "sha512-d/s+zhUx5Kh4l/ecMP/TBjzp1GR/g89Q4nWH6+wH5WgdHsK+LG+vmsk6mVNuP/8wsCofYG4NBqp5Ulbztbm9QA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -6743,8 +6678,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-sdk/util-middleware": {
       "version": "3.186.0",
@@ -6771,7 +6705,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
       "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.8.0"
       },
@@ -6784,7 +6717,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
       "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "bowser": "^2.11.0",
@@ -6796,7 +6728,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
       "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -6811,7 +6742,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -6820,15 +6750,13 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@aws-sdk/util-utf8-node": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
       "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -11322,29 +11250,12 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@smithy/types": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
       "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -11356,63 +11267,8 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
       "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
-      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@turf/along": {
       "version": "6.5.0",
@@ -11622,8 +11478,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.13",
@@ -11694,7 +11549,6 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
       "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -11705,7 +11559,6 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11739,12 +11592,6 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
-      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -12628,8 +12475,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -13424,7 +13270,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14502,8 +14347,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
       "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -14745,7 +14589,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -15688,7 +15531,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
       "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
@@ -15932,8 +15774,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
@@ -17616,7 +17457,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
       "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -18511,7 +18351,6 @@
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -18734,7 +18573,6 @@
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
       "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-base64-decode": "^1.0.0"
       },
@@ -18754,7 +18592,6 @@
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
       "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -20486,8 +20323,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/traverse": {
       "version": "0.6.7",
@@ -20502,8 +20338,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -20619,8 +20454,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -20697,7 +20531,6 @@
       "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
       "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/cookie": "^0.3.3",
         "cookie": "^0.4.0"
@@ -20863,7 +20696,6 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -20873,8 +20705,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -20987,7 +20818,6 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
-      "peer": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -21058,8 +20888,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/wgs84": {
       "version": "0.0.0",
@@ -21079,7 +20908,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -21090,7 +20918,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
       "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.4.3",
         "punycode": "^2.1.1",
@@ -21119,7 +20946,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -21130,7 +20956,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
       "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -21357,15 +21182,13 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/zen-observable-ts": {
       "version": "0.8.19",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
       "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
@@ -21376,7 +21199,6 @@
       "resolved": "https://registry.npmjs.org/zen-push/-/zen-push-0.2.1.tgz",
       "integrity": "sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "zen-observable": "^0.7.0"
       }
@@ -21385,8 +21207,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
       "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     }
   },
   "dependencies": {
@@ -21603,152 +21424,162 @@
       }
     },
     "@aws-amplify/core": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.2.tgz",
-      "integrity": "sha512-PzOBZbelbOFhNRCj+PpV0lzWPEInB3TN8Yp0aNj8u+qy2+je8L3EQIPSw367KB3Ix69XhWzd9uLd6W2/ZDGk+Q==",
+      "version": "5.8.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.6.tgz",
+      "integrity": "sha512-fDu4aduCagJb8uwQd+S0FBhuYgCgnpwfRsmO0/t01h68JR+KS3Cny0pQa7Qzk6cW/HY3rtPLELOqbdF6doA6oA==",
       "dev": true,
       "requires": {
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/types": "3.398.0",
-        "@smithy/util-hex-encoding": "2.0.0",
-        "@types/uuid": "^9.0.0",
-        "js-cookie": "^3.0.5",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.5.0",
-        "uuid": "^9.0.0"
-      },
-      "dependencies": {
-        "@aws-crypto/sha256-js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.398.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.398.0.tgz",
-          "integrity": "sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==",
-          "dev": true,
-          "requires": {
-            "@smithy/types": "^2.2.2",
-            "tslib": "^2.5.0"
-          }
-        },
-        "js-cookie": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-          "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-          "dev": true
-        },
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-          "dev": true
-        }
-      }
-    },
-    "@aws-amplify/data-schema-types": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.4.2.tgz",
-      "integrity": "sha512-ip5U1FisKxCAgIupo5FxoJVsWedKOl1UIJrUOpMWBtSnhCeVDJerNyaH7Su5YxmOX4ZpG7SAMF9qwF5C1zIKgg==",
-      "dev": true,
-      "requires": {
-        "rxjs": "^7.8.1"
+        "@aws-crypto/sha256-js": "1.2.2",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
+        "@aws-sdk/types": "3.6.1",
+        "@aws-sdk/util-hex-encoding": "3.6.1",
+        "@types/node-fetch": "2.6.4",
+        "isomorphic-unfetch": "^3.0.0",
+        "react-native-url-polyfill": "^1.3.0",
+        "tslib": "^1.8.0",
+        "universal-cookie": "^4.0.4",
+        "zen-observable-ts": "0.8.19"
       }
     },
     "@aws-amplify/datastore": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.2.tgz",
-      "integrity": "sha512-GWYhEBHrHZsugUriY5cTs0TXMQ9vzaibOhnXxE9LZlYCHaMAAzq15rspVt4wxD6hZgCyS3PX1qqeSudT/anf8g==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.6.tgz",
+      "integrity": "sha512-vuozosYTmWUgYzR9tqBaP1CyusPQG9/caDeqQkHCDogqJRHIkWG9INon/EUZQu4bR7W5/V8y1Dv2bLqUJSUWZA==",
       "dev": true,
       "requires": {
-        "@aws-amplify/api": "6.0.2",
+        "@aws-amplify/api": "5.4.6",
+        "@aws-amplify/auth": "5.6.6",
+        "@aws-amplify/core": "5.8.6",
+        "@aws-amplify/pubsub": "5.5.6",
+        "amazon-cognito-identity-js": "6.3.7",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
-        "rxjs": "^7.8.1",
-        "ulid": "^2.3.0"
+        "ulid": "2.3.0",
+        "uuid": "3.4.0",
+        "zen-observable-ts": "0.8.19",
+        "zen-push": "0.2.1"
       },
       "dependencies": {
         "@aws-amplify/api": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.2.tgz",
-          "integrity": "sha512-YhZa1jP9gh1Mfu73/x0TSz4CNMWbSdepQDjbyseRQGxwBRKQOG//bIcjup9LgCqmZlpwCbAOQdfPgAsReTFtHQ==",
+          "version": "5.4.6",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.4.6.tgz",
+          "integrity": "sha512-Wn9kQJ/uf0CYW1zoBueaCsoF5v3wJZpMxkpdEBYwD10GqhSt5baoghq2oW72JyDrGS8Hfq71o4a2vpXiIL/8hg==",
           "dev": true,
           "requires": {
-            "@aws-amplify/api-graphql": "4.0.2",
-            "@aws-amplify/api-rest": "4.0.2",
-            "tslib": "^2.5.0"
+            "@aws-amplify/api-graphql": "3.4.12",
+            "@aws-amplify/api-rest": "3.5.6",
+            "tslib": "^1.8.0"
           }
         },
         "@aws-amplify/api-graphql": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.2.tgz",
-          "integrity": "sha512-2GRyvGYq9qCGUb/d9t5letHcTKAgCAvmqZN3Y2MyYWXRD+TwGTW/R8CM+N7uC/9j7S7cPQd09H9bDOH56Otekg==",
+          "version": "3.4.12",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-3.4.12.tgz",
+          "integrity": "sha512-lEKXl0hM7nyulCRUQNIQ6I0+DCD16hR+V4XUdMmVgnlVnPVows5H17wM/Hu24lX84G1jFi/i14umH8+qvpk1fQ==",
           "dev": true,
           "requires": {
-            "@aws-amplify/api-rest": "4.0.2",
-            "@aws-amplify/core": "6.0.2",
-            "@aws-amplify/data-schema-types": "^0.4.2",
-            "@aws-sdk/types": "3.387.0",
+            "@aws-amplify/api-rest": "3.5.6",
+            "@aws-amplify/auth": "5.6.6",
+            "@aws-amplify/cache": "5.1.12",
+            "@aws-amplify/core": "5.8.6",
+            "@aws-amplify/pubsub": "5.5.6",
             "graphql": "15.8.0",
-            "rxjs": "^7.8.1",
-            "tslib": "^2.5.0",
-            "uuid": "^9.0.0"
+            "tslib": "^1.8.0",
+            "uuid": "^3.2.1",
+            "zen-observable-ts": "0.8.19"
           }
         },
         "@aws-amplify/api-rest": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.2.tgz",
-          "integrity": "sha512-pMNkndD1TJw7/Epeu59Izx67aol8mz55SjtskQT2awIhMFh/J1S2tbkkZ1jZAzKb8oS9jg/+4llRJCEQN/3mdg==",
+          "version": "3.5.6",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.5.6.tgz",
+          "integrity": "sha512-WAv7q05G2ypE59ebVMvIih5aTIi+jOTu+ApkEI/E5mNM2Lj33TnaOrM5Vt2oja0aHT37AQHvIF1gYYf6gF1iRQ==",
           "dev": true,
           "requires": {
-            "tslib": "^2.5.0"
+            "@aws-amplify/core": "5.8.6",
+            "axios": "1.6.0",
+            "tslib": "^1.8.0",
+            "url": "0.11.0"
           }
         },
-        "@aws-sdk/types": {
-          "version": "3.387.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
-          "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
+        "@aws-amplify/auth": {
+          "version": "5.6.6",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.6.tgz",
+          "integrity": "sha512-v4qiOTW7dTObEoHPjQMl0diL+E7KKk6HrKd1O+roE9f93U1ZDbcIkeY5Yih+I/U8VbS+hQ5D9oHyFbeLZWsDcg==",
           "dev": true,
           "requires": {
-            "@smithy/types": "^2.1.0",
-            "tslib": "^2.5.0"
+            "@aws-amplify/core": "5.8.6",
+            "amazon-cognito-identity-js": "6.3.7",
+            "buffer": "4.9.2",
+            "tslib": "^1.8.0",
+            "url": "0.11.0"
           }
         },
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
+        "@aws-amplify/cache": {
+          "version": "5.1.12",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.12.tgz",
+          "integrity": "sha512-bOhkqABOUehPCWy5x5XHMHfJtuQ7tBOGD7gAhDo6leY1O7NIHjDBto+U6FZmCE2bS8u/QcgJ94PRZ1E5/3rsng==",
+          "dev": true,
+          "requires": {
+            "@aws-amplify/core": "5.8.6",
+            "tslib": "^1.8.0"
+          }
         },
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+        "@aws-amplify/pubsub": {
+          "version": "5.5.6",
+          "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.5.6.tgz",
+          "integrity": "sha512-IxM2hjGwLQm2ICFKyr2jdpLVje5Z/m0wsLD0laDfF441NkGwSP1AEpds1I5ozAJ18ETsnxRS/6731H+nSdLVgQ==",
+          "dev": true,
+          "requires": {
+            "@aws-amplify/auth": "5.6.6",
+            "@aws-amplify/cache": "5.1.12",
+            "@aws-amplify/core": "5.8.6",
+            "buffer": "4.9.2",
+            "graphql": "15.8.0",
+            "tslib": "^1.8.0",
+            "url": "0.11.0",
+            "uuid": "^3.2.1",
+            "zen-observable-ts": "0.8.19"
+          }
+        },
+        "amazon-cognito-identity-js": {
+          "version": "6.3.7",
+          "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.7.tgz",
+          "integrity": "sha512-tSjnM7KyAeOZ7UMah+oOZ6cW4Gf64FFcc7BE2l7MTcp7ekAPrXaCbpcW2xEpH1EiDS4cPcAouHzmCuc2tr72vQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-js": "1.2.2",
+            "buffer": "4.9.2",
+            "fast-base64-decode": "^1.0.0",
+            "isomorphic-unfetch": "^3.0.0",
+            "js-cookie": "^2.2.1"
+          }
+        },
+        "axios": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+          "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
           "dev": true
         }
       }
@@ -22195,7 +22026,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
       "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       }
@@ -22205,7 +22035,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.2.2.tgz",
       "integrity": "sha512-0tNR4kBtJp+9S0kis4+JLab3eg6QWuIeuPhzaYoYwNUXGBgsWIkktA2mnilet+EGWzf3n1zknJXC4X4DVyyXbg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.2.2",
@@ -22221,7 +22050,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
       "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-crypto/util": "^1.2.2",
         "@aws-sdk/types": "^3.1.0",
@@ -22233,7 +22061,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
       "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       }
@@ -22243,7 +22070,6 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
       "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -22255,7 +22081,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.6.1.tgz",
       "integrity": "sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -22266,7 +22091,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.6.1.tgz",
       "integrity": "sha512-QOxIDnlVTpnwJ26Gap6RGz61cDLH6TKrIp30VqwdMeT1pCGy8mn9rWln6XA+ymkofHy/08RfpGp+VN4axwd4Lw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
@@ -22306,7 +22130,6 @@
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
           "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "tslib": "^1.8.0"
           },
@@ -22315,8 +22138,7 @@
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
               "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-              "dev": true,
-              "peer": true
+              "dev": true
             }
           }
         },
@@ -22324,8 +22146,7 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -26171,7 +25992,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
       "integrity": "sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26183,7 +26003,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.6.1.tgz",
       "integrity": "sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26195,7 +26014,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
       "integrity": "sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26207,7 +26025,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.6.1.tgz",
       "integrity": "sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -26220,7 +26037,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.6.1.tgz",
       "integrity": "sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.6.1",
         "@aws-sdk/credential-provider-imds": "3.6.1",
@@ -26237,7 +26053,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
       "integrity": "sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-ini": "3.6.1",
         "@aws-sdk/property-provider": "3.6.1",
@@ -26485,7 +26300,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.6.1.tgz",
       "integrity": "sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/querystring-builder": "3.6.1",
@@ -26499,7 +26313,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
       "integrity": "sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-buffer-from": "3.6.1",
@@ -26511,7 +26324,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
       "integrity": "sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -26522,7 +26334,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz",
       "integrity": "sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -26556,7 +26367,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
       "integrity": "sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26607,7 +26417,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
       "integrity": "sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26619,7 +26428,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
       "integrity": "sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -26669,7 +26477,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.6.1.tgz",
       "integrity": "sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/service-error-classification": "3.6.1",
@@ -26797,7 +26604,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
       "integrity": "sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -26808,7 +26614,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.6.1.tgz",
       "integrity": "sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/signature-v4": "3.6.1",
@@ -26821,7 +26626,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.6.1.tgz",
       "integrity": "sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -26831,7 +26635,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.6.1.tgz",
       "integrity": "sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26843,7 +26646,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
       "integrity": "sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
@@ -26856,7 +26658,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.6.1.tgz",
       "integrity": "sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.6.1",
         "@aws-sdk/protocol-http": "3.6.1",
@@ -26870,7 +26671,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
       "integrity": "sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -26881,7 +26681,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
       "integrity": "sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -26892,7 +26691,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.6.1.tgz",
       "integrity": "sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-uri-escape": "3.6.1",
@@ -26904,7 +26702,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
       "integrity": "sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
@@ -26914,15 +26711,13 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.6.1.tgz",
       "integrity": "sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz",
       "integrity": "sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -26932,7 +26727,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.6.1.tgz",
       "integrity": "sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26946,7 +26740,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
       "integrity": "sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26957,15 +26750,13 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
       "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@aws-sdk/url-parser": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.6.1.tgz",
       "integrity": "sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26977,7 +26768,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz",
       "integrity": "sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -26990,7 +26780,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.6.1.tgz",
       "integrity": "sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -27000,7 +26789,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.6.1.tgz",
       "integrity": "sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -27011,7 +26799,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.6.1.tgz",
       "integrity": "sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -27021,7 +26808,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.6.1.tgz",
       "integrity": "sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -27031,7 +26817,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.6.1.tgz",
       "integrity": "sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.6.1",
         "tslib": "^1.8.0"
@@ -27263,7 +27048,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.6.1.tgz",
       "integrity": "sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -27273,7 +27057,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.295.0.tgz",
       "integrity": "sha512-d/s+zhUx5Kh4l/ecMP/TBjzp1GR/g89Q4nWH6+wH5WgdHsK+LG+vmsk6mVNuP/8wsCofYG4NBqp5Ulbztbm9QA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       },
@@ -27282,8 +27065,7 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
           "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -27311,7 +27093,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.6.1.tgz",
       "integrity": "sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -27321,7 +27102,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz",
       "integrity": "sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "bowser": "^2.11.0",
@@ -27333,7 +27113,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
       "integrity": "sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -27345,7 +27124,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       },
@@ -27354,8 +27132,7 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
           "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -27364,7 +27141,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.6.1.tgz",
       "integrity": "sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
@@ -30829,28 +30605,12 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
-    "@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
-      }
-    },
     "@smithy/types": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
       "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       },
@@ -30859,60 +30619,8 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
-      }
-    },
-    "@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
-      "requires": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
-      }
-    },
-    "@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
-      }
-    },
-    "@smithy/util-utf8": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
-      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
-      "dev": true,
-      "requires": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -31079,8 +30787,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
       "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/geojson": {
       "version": "7946.0.13",
@@ -31151,7 +30858,6 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
       "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -31162,7 +30868,6 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
           "dev": true,
-          "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -31195,12 +30900,6 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true,
       "peer": true
-    },
-    "@types/uuid": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
-      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.24",
@@ -31916,8 +31615,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -32565,8 +32263,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -33425,8 +33122,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
       "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -33619,8 +33315,7 @@
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
       "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -34336,7 +34031,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
       "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
@@ -34539,8 +34233,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "js-sdsl": {
       "version": "4.4.0",
@@ -35966,7 +35659,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
       "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -36671,8 +36363,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -36836,7 +36527,6 @@
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
       "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fast-base64-decode": "^1.0.0"
       }
@@ -36853,7 +36543,6 @@
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
       "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "whatwg-url-without-unicode": "8.0.0-3"
       }
@@ -38265,8 +37954,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "traverse": {
       "version": "0.6.7",
@@ -38278,8 +37966,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -38362,8 +38049,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -38424,7 +38110,6 @@
       "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
       "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/cookie": "^0.3.3",
         "cookie": "^0.4.0"
@@ -38560,7 +38245,6 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -38570,8 +38254,7 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -38649,8 +38332,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -38712,8 +38394,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "wgs84": {
       "version": "0.0.0",
@@ -38733,7 +38414,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -38744,7 +38424,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
       "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
       "dev": true,
-      "peer": true,
       "requires": {
         "buffer": "^5.4.3",
         "punycode": "^2.1.1",
@@ -38756,7 +38435,6 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
           "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -38766,8 +38444,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -38946,15 +38623,13 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "zen-observable-ts": {
       "version": "0.8.19",
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
       "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
@@ -38965,7 +38640,6 @@
       "resolved": "https://registry.npmjs.org/zen-push/-/zen-push-0.2.1.tgz",
       "integrity": "sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "zen-observable": "^0.7.0"
       },
@@ -38974,8 +38648,7 @@
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
           "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     }

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -26,8 +26,8 @@
     "typescript": "^4.2.4"
   },
   "devDependencies": {
-    "@aws-amplify/datastore": "^4.0.0",
-    "@aws-amplify/ui-react": "^4.6.0",
+    "@aws-amplify/datastore": "^5.0.0",
+    "@aws-amplify/ui-react": "^5.0.0",
     "@aws-amplify/ui-react-storage": "^1.1.0",
     "cypress": "12.0.2",
     "eslint-plugin-cypress": "2.12.1",

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.2.4"
   },
   "devDependencies": {
-    "@aws-amplify/datastore": "^5.0.0",
+    "@aws-amplify/datastore": "^4.0.0",
     "@aws-amplify/ui-react": "^5.0.0",
     "@aws-amplify/ui-react-storage": "^1.1.0",
     "cypress": "12.0.2",

--- a/scripts/integ-setup.bat
+++ b/scripts/integ-setup.bat
@@ -14,7 +14,7 @@ call npm run integ:templates
 call lerna bootstrap
 call lerna add --scope integration-test aws-amplify@^5.0.0
 call lerna add --scope integration-test @aws-amplify/ui-react@^5.0.0
-call lerna add --scope integration-test @aws-amplify/datastore@^5.0.0
+call lerna add --scope integration-test @aws-amplify/datastore@^4.0.0
 call lerna add --scope integration-test @aws-amplify/codegen-ui
 call lerna add --scope integration-test @aws-amplify/codegen-ui-react
 call lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator

--- a/scripts/integ-setup.bat
+++ b/scripts/integ-setup.bat
@@ -12,9 +12,9 @@ call npm run integ:templates
 
 :: install
 call lerna bootstrap
-call lerna add --scope integration-test aws-amplify
-call lerna add --scope integration-test @aws-amplify/ui-react
-call lerna add --scope integration-test @aws-amplify/datastore
+call lerna add --scope integration-test aws-amplify@^5.0.0
+call lerna add --scope integration-test @aws-amplify/ui-react@^5.0.0
+call lerna add --scope integration-test @aws-amplify/datastore@^5.0.0
 call lerna add --scope integration-test @aws-amplify/codegen-ui
 call lerna add --scope integration-test @aws-amplify/codegen-ui-react
 call lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator

--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -19,7 +19,7 @@ lerna bootstrap
 lerna add --scope integration-test typescript@4.4.4
 lerna add --scope integration-test aws-amplify@^5.0.0
 lerna add --scope integration-test @aws-amplify/ui-react@^5.0.0
-lerna add --scope integration-test @aws-amplify/datastore
+lerna add --scope integration-test @aws-amplify/datastore@^5.0.0
 lerna add --scope integration-test @aws-amplify/codegen-ui
 lerna add --scope integration-test @aws-amplify/codegen-ui-react
 lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator

--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -17,8 +17,8 @@ npm run integ:templates
 # install
 lerna bootstrap
 lerna add --scope integration-test typescript@4.4.4
-lerna add --scope integration-test aws-amplify
-lerna add --scope integration-test @aws-amplify/ui-react
+lerna add --scope integration-test aws-amplify@^5.0.0
+lerna add --scope integration-test @aws-amplify/ui-react@^5.0.0
 lerna add --scope integration-test @aws-amplify/datastore
 lerna add --scope integration-test @aws-amplify/codegen-ui
 lerna add --scope integration-test @aws-amplify/codegen-ui-react

--- a/scripts/integ-setup.sh
+++ b/scripts/integ-setup.sh
@@ -19,7 +19,7 @@ lerna bootstrap
 lerna add --scope integration-test typescript@4.4.4
 lerna add --scope integration-test aws-amplify@^5.0.0
 lerna add --scope integration-test @aws-amplify/ui-react@^5.0.0
-lerna add --scope integration-test @aws-amplify/datastore@^5.0.0
+lerna add --scope integration-test @aws-amplify/datastore@^4.0.0
 lerna add --scope integration-test @aws-amplify/codegen-ui
 lerna add --scope integration-test @aws-amplify/codegen-ui-react
 lerna add --scope integration-test @aws-amplify/codegen-ui-test-generator

--- a/scripts/integ-templates.sh
+++ b/scripts/integ-templates.sh
@@ -3,4 +3,4 @@ set -e
 
 lerna run build --scope @aws-amplify/codegen-ui-test-generator
 cp -r packages/test-generator/integration-test-templates/. packages/integration-test
-node DEPENDENCIES='{"aws-amplify": "5.0.0"}' packages/test-generator/dist/generators/GenerateTestApp.js
+DEPENDENCIES='{"aws-amplify": "5.0.0"}' node packages/test-generator/dist/generators/GenerateTestApp.js

--- a/scripts/integ-templates.sh
+++ b/scripts/integ-templates.sh
@@ -3,4 +3,4 @@ set -e
 
 lerna run build --scope @aws-amplify/codegen-ui-test-generator
 cp -r packages/test-generator/integration-test-templates/. packages/integration-test
-node packages/test-generator/dist/generators/GenerateTestApp.js
+node DEPENDENCIES='{"aws-amplify": "5.0.0"}' packages/test-generator/dist/generators/GenerateTestApp.js


### PR DESCRIPTION
## Problem

Amplify JS UI React just moved v6 to latest and we need to render v6 code as latest.

## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

Update v6 feature flag

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] N/A - (provide a reason) feature flag update only. We already have a bunch of unit tests that tests this feature flag being on and off.
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
