### PR TITLE
fix: v6 cli release canary

### DIFF
--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -173,3 +173,85 @@ jobs:
           role-to-assume: ${{ secrets.CANARY_METRIC_ROLE_ARN }}
           aws-region: us-west-2
       - run: aws cloudwatch put-metric-data --metric-name ReleaseSuccessRate --namespace CodegenUiCanaries --value 1
+
+  release-canary-v6:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Studio Codegen
+        uses: actions/checkout@v2
+        with:
+          path: amplify-codegen-ui
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+      - name: Install Latest Amplfy CLI
+        run: npm i -g @aws-amplify/cli@latest
+      - name: Create a test react app
+        run: npx create-react-app e2e-test-app
+      - name: Install test app dependencies
+        working-directory: e2e-test-app
+        run: |
+          npm i aws-amplify@^6.0.0 @aws-amplify/ui-react@^6.0.0
+          npm i --save-dev cypress
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.E2E_TEST_ROLE_ARN }}
+          aws-region: us-west-2
+      - name: Create temp AWS credentials file
+        working-directory: e2e-test-app
+        run: |
+          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID && \
+          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY && \
+          aws configure set aws_session_token $AWS_SESSION_TOKEN && \
+          aws configure set default.region $AWS_REGION
+      - name: Run CLI Pull in test app
+        working-directory: e2e-test-app
+        run: |
+          FORCE_RENDER=1 amplify pull --appId ${{ secrets.E2E_TEST_APP_ID }} --envName staging -y --providers "{\
+            \"awscloudformation\":{\
+              \"configLevel\":\"project\",\
+              \"useProfile\":true,\
+              \"profileName\":\"default\",\
+            }\
+          }"
+      - name: Write test files
+        working-directory: e2e-test-app
+        run: cp -r ../amplify-codegen-ui/packages/test-generator/e2e-test-templates-amplify-js-v6/. .
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: e2e-test-app
+          install: false
+          start: npm start
+          wait-on: 'http://localhost:3000'
+          wait-on-timeout: 120
+          config-file: cypress.config.js
+        env:
+          REACT_APP_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+          REACT_APP_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+
+  write-release-canary-v6-failure-metric:
+    runs-on: ubuntu-latest
+    needs: release-canary-v6
+    if: ${{ failure() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.CANARY_METRIC_ROLE_ARN }}
+          aws-region: us-west-2
+      - run: aws cloudwatch put-metric-data --metric-name ReleaseSuccessRate --namespace CodegenUiCanaries --value 0
+
+  write-release-canary-v6-success-metric:
+    runs-on: ubuntu-latest
+    needs: release-canary-v6
+    if: ${{ success() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.CANARY_METRIC_ROLE_ARN }}
+          aws-region: us-west-2
+      - run: aws cloudwatch put-metric-data --metric-name ReleaseSuccessRate --namespace CodegenUiCanaries --value 1


### PR DESCRIPTION
## Problem

need the cli release canary for v6

## Solution

this adds the v6 canary workflow

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [x] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
