### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           COMMIT_MESSAGE: ${{github.event.head_commit.message}}
         run: |
           version_number=$(echo "$COMMIT_MESSAGE" | sed -n "s/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p")
-          echo "::set-output name=version_number::$version_number"
+          echo "version_number=$version_number" >> "$GITHUB_OUTPUT"
       - name: Get Release Description
         run: npx -y changelog-parser CHANGELOG.md | jq -r '.versions[0].body' > release_description.md
       - name: Create Release


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter