### PR TITLE
fix: clear form field errors on cancel

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
+++ b/packages/codegen-ui-react/lib/__tests__/__snapshots__/studio-ui-codegen-react-forms.test.ts.snap
@@ -163,6 +163,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -722,6 +723,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -1280,6 +1282,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -1950,6 +1953,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -2621,6 +2625,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -3296,6 +3301,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -3958,6 +3964,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -4516,6 +4523,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -5067,6 +5075,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -5587,6 +5596,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -6226,6 +6236,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -6921,6 +6932,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -7763,6 +7775,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -8335,6 +8348,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -9041,6 +9055,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -9837,6 +9852,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -10643,6 +10659,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -11434,6 +11451,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -12216,6 +12234,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -12958,6 +12977,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -13698,6 +13718,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -14438,6 +14459,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -15002,6 +15024,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -15624,6 +15647,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -16239,6 +16263,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -16856,6 +16881,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -17882,6 +17908,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -18896,6 +18923,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -19686,6 +19714,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -20647,6 +20676,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -21763,6 +21793,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -22311,6 +22342,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -22923,6 +22955,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -23546,6 +23579,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -24292,6 +24326,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -24847,6 +24882,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -25406,6 +25442,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -25961,6 +25998,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -26610,6 +26648,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -27145,6 +27184,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -27809,6 +27849,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -28619,6 +28660,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -30378,6 +30420,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -31336,6 +31379,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -32091,6 +32135,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -32662,6 +32707,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -33808,6 +33854,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -34689,6 +34736,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -35284,6 +35332,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -35893,6 +35942,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -36627,6 +36677,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -37157,6 +37208,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -38499,6 +38551,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -39007,6 +39060,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -39553,6 +39607,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -40062,6 +40117,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -40610,6 +40666,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -41114,6 +41171,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -41782,6 +41840,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -42383,6 +42442,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -42975,6 +43035,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -43492,6 +43553,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -44003,6 +44065,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -44604,6 +44667,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -45218,6 +45282,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -46008,6 +46073,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -46582,6 +46648,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -47205,6 +47272,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -47828,6 +47896,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -48505,6 +48574,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -49105,6 +49175,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -49672,6 +49743,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -50670,6 +50742,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -51586,6 +51659,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -52270,6 +52344,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -53000,6 +53075,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -54753,6 +54829,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}
@@ -55269,6 +55346,7 @@ function ArrayField({
                 setFieldValue(defaultFieldValue);
                 setIsEditing(false);
                 setSelectedBadgeIndex(undefined);
+                setErrors({ ...errors, [fieldName]: undefined });
               }}
             ></Button>
           )}

--- a/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
+++ b/packages/codegen-ui-react/lib/utils/forms/array-field-component.ts
@@ -1077,6 +1077,26 @@ export const generateArrayFieldComponent = () => {
                                               [factory.createIdentifier('undefined')],
                                             ),
                                           ),
+                                          factory.createExpressionStatement(
+                                            factory.createCallExpression(
+                                              factory.createIdentifier('setErrors'),
+                                              undefined,
+                                              [
+                                                factory.createObjectLiteralExpression(
+                                                  [
+                                                    factory.createSpreadAssignment(factory.createIdentifier('errors')),
+                                                    factory.createPropertyAssignment(
+                                                      factory.createComputedPropertyName(
+                                                        factory.createIdentifier('fieldName'),
+                                                      ),
+                                                      factory.createIdentifier('undefined'),
+                                                    ),
+                                                  ],
+                                                  false,
+                                                ),
+                                              ],
+                                            ),
+                                          ),
                                         ],
                                         true,
                                       ),


### PR DESCRIPTION
## Problem
Required field error not being cleared when cancelling input

## Solution
On cancel clear form field errors

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [ ] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
