### PR TITLE
fix: fix code scanning alerts

### DIFF
--- a/codegen-ui-golden-files/lib/react/forms/datastore-create-form-with-belongs-to/MemberCreateForm.jsx
+++ b/codegen-ui-golden-files/lib/react/forms/datastore-create-form-with-belongs-to/MemberCreateForm.jsx
@@ -50,7 +50,7 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((currentFieldValue !== undefined || currentFieldValue !== null || currentFieldValue !== '') && !hasError) {
+    if ((currentFieldValue !== undefined || currentFieldValue !== '') && !hasError) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;

--- a/codegen-ui-golden-files/lib/react/forms/datastore-update-form-with-has-many-relationship/SchoolUpdateForm.jsx
+++ b/codegen-ui-golden-files/lib/react/forms/datastore-update-form-with-has-many-relationship/SchoolUpdateForm.jsx
@@ -44,7 +44,7 @@ function ArrayField({
     setSelectedBadgeIndex(undefined);
   };
   const addItem = async () => {
-    if ((currentFieldValue !== undefined || currentFieldValue !== null || currentFieldValue !== '') && !hasError) {
+    if ((currentFieldValue !== undefined || currentFieldValue !== '') && !hasError) {
       const newItems = [...items];
       if (selectedBadgeIndex !== undefined) {
         newItems[selectedBadgeIndex] = currentFieldValue;

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ const {
 module.exports = {
   extends: ['@commitlint/config-conventional', '@commitlint/config-lerna-scopes'],
   rules: {
-    'scope-enum': async (context) => [2, 'always', [...(await getPackages(context)), 'release', 'deps']],
+    'scope-enum': async (context) => [2, 'always', [...(await getPackages(context)), 'release', 'deps', 'deps-dev']],
     'header-max-length': [2, 'always', 200],
   },
 };


### PR DESCRIPTION
## Problem

Fix [code scanning alerts](https://github.com/aws-amplify/amplify-codegen-ui/security/code-scanning/44) and add `deps-dev` to allow dev dependencies update from dependabot

## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [ ] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
