### PR TITLE
fix: add optional chaining

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -32139,7 +32139,7 @@ export default function UpdateOrgForm(props) {
     const queryData = async () => {
       const record = idProp ? await DataStore.query(Org, idProp) : orgModelProp;
       setOrgRecord(record);
-      const linkedComments = record ? await record.comments.toArray() : [];
+      const linkedComments = record ? await record?.comments?.toArray() : [];
       setLinkedComments(linkedComments);
     };
     queryData();
@@ -32759,13 +32759,13 @@ export default function UpdateCompositeDogForm(props) {
         : undefined;
       setCompositeOwner(CompositeOwnerRecord);
       const linkedCompositeToys = record
-        ? await record.CompositeToys.toArray()
+        ? await record?.CompositeToys?.toArray()
         : [];
       setLinkedCompositeToys(linkedCompositeToys);
       const linkedCompositeVets = record
         ? await Promise.all(
             (
-              await record.CompositeVets.toArray()
+              await record?.CompositeVets?.toArray()
             ).map((r) => {
               return r.compositeVet;
             })
@@ -33888,7 +33888,7 @@ export default function UpdateCPKTeacherForm(props) {
       const linkedCPKClasses = record
         ? await Promise.all(
             (
-              await record.CPKClasses.toArray()
+              await record?.CPKClasses?.toArray()
             ).map((r) => {
               return r.cpkClass;
             })
@@ -33896,7 +33896,7 @@ export default function UpdateCPKTeacherForm(props) {
         : [];
       setLinkedCPKClasses(linkedCPKClasses);
       const linkedCPKProjects = record
-        ? await record.CPKProjects.toArray()
+        ? await record?.CPKProjects?.toArray()
         : [];
       setLinkedCPKProjects(linkedCPKProjects);
     };
@@ -37257,13 +37257,13 @@ export default function UpdateCompositeDogForm(props) {
         : undefined;
       setCompositeOwner(CompositeOwnerRecord);
       const linkedCompositeToys = record
-        ? await record.CompositeToys.toArray()
+        ? await record?.CompositeToys?.toArray()
         : [];
       setLinkedCompositeToys(linkedCompositeToys);
       const linkedCompositeVets = record
         ? await Promise.all(
             (
-              await record.CompositeVets.toArray()
+              await record?.CompositeVets?.toArray()
             ).map((r) => {
               return r.compositeVet;
             })
@@ -46067,7 +46067,7 @@ export default function SchoolUpdateForm(props) {
         ? await DataStore.query(School, idProp)
         : schoolModelProp;
       setSchoolRecord(record);
-      const linkedStudents = record ? await record.Students.toArray() : [];
+      const linkedStudents = record ? await record?.Students?.toArray() : [];
       setLinkedStudents(linkedStudents);
     };
     queryData();
@@ -46643,7 +46643,7 @@ export default function SchoolUpdateForm(props) {
         ? await DataStore.query(School, idProp)
         : schoolModelProp;
       setSchoolRecord(record);
-      const linkedStudent = record ? await record.Student.toArray() : [];
+      const linkedStudent = record ? await record?.Student?.toArray() : [];
       setLinkedStudent(linkedStudent);
     };
     queryData();
@@ -47891,7 +47891,7 @@ export default function TagUpdateForm(props) {
       const linkedPosts = record
         ? await Promise.all(
             (
-              await record.Posts.toArray()
+              await record?.Posts?.toArray()
             ).map((r) => {
               return r.post;
             })
@@ -55329,7 +55329,7 @@ export default function UpdateDealershipForm(props) {
         ? await DataStore.query(Dealership, idProp)
         : dealershipModelProp;
       setDealershipRecord(record);
-      const linkedCars = record ? await record.cars.toArray() : [];
+      const linkedCars = record ? await record?.cars?.toArray() : [];
       setLinkedCars(linkedCars);
     };
     queryData();

--- a/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/studio-ui-codegen-react-forms.test.ts
@@ -159,7 +159,7 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toContain('const postRecords = useDataStoreBinding({');
 
       // check lazy load linked data
-      expect(componentText).toContain('await record.Posts.toArray()');
+      expect(componentText).toContain('await record?.Posts?.toArray()');
 
       // check custom display value is set
       expect(componentText).toContain('Posts: (r) => r?.title');
@@ -228,7 +228,7 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toContain('const studentRecords = useDataStoreBinding({');
 
       // check lazy load linked data
-      expect(componentText).toContain('const linkedStudents = record ? await record.Students.toArray() : [];');
+      expect(componentText).toContain('const linkedStudents = record ? await record?.Students?.toArray() : [];');
 
       // check custom display value is set
       expect(componentText).toContain('Students: (r) => r?.name');
@@ -257,7 +257,7 @@ describe('amplify form renderer tests', () => {
       expect(componentText).toContain('const studentRecords = useDataStoreBinding({');
 
       // check lazy load linked data
-      expect(componentText).toContain('const linkedStudent = record ? await record.Student.toArray() : [];');
+      expect(componentText).toContain('const linkedStudent = record ? await record?.Student?.toArray() : [];');
 
       // check custom display value is set
       expect(componentText).toContain('Student: (r) => `${r?.name ? r?.name + " - " : ""}${r?.id}`,');

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/relationship.ts
@@ -1233,11 +1233,13 @@ export const buildGetRelationshipModels = (
                             factory.createParenthesizedExpression(
                               factory.createAwaitExpression(
                                 factory.createCallExpression(
-                                  factory.createPropertyAccessExpression(
-                                    factory.createPropertyAccessExpression(
+                                  factory.createPropertyAccessChain(
+                                    factory.createPropertyAccessChain(
                                       factory.createIdentifier('record'),
+                                      factory.createToken(SyntaxKind.QuestionDotToken),
                                       factory.createIdentifier(fieldName),
                                     ),
+                                    factory.createToken(SyntaxKind.QuestionDotToken),
                                     factory.createIdentifier('toArray'),
                                   ),
                                   undefined,
@@ -1309,8 +1311,13 @@ export const buildGetRelationshipModels = (
                     factory.createToken(SyntaxKind.QuestionToken),
                     factory.createAwaitExpression(
                       factory.createCallExpression(
-                        factory.createPropertyAccessExpression(
-                          factory.createPropertyAccessExpression(recordIdentifier, factory.createIdentifier(fieldName)),
+                        factory.createPropertyAccessChain(
+                          factory.createPropertyAccessChain(
+                            recordIdentifier,
+                            factory.createToken(SyntaxKind.QuestionDotToken),
+                            factory.createIdentifier(fieldName),
+                          ),
+                          factory.createToken(SyntaxKind.QuestionDotToken),
                           factory.createIdentifier('toArray'),
                         ),
                         undefined,


### PR DESCRIPTION
## Problem
Codegened code is throwing this error `TypeError: undefined is not an object (evaluating 'record.ScanEvents.toArray')` when the field is undefined.

## Solution
Add optional chaining so that an error won't be thrown and instead the conditional empty array will be returned

## Verification
Tests are showing the desired optional chaining.

### Automated tests

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [x] No non-essential console logs
- [x] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
