### PR TITLE
fix: upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -100,7 +100,7 @@ jobs:
           REACT_APP_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
       - name: Upload Cypress videos
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/e2e-test-app/cypress/videos
@@ -193,7 +193,7 @@ jobs:
           REACT_APP_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
       - name: Upload Cypress videos
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/e2e-test-app-v6/cypress/videos
@@ -224,7 +224,7 @@ jobs:
           config-file: cypress.config.ts
       - name: Upload Cypress videos
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/packages/integration-test/cypress/videos
@@ -258,7 +258,7 @@ jobs:
           config-file: cypress.config.ts
       - name: Upload Cypress videos
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: /home/runner/work/amplify-codegen-ui/amplify-codegen-ui/packages/integration-test/cypress/videos


### PR DESCRIPTION
## Problem

This change upgrades `upload-artifact` action  to v4. v3 is deprecated.

## Solution

<!-- How do the changes in this pull request solve the stated problem? Be descriptive. -->

## Additional Notes

<!-- Is there anything in particular that you want to call attention to? Areas of focus, follow-up actions, etc. -->

## Links

### Ticket

<!-- *do not link to private ticketing systems* -->

GitHub issue:

### Other links

## Verification

### Manual tests

<!-- Include the data and actions taken to exercise the Subject Under Test (SUT). Include any screen captures if relevant. -->

### Automated tests

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] N/A - (provide a reason)
- [ ] deferred - (provide GitHub issue for tracking)

### Housekeeping

- [ ] No non-essential console logs
- [ ] All new files contain license notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
