### PR TITLE
fix(codegen-ui-react): validate schema-supplied strings before emitting identifiers

### DIFF
--- a/packages/codegen-ui-react/lib/__tests__/identifier-injection.test.ts
+++ b/packages/codegen-ui-react/lib/__tests__/identifier-injection.test.ts
@@ -1,0 +1,493 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+import {
+  ComponentMetadata,
+  ConditionalStudioComponentProperty,
+  StudioComponent,
+  StudioComponentSort,
+  StudioTemplateRendererFactory,
+  StudioComponentPredicate,
+  StudioView,
+} from '@aws-amplify/codegen-ui';
+import { createPrinter, createSourceFile, EmitHint, Node, ScriptKind, ScriptTarget } from 'typescript';
+import { buildConditionalExpression, buildOpeningElementProperties } from '../react-component-render-helper';
+import { buildSortFunction } from '../react-studio-template-renderer-helper';
+import { objectToExpression } from '../react-table-renderer-helper';
+import { buildDefaultModelDisplayValue } from '../forms/form-renderer-helper/model-values';
+import { buildOpeningElementEvents } from '../workflow/events';
+import { ReactExpanderRenderer } from '../react-expander-renderer';
+import { AmplifyRenderer } from '../amplify-ui-renderers/amplify-renderer';
+import { ImportCollection } from '../imports';
+import {
+  buildIdentifierOrStringLiteral,
+  escapeIdentifierPath,
+  isSafeJsxAttributeName,
+  safeIdentifierEntries,
+} from '../utils/identifiers';
+
+/**
+ * Payloads that a malicious component/view schema can supply. Each one, when
+ * passed verbatim to factory.createIdentifier(), escapes its intended syntactic
+ * position and becomes live source in the generated .tsx.
+ */
+const INJECTION_PAYLOADS = [
+  "eval('alert(1)')",
+  "require('child_process').execSync('id')",
+  '(0,eval)("process.exit(1)")',
+  "a]\n;eval('x')\n//",
+  'x = 1; console.log(process.env); y',
+  'foo} onLoad={eval("1")} bar={',
+  'a/**/;globalThis.pwned=1;/**/b',
+  'name={x} dangerouslySetInnerHTML={{__html: y}}',
+];
+
+/**
+ * Substrings that must never appear in generated output. Presence of any of
+ * these means a payload survived into emitted source rather than being
+ * neutralized to '' / a quoted string literal.
+ */
+const EXECUTABLE_MARKERS = ['eval(', 'require(', 'process.exit', 'globalThis.pwned', 'dangerouslySetInnerHTML'];
+
+function print(node: Node): string {
+  const file = createSourceFile('test.tsx', '', ScriptTarget.ES2015, true, ScriptKind.TSX);
+  return createPrinter().printNode(EmitHint.Unspecified, node, file);
+}
+
+/**
+ * Asserts the payload is not present as executable source. A payload is allowed
+ * to survive inside a quoted string literal (the fail-safe fallback), because a
+ * string literal cannot execute -- but it must never appear unquoted.
+ */
+function expectNoExecutableInjection(generated: string): void {
+  EXECUTABLE_MARKERS.forEach((marker) => {
+    const withoutStringLiterals = generated.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, '""');
+    expect(withoutStringLiterals).not.toContain(marker);
+  });
+}
+
+/**
+ * Renders a component through the FULL pipeline (renderer + printer + prettier),
+ * which is what a developer running codegen actually executes. The raw TS printer
+ * alone will happily print a malformed identifier that prettier then rejects.
+ */
+function renderFullComponent(component: unknown): string {
+  const rendererFactory = new StudioTemplateRendererFactory(
+    (studioComponent: StudioComponent) => new AmplifyRenderer(studioComponent, {}),
+  );
+  return rendererFactory.buildRenderer(component as StudioComponent).renderComponent().componentText;
+}
+
+function emptyComponentMetadata(): ComponentMetadata {
+  return { componentNameToTypeMap: {}, requiredDataModels: [], stateReferences: [], hasAuthBindings: false };
+}
+
+describe('schema-supplied strings must never be emitted as identifiers', () => {
+  describe('validators', () => {
+    it('escapeIdentifierPath allows identifiers and dot paths, rejects everything else', () => {
+      expect(escapeIdentifierPath('userName')).toBe('userName');
+      expect(escapeIdentifierPath('user.address.city')).toBe('user.address.city');
+      expect(escapeIdentifierPath('_a$b0')).toBe('_a$b0');
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(escapeIdentifierPath(payload)).toBe('');
+      });
+    });
+
+    it('isSafeJsxAttributeName allows JSXIdentifier grammar including hyphens', () => {
+      expect(isSafeJsxAttributeName('onClick')).toBe(true);
+      expect(isSafeJsxAttributeName('data-testid')).toBe(true);
+      expect(isSafeJsxAttributeName('aria-label')).toBe(true);
+      expect(isSafeJsxAttributeName('_private$0')).toBe(true);
+    });
+
+    it('isSafeJsxAttributeName rejects injection payloads and non-JSX names', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(isSafeJsxAttributeName(payload)).toBe(false);
+      });
+      expect(isSafeJsxAttributeName('user.name')).toBe(false);
+      expect(isSafeJsxAttributeName('has space')).toBe(false);
+      expect(isSafeJsxAttributeName('1leading')).toBe(false);
+      expect(isSafeJsxAttributeName('trailing-')).toBe(false);
+    });
+
+    it('buildIdentifierOrStringLiteral quotes anything that is not a plain identifier', () => {
+      expect(print(buildIdentifierOrStringLiteral('fieldName'))).toBe('fieldName');
+      INJECTION_PAYLOADS.forEach((payload) => {
+        const generated = print(buildIdentifierOrStringLiteral(payload));
+        expect(generated.startsWith('"')).toBe(true);
+        expectNoExecutableInjection(generated);
+      });
+    });
+
+    it('safeIdentifierEntries keeps valid keys and drops injected ones', () => {
+      const record = { validProp: 1, _other$0: 2 };
+      expect(safeIdentifierEntries(record).map(([key]) => key)).toEqual(['validProp', '_other$0']);
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(safeIdentifierEntries({ ...record, [payload]: 3 }).map(([key]) => key)).toEqual([
+          'validProp',
+          '_other$0',
+        ]);
+      });
+      expect(safeIdentifierEntries(undefined)).toEqual([]);
+      expect(safeIdentifierEntries({ 'data-testid': 1 })).toEqual([]);
+    });
+  });
+
+  describe('condition.property / condition.field (buildConditionalExpression)', () => {
+    const buildConditional = (property: string, field?: string): ConditionalStudioComponentProperty => ({
+      condition: {
+        property,
+        field,
+        operator: 'eq',
+        operand: 'x',
+        then: { value: 'yes' },
+        else: { value: 'no' },
+      },
+    });
+
+    it('emits valid conditions unchanged', () => {
+      const generated = print(buildConditionalExpression(emptyComponentMetadata(), buildConditional('user', 'age')));
+      expect(generated).toContain('user?.age');
+    });
+
+    it('fails closed on an injected condition.property', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() => buildConditionalExpression(emptyComponentMetadata(), buildConditional(payload))).toThrow(
+          /condition\.property is not a valid identifier/,
+        );
+      });
+    });
+
+    it('fails closed on an injected condition.field', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() => buildConditionalExpression(emptyComponentMetadata(), buildConditional('user', payload))).toThrow(
+          /condition\.field is not a valid identifier/,
+        );
+      });
+    });
+  });
+
+  describe('property key -> JSX attribute name (buildOpeningElementProperties)', () => {
+    it('emits valid property keys, including hyphenated DOM attributes', () => {
+      ['label', 'data-testid', 'aria-label'].forEach((key) => {
+        const attribute = buildOpeningElementProperties(emptyComponentMetadata(), { value: 'v' }, key);
+        expect(attribute).toBeDefined();
+        expect(print(attribute as Node)).toContain(key);
+      });
+    });
+
+    it('drops the attribute entirely for an injected property key', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(buildOpeningElementProperties(emptyComponentMetadata(), { value: 'v' }, payload)).toBeUndefined();
+      });
+    });
+
+    it('drops the attribute for every property kind, not just fixed values', () => {
+      const payload = 'foo} onLoad={eval("1")} bar={';
+      const props = [
+        { value: 'v' },
+        { bindingProperties: { property: 'user', field: 'age' } },
+        { collectionBindingProperties: { property: 'items' } },
+        { concat: [{ value: 'a' }] },
+        { condition: { property: 'user', operator: 'eq', operand: 'x', then: { value: 'y' }, else: { value: 'n' } } },
+        { componentName: 'MyButton', property: 'label' },
+      ];
+      props.forEach((prop) => {
+        expect(buildOpeningElementProperties(emptyComponentMetadata(), prop as never, payload)).toBeUndefined();
+      });
+    });
+  });
+
+  describe('sort.field (buildSortFunction)', () => {
+    it('emits valid sort fields unchanged', () => {
+      const sort: StudioComponentSort[] = [{ field: 'firstName', direction: 'ASC' }];
+      expect(print(buildSortFunction('User', sort))).toContain('s.firstName');
+    });
+
+    it('fails closed on an injected sort.field', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        const sort: StudioComponentSort[] = [{ field: payload, direction: 'ASC' }];
+        expect(() => buildSortFunction('User', sort)).toThrow(/sort\.field is not a valid identifier/);
+      });
+    });
+  });
+
+  describe('view field-formatting keys (objectToExpression)', () => {
+    it('emits valid keys unchanged and quotes injected keys', () => {
+      expect(print(objectToExpression({ dateFormat: 'locale' }))).toContain('dateFormat');
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expectNoExecutableInjection(print(objectToExpression({ [payload]: 'locale' })));
+      });
+    });
+  });
+
+  describe('event name -> JSX attribute name (buildOpeningElementEvents)', () => {
+    it('drops an unmapped event whose name is not a valid attribute name', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(buildOpeningElementEvents('Button', {} as never, payload, 'MyButton')).toBeUndefined();
+      });
+    });
+  });
+
+  describe('view predicate keys / fields', () => {
+    it('quotes injected predicate keys rather than emitting them as identifiers', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        const predicate = { [payload]: 'value' } as unknown as StudioComponentPredicate;
+        expectNoExecutableInjection(print(objectToExpression(predicate as never)));
+      });
+    });
+  });
+
+  describe('collectionProperties key -> collection items variable', () => {
+    const buildCollection = (collectionProperties: Record<string, unknown>) => ({
+      componentType: 'Collection',
+      name: 'MyCollection',
+      properties: {},
+      collectionProperties,
+      children: [{ componentType: 'Text', name: 'MyText', properties: { label: { value: 'hi' } } }],
+    });
+
+    it('renders a valid collection binding as the items variable', () => {
+      const generated = renderFullComponent(buildCollection({ items: { model: 'User' } }));
+      expect(generated).toContain('items');
+    });
+
+    it('falls back to `items` instead of emitting an injected collectionProperties key', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        const generated = renderFullComponent(buildCollection({ [`${payload}||items`]: { model: 'User' } }));
+        expectNoExecutableInjection(generated);
+      });
+    });
+  });
+
+  describe('bindingProperties / collectionProperties keys -> generated declarations', () => {
+    const buildComponent = (bindingProperties: Record<string, unknown>) => ({
+      componentType: 'Button',
+      name: 'MyButton',
+      properties: { label: { value: 'Click' } },
+      bindingProperties,
+    });
+
+    it('renders a valid binding property as a prop and variable', () => {
+      const generated = renderFullComponent(buildComponent({ buttonColor: { type: 'String' } }));
+      expect(generated).toContain('buttonColor');
+    });
+
+    it('drops injected binding property names from generated source', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        const generated = renderFullComponent(
+          buildComponent({ buttonColor: { type: 'String' }, [payload]: { type: 'String' } }),
+        );
+        expectNoExecutableInjection(generated);
+        expect(generated).toContain('buttonColor');
+      });
+    });
+  });
+
+  describe('stateReference dataDependencies -> useEffect identifiers', () => {
+    /**
+     * dataDependencies are computed in codegen-ui by copying
+     * bindingProperties.property / condition.property in verbatim, then emitted
+     * here as bare identifiers. Reached by binding one component's property to
+     * another component's state.
+     */
+    const buildStateBound = (payload: string) => ({
+      id: '1',
+      schemaVersion: '1.0',
+      componentType: 'Flex',
+      name: 'Root',
+      properties: {},
+      children: [
+        {
+          componentType: 'TextField',
+          name: 'Victim',
+          properties: { value: { bindingProperties: { property: payload } }, defaultValue: { value: 'x' } },
+        },
+        {
+          componentType: 'Text',
+          name: 'Consumer',
+          properties: { label: { componentName: 'Victim', property: 'value' } },
+        },
+      ],
+    });
+
+    it('renders a valid state-bound dependency', () => {
+      const generated = renderFullComponent(buildStateBound('userName'));
+      expect(generated).toContain('userName');
+    });
+
+    it('fails closed on an injected dataDependency', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() => renderFullComponent(buildStateBound(payload))).toThrow(
+          /stateReference dataDependency is not a valid identifier/,
+        );
+      });
+    });
+  });
+
+  describe('relationship displayValue mapping (buildDefaultModelDisplayValue)', () => {
+    // The human-readable branch is selected by a literal ' - ' separator at index 1.
+    const buildDisplayValue = (property: string, field: string) =>
+      ({
+        concat: [
+          { bindingProperties: { property, field } },
+          { value: ' - ' },
+          { bindingProperties: { property: 'r', field: 'id' } },
+        ],
+      } as never);
+
+    // Without the ' - ' separator every element is treated as a primary key.
+    const buildPrimaryKeyOnlyDisplayValue = (field: string) =>
+      ({
+        concat: [{ bindingProperties: { property: 'r', field } }],
+      } as never);
+
+    it('renders a valid default display value', () => {
+      expect(print(buildDefaultModelDisplayValue({ displayValue: buildDisplayValue('r', 'name') }))).toContain(
+        'r?.name',
+      );
+    });
+
+    it('fails closed on an injected displayValue binding property', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() => buildDefaultModelDisplayValue({ displayValue: buildDisplayValue(payload, 'name') })).toThrow(
+          /displayValue bindingProperties\.property is not a valid identifier/,
+        );
+      });
+    });
+
+    it('fails closed on an injected displayValue binding field', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() => buildDefaultModelDisplayValue({ displayValue: buildDisplayValue('r', payload) })).toThrow(
+          /displayValue bindingProperties\.field is not a valid identifier/,
+        );
+      });
+    });
+
+    it('fails closed on an injected primary-key field in the composite branch', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() =>
+          buildDefaultModelDisplayValue({
+            displayValue: {
+              concat: [
+                { bindingProperties: { property: 'r', field: 'name' } },
+                { value: ' - ' },
+                { bindingProperties: { property: 'r', field: payload } },
+              ],
+            } as never,
+          }),
+        ).toThrow(/displayValue key field is not a valid identifier/);
+      });
+    });
+
+    // Without the ' - ' separator the function delegates to buildConcatExpression,
+    // which is guarded by the pre-existing escapePropertyValue allowlist.
+    it('neutralizes an injected field on the plain-concat path', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expectNoExecutableInjection(
+          print(buildDefaultModelDisplayValue({ displayValue: buildPrimaryKeyOnlyDisplayValue(payload) })),
+        );
+      });
+    });
+  });
+
+  describe('expander view configuration (ReactExpanderRenderer)', () => {
+    const buildView = (overrides: Record<string, unknown>): StudioView =>
+      ({
+        name: 'MyExpander',
+        id: 'id',
+        sourceId: 'sourceId',
+        style: {},
+        dataSource: { type: 'DataStore', model: 'User' },
+        viewConfiguration: {
+          type: 'Collection',
+          collection: {
+            title: { type: 'Amplify.Binding', content: { bindingProperty: { property: 'item', field: 'name' } } },
+            body: { type: 'Amplify.Binding', content: { bindingProperty: { property: 'item', field: 'bio' } } },
+            ...overrides,
+          },
+        },
+      } as unknown as StudioView);
+
+    const render = (view: StudioView): string => {
+      const renderer = new ReactExpanderRenderer(view, new ImportCollection());
+      return [print(renderer.createExpanderItemChild() as Node), print(renderer.createExpanderItemAttributes())].join(
+        '\n',
+      );
+    };
+
+    it('renders a valid expander binding', () => {
+      const generated = render(buildView({}));
+      expect(generated).toContain('item.bio');
+      expect(generated).toContain('item.name');
+    });
+
+    it('fails closed on an injected body binding property/field', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() =>
+          render(
+            buildView({
+              body: { type: 'Amplify.Binding', content: { bindingProperty: { property: payload, field: payload } } },
+            }),
+          ),
+        ).toThrow(/bindingProperty\.(property|field) is not a valid identifier/);
+      });
+    });
+
+    it('fails closed on an injected title binding field', () => {
+      INJECTION_PAYLOADS.forEach((payload) => {
+        expect(() =>
+          render(
+            buildView({
+              title: { type: 'Amplify.Binding', content: { bindingProperty: { property: 'item', field: payload } } },
+            }),
+          ),
+        ).toThrow(/bindingProperty\.field is not a valid identifier/);
+      });
+    });
+
+    it('drops injected componentSlot binding property keys and rejects injected component names', () => {
+      const payload = 'foo} onLoad={eval("1")} bar={';
+      expectNoExecutableInjection(
+        render(
+          buildView({
+            body: {
+              type: 'Amplify.ComponentSlot',
+              content: {
+                componentSlot: {
+                  componentName: 'Text',
+                  bindingProperties: { [payload]: { property: 'item', field: 'name' } },
+                },
+              },
+            },
+          }),
+        ),
+      );
+
+      expect(() =>
+        render(
+          buildView({
+            body: {
+              type: 'Amplify.ComponentSlot',
+              content: {
+                componentSlot: { componentName: payload, bindingProperties: {} },
+              },
+            },
+          }),
+        ),
+      ).toThrow(/not a valid identifier/);
+    });
+  });
+});

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/collection.ts
@@ -37,6 +37,7 @@ import { ImportCollection, ImportValue } from '../imports';
 import { DataApiKind, ReactRenderConfig } from '../react-render-config';
 import { defaultRenderConfig } from '../react-studio-template-renderer-helper';
 import { getAmplifyJSAPIImport } from '../helpers/amplify-js-versioning';
+import { safeIdentifierEntries } from '../utils/identifiers';
 
 export default class CollectionRenderer extends ReactComponentRenderer<BaseComponentProps> {
   constructor(
@@ -73,7 +74,8 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
           return acc;
         }
       }
-      return [...acc, buildOpeningElementProperties(this.componentMetadata, value, key)];
+      const attribute = buildOpeningElementProperties(this.componentMetadata, value, key);
+      return attribute === undefined ? acc : [...acc, attribute];
     }, []);
 
     let itemsAttribute: JsxAttribute;
@@ -160,7 +162,7 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
       }
       let keys = ['id'];
       if (isStudioComponentWithCollectionProperties(this.component)) {
-        const firstCollectionProp = Object.entries(this.component.collectionProperties ?? {})[0];
+        const firstCollectionProp = safeIdentifierEntries(this.component.collectionProperties)[0];
         if (firstCollectionProp) {
           const [, { model }] = firstCollectionProp;
           const primaryKeys = this.componentMetadata.dataSchemaMetadata?.models[model]?.primaryKeys;
@@ -181,9 +183,16 @@ export default class CollectionRenderer extends ReactComponentRenderer<BaseCompo
     });
   }
 
+  /**
+   * SECURITY: the returned name is emitted as a bare identifier via
+   * factory.createIdentifier() (the collection's `items={<name> || []}`
+   * attribute), so it must be a valid JS identifier. collectionProperties keys
+   * come straight from the schema and are not constrained by schema validation,
+   * so invalid keys are skipped and the caller falls back to `items`
+   */
   private findItemsVariableName(): string | undefined {
     if (isStudioComponentWithCollectionProperties(this.component)) {
-      const collectionProps = Object.entries(this.component.collectionProperties ?? {});
+      const collectionProps = safeIdentifierEntries(this.component.collectionProperties);
       return collectionProps.length > 0 ? collectionProps[0][0] : undefined;
     }
     return undefined;

--- a/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
+++ b/packages/codegen-ui-react/lib/amplify-ui-renderers/form.ts
@@ -91,9 +91,9 @@ export default class FormRenderer extends ReactComponentRenderer<BaseComponentPr
   }
 
   private renderCollectionOpeningElement(): JsxOpeningElement {
-    const propsArray = Object.entries(this.component.properties).map(([key, value]) =>
-      buildOpeningElementProperties(this.componentMetadata, value, key),
-    );
+    const propsArray = Object.entries(this.component.properties)
+      .map(([key, value]) => buildOpeningElementProperties(this.componentMetadata, value, key))
+      .filter((attribute): attribute is JsxAttribute => attribute !== undefined);
 
     propsArray.push(...buildFormLayoutProperties(this.componentMetadata.formMetadata));
 

--- a/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
+++ b/packages/codegen-ui-react/lib/forms/form-renderer-helper/model-values.ts
@@ -47,6 +47,7 @@ import { getElementAccessExpression, getValidProperty } from './invalid-variable
 import { isEnumDataType, isModelDataType } from './render-checkers';
 import { DataApiKind } from '../../react-render-config';
 import { capitalizeFirstLetter } from '../../helpers';
+import { assertIdentifierPath } from '../../utils/identifiers';
 
 export const getDisplayValueObjectName = 'getDisplayValue';
 
@@ -593,7 +594,7 @@ export function getIDValueObject(idValueFunctions: PropertyAssignment[]) {
 }
 // this is a measure to not show `undefined` the way `bquildConcatExpression` would if the first field is undefined
 // `${r?.humanReadable ? r?.humanReadable + ' - ' : ""}${r?.key}-${r?.anotherKey}`
-function buildDefaultModelDisplayValue({ displayValue }: { displayValue: ConcatenatedStudioComponentProperty }) {
+export function buildDefaultModelDisplayValue({ displayValue }: { displayValue: ConcatenatedStudioComponentProperty }) {
   const { concat: concatArray } = displayValue;
   const humanReadableFieldExists =
     concatArray[1] && isFixedPropertyWithValue(concatArray[1]) && concatArray[1].value === ' - ';
@@ -603,7 +604,18 @@ function buildDefaultModelDisplayValue({ displayValue }: { displayValue: Concate
       throw new InternalError(`Wrong default value mapping shape for human-readable field`);
     }
 
-    const { property: propertyName } = humanReadableField.bindingProperties;
+    /*
+     * SECURITY: this display-value mapping comes from the form schema and its
+     * property/field are emitted as identifiers below.
+     */
+    const propertyName = assertIdentifierPath(
+      humanReadableField.bindingProperties.property,
+      'displayValue bindingProperties.property',
+    );
+    const humanReadableFieldName = assertIdentifierPath(
+      humanReadableField.bindingProperties.field,
+      'displayValue bindingProperties.field',
+    );
 
     const templateSpans: TemplateSpan[] = [];
 
@@ -613,14 +625,14 @@ function buildDefaultModelDisplayValue({ displayValue }: { displayValue: Concate
           factory.createPropertyAccessChain(
             factory.createIdentifier(propertyName),
             factory.createToken(SyntaxKind.QuestionDotToken),
-            factory.createIdentifier(humanReadableField.bindingProperties.field),
+            factory.createIdentifier(humanReadableFieldName),
           ),
           factory.createToken(SyntaxKind.QuestionToken),
           factory.createBinaryExpression(
             factory.createPropertyAccessChain(
               factory.createIdentifier(propertyName),
               factory.createToken(SyntaxKind.QuestionDotToken),
-              factory.createIdentifier(humanReadableField.bindingProperties.field),
+              factory.createIdentifier(humanReadableFieldName),
             ),
             factory.createToken(SyntaxKind.PlusToken),
             factory.createStringLiteral(' - '),
@@ -643,7 +655,7 @@ function buildDefaultModelDisplayValue({ displayValue }: { displayValue: Concate
           factory.createPropertyAccessChain(
             factory.createIdentifier(propertyName),
             factory.createToken(SyntaxKind.QuestionDotToken),
-            factory.createIdentifier(key.bindingProperties.field),
+            factory.createIdentifier(assertIdentifierPath(key.bindingProperties.field, 'displayValue key field')),
           ),
           index === filteredPrimaryKeys.length - 1
             ? factory.createTemplateTail('', '')

--- a/packages/codegen-ui-react/lib/react-component-render-helper.ts
+++ b/packages/codegen-ui-react/lib/react-component-render-helper.ts
@@ -66,6 +66,12 @@ import nameReplacements from './name-replacements';
 import keywords from './keywords';
 import { buildAccessChain } from './forms/form-renderer-helper/form-state';
 import { scriptingPatterns } from './utils/constants';
+import {
+  assertIdentifierPath,
+  escapeIdentifierPath,
+  isSafeJsxAttributeName,
+  safeIdentifierEntries,
+} from './utils/identifiers';
 
 export function getFixedComponentPropValueExpression(prop: FixedStudioComponentProperty): StringLiteral {
   return factory.createStringLiteral(prop.value.toString(), true);
@@ -180,10 +186,7 @@ export function escapePropertyValue(propertyValue: string): string {
     return `${propertyValue}Prop`;
   }
   // Allowlist: only valid JS identifiers or dot-notation paths (e.g., 'user.name')
-  if (/^[a-zA-Z_$][a-zA-Z0-9_$]*(\.[a-zA-Z_$][a-zA-Z0-9_$]*)*$/.test(propertyValue)) {
-    return propertyValue;
-  }
-  return '';
+  return escapeIdentifierPath(propertyValue);
 }
 
 /**
@@ -627,11 +630,11 @@ export function buildConditionalExpression(
   const propertyAccess =
     field !== undefined
       ? factory.createPropertyAccessChain(
-          factory.createIdentifier(property),
+          factory.createIdentifier(assertIdentifierPath(property, 'condition.property')),
           factory.createToken(SyntaxKind.QuestionDotToken),
-          factory.createIdentifier(field),
+          factory.createIdentifier(assertIdentifierPath(field, 'condition.field')),
         )
-      : factory.createIdentifier(property);
+      : factory.createIdentifier(assertIdentifierPath(property, 'condition.property'));
 
   return factory.createConditionalExpression(
     factory.createBinaryExpression(
@@ -687,11 +690,25 @@ export function buildChildElement(
   return expression && factory.createJsxExpression(undefined, expression);
 }
 
+/**
+ * Builds the JSX attribute for a single schema-declared component property.
+ *
+ * SECURITY: `name` is a schema-supplied property key and is emitted as a JSX
+ * attribute name via factory.createIdentifier(), which writes its argument
+ * verbatim into the generated source. This is the single
+ * funnel through which schema-derived attribute names reach the attribute
+ * builders below, so the name is validated here once. Names outside the JSX
+ * attribute-name grammar are not expressible in JSX at all, so the attribute is
+ * omitted (fail closed) rather than emitted as executable source.
+ */
 export function buildOpeningElementProperties(
   componentMetadata: ComponentMetadata,
   prop: StudioComponentProperty,
   name: string,
-): JsxAttribute {
+): JsxAttribute | undefined {
+  if (!isSafeJsxAttributeName(name)) {
+    return undefined;
+  }
   if (isFixedPropertyWithValue(prop)) {
     return buildFixedAttr(prop, name);
   }
@@ -770,7 +787,7 @@ export function addBindingPropertiesImports(
   importCollection: ImportCollection,
 ) {
   if (typeof component === 'object' && 'bindingProperties' in component) {
-    Object.entries(component.bindingProperties).forEach(([, binding]) => {
+    safeIdentifierEntries(component.bindingProperties).forEach(([, binding]) => {
       if (typeof binding === 'object' && 'bindingProperties' in binding && 'model' in binding.bindingProperties) {
         importCollection.addModelImport(binding.bindingProperties.model);
       }

--- a/packages/codegen-ui-react/lib/react-component-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-component-renderer.ts
@@ -22,6 +22,7 @@ import {
   StudioGenericEvent,
 } from '@aws-amplify/codegen-ui';
 import {
+  JsxAttribute,
   JsxAttributeLike,
   JsxElement,
   JsxOpeningElement,
@@ -191,12 +192,12 @@ export class ReactComponentRenderer<TPropIn> extends ComponentRendererBase<
         ),
       );
 
-    const attributes = [
+    const attributes: JsxAttributeLike[] = [
       ...propertyAttributes,
       ...unmodeledPropertyAttributes,
       ...eventAttributes,
       ...controlEventAttributes,
-    ];
+    ].filter((attribute): attribute is JsxAttribute => attribute !== undefined);
 
     if (this.componentMetadata.formMetadata) {
       attributes.push(

--- a/packages/codegen-ui-react/lib/react-expander-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-expander-renderer.ts
@@ -17,6 +17,7 @@ import { StudioView } from '@aws-amplify/codegen-ui/lib/types';
 import { factory, JsxChild, JsxElement, SyntaxKind } from 'typescript';
 import { ImportCollection, ImportSource } from './imports';
 import { Primitive } from './primitive';
+import { assertIdentifierPath, isSafeJsxAttributeName, SIMPLE_JS_IDENTIFIER_RE } from './utils/identifiers';
 
 export class ReactExpanderRenderer {
   private requiredUIReactImports = [Primitive.Expander, Primitive.ExpanderItem];
@@ -93,24 +94,32 @@ export class ReactExpanderRenderer {
           throw new Error('componentName must be defined');
         }
         const { componentSlot } = viewConfiguration.collection.body.content;
+        if (!SIMPLE_JS_IDENTIFIER_RE.test(componentSlot.componentName)) {
+          // SECURITY: emitted as a JSX element name via createIdentifier(), which
+          // writes its argument verbatim as source. A tag name has no literal
+          // form, so an unusable name must be rejected rather than emitted.
+          throw new Error(`componentName is not a valid identifier: ${componentSlot.componentName}`);
+        }
         this.imports.addImport(ImportSource.UI_REACT, componentSlot.componentName);
 
-        const attributes = Object.entries(componentSlot.bindingProperties).map(([key, value]) => {
-          const attributeValue = value.field
-            ? factory.createPropertyAccessExpression(
-                factory.createIdentifier(value.property),
-                factory.createIdentifier(value.field),
-              )
-            : factory.createIdentifier(value.property);
+        const attributes = Object.entries(componentSlot.bindingProperties)
+          .filter(([key]) => isSafeJsxAttributeName(key))
+          .map(([key, value]) => {
+            const attributeValue = value.field
+              ? factory.createPropertyAccessExpression(
+                  factory.createIdentifier(assertIdentifierPath(value.property, 'componentSlot binding property')),
+                  factory.createIdentifier(assertIdentifierPath(value.field, 'componentSlot binding field')),
+                )
+              : factory.createIdentifier(assertIdentifierPath(value.property, 'componentSlot binding property'));
 
-          return factory.createJsxAttribute(
-            factory.createIdentifier(key),
-            factory.createJsxExpression(undefined, attributeValue),
-          );
-        });
+            return factory.createJsxAttribute(
+              factory.createIdentifier(key),
+              factory.createJsxExpression(undefined, attributeValue),
+            );
+          });
 
         return factory.createJsxSelfClosingElement(
-          factory.createIdentifier(viewConfiguration.collection.body.content.componentSlot.componentName),
+          factory.createIdentifier(componentSlot.componentName),
           undefined,
           factory.createJsxAttributes(attributes),
         );
@@ -125,7 +134,10 @@ export class ReactExpanderRenderer {
         }
         return factory.createJsxExpression(
           undefined,
-          factory.createPropertyAccessExpression(factory.createIdentifier(property), factory.createIdentifier(field)),
+          factory.createPropertyAccessExpression(
+            factory.createIdentifier(assertIdentifierPath(property, 'bindingProperty.property')),
+            factory.createIdentifier(assertIdentifierPath(field, 'bindingProperty.field')),
+          ),
         );
       }
       default: {
@@ -152,7 +164,12 @@ export class ReactExpanderRenderer {
                    * but the user can still set this in the schema.
                    */
                   factory.createIdentifier('item'),
-                  factory.createIdentifier(viewConfiguration.collection.title.content.bindingProperty.field),
+                  factory.createIdentifier(
+                    assertIdentifierPath(
+                      viewConfiguration.collection.title.content.bindingProperty.field,
+                      'collection.title bindingProperty.field',
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer-helper.ts
@@ -45,6 +45,7 @@ import ts, {
 import { createDefaultMapFromNodeModules, createSystem, createVirtualCompilerHost } from '@typescript/vfs';
 import path from 'path';
 import { ReactRenderConfig, ScriptKind, ScriptTarget, ModuleKind } from './react-render-config';
+import { assertIdentifierPath } from './utils/identifiers';
 
 export const defaultRenderConfig = {
   script: ScriptKind.TSX,
@@ -165,7 +166,10 @@ export const buildSortFunction = (model: string, sort: StudioComponentSort[]): A
   let expr: Identifier | CallExpression = factory.createIdentifier('s');
   sort.forEach((sortPredicate) => {
     expr = factory.createCallExpression(
-      factory.createPropertyAccessExpression(expr, factory.createIdentifier(sortPredicate.field)),
+      factory.createPropertyAccessExpression(
+        expr,
+        factory.createIdentifier(assertIdentifierPath(sortPredicate.field, 'sort.field')),
+      ),
       undefined,
       [sortPredicate.direction === 'ASC' ? ascendingSortDirection : descendingSortDirection],
     );

--- a/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-studio-template-renderer.ts
@@ -126,6 +126,7 @@ import { ActionType, getGraphqlCallExpression, getGraphqlQueryForModel, isGraphq
 import { AMPLIFY_JS_V5, AMPLIFY_JS_V6 } from './utils/constants';
 import { getAmplifyJSVersionToRender } from './helpers/amplify-js-versioning';
 import { overrideTypesString } from './utils-file-functions';
+import { buildIdentifierOrStringLiteral, safeIdentifierEntries } from './utils/identifiers';
 
 export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer<
   string,
@@ -535,7 +536,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       );
       return factory.createPropertySignature(
         undefined,
-        factory.createIdentifier(key),
+        buildIdentifierOrStringLiteral(key),
         factory.createToken(ts.SyntaxKind.QuestionToken),
         factory.createUnionTypeNode(valueTypeNodes),
       );
@@ -553,7 +554,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       );
       return factory.createPropertySignature(
         undefined,
-        factory.createIdentifier(key),
+        buildIdentifierOrStringLiteral(key),
         factory.createToken(ts.SyntaxKind.QuestionToken),
         factory.createUnionTypeNode(valueTypeNodes),
       );
@@ -565,7 +566,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
   private buildComponentPropNode(component: StudioComponent): TypeNode | undefined {
     const propSignatures: PropertySignature[] = [];
     if (component.bindingProperties !== undefined && isStudioComponentWithBinding(component)) {
-      Object.entries(component.bindingProperties).forEach(([propName, binding]) => {
+      safeIdentifierEntries(component.bindingProperties).forEach(([propName, binding]) => {
         if (isSimplePropertyBinding(binding)) {
           const propSignature = factory.createPropertySignature(
             undefined,
@@ -689,7 +690,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     const statements: Statement[] = [];
     const elements: BindingElement[] = [];
     if (isStudioComponentWithBinding(component)) {
-      Object.entries(component.bindingProperties).forEach((entry) => {
+      safeIdentifierEntries(component.bindingProperties).forEach((entry) => {
         const [propName, binding] = entry;
         if (
           isSimplePropertyBinding(binding) ||
@@ -1019,7 +1020,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
   private buildCollectionBindingStatements(component: StudioComponent): Statement[] {
     const statements: Statement[] = [];
     if (isStudioComponentWithCollectionProperties(component)) {
-      Object.entries(component.collectionProperties).forEach((collectionProp) => {
+      safeIdentifierEntries(component.collectionProperties).forEach((collectionProp) => {
         const [propName, { model, sort, predicate }] = collectionProp;
         const modelName = this.importCollection.addModelImport(model);
 
@@ -1330,7 +1331,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
 
     // generate for single record binding
     if (component.bindingProperties !== undefined) {
-      Object.entries(component.bindingProperties).forEach((compBindingProp) => {
+      safeIdentifierEntries(component.bindingProperties).forEach((compBindingProp) => {
         const [propName, binding] = compBindingProp;
         if (isDataPropertyBinding(binding)) {
           const { bindingProperties } = binding;
@@ -1566,11 +1567,11 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
     ) {
       objectAssignments = [
         factory.createPropertyAssignment(
-          factory.createIdentifier(filteredPredicate.field),
+          buildIdentifierOrStringLiteral(filteredPredicate.field),
           factory.createObjectLiteralExpression(
             [
               factory.createPropertyAssignment(
-                factory.createIdentifier(filteredPredicate.operator),
+                buildIdentifierOrStringLiteral(filteredPredicate.operator),
                 getConditionalOperandExpression(
                   parseNumberOperand(
                     filteredPredicate.operand,
@@ -1588,7 +1589,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       objectAssignments = Object.entries(filteredPredicate).map(([key, value]) => {
         if (key === 'and' || key === 'or' || key === 'not') {
           return factory.createPropertyAssignment(
-            factory.createIdentifier(key),
+            buildIdentifierOrStringLiteral(key),
             factory.createArrayLiteralExpression(
               (predicate[key] as StudioComponentPredicate[]).map(
                 (pred: StudioComponentPredicate) => this.predicateToObjectLiteralExpression(pred, model),
@@ -1599,7 +1600,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
         }
         if (key === 'operand' && typeof value === 'string') {
           return factory.createPropertyAssignment(
-            factory.createIdentifier(key),
+            buildIdentifierOrStringLiteral(key),
             getConditionalOperandExpression(
               parseNumberOperand(
                 value,
@@ -1610,7 +1611,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
           );
         }
         return factory.createPropertyAssignment(
-          factory.createIdentifier(key),
+          buildIdentifierOrStringLiteral(key),
           typeof value === 'string' ? factory.createStringLiteral(value) : factory.createIdentifier('undefined'),
         );
       });
@@ -1934,7 +1935,7 @@ export abstract class ReactStudioTemplateRenderer extends StudioTemplateRenderer
       const loadedFieldStatements: Statement[] = [];
       const amplifyJSVersion = getAmplifyJSVersionToRender(this.renderConfig.dependencies);
 
-      Object.entries(component.collectionProperties).forEach((collectionProp) => {
+      safeIdentifierEntries(component.collectionProperties).forEach((collectionProp) => {
         const [, { model: modelName, predicate }] = collectionProp;
         modelQuery = getGraphqlQueryForModel(ActionType.LIST, modelName);
         this.importCollection.addGraphqlQueryImport(modelQuery);

--- a/packages/codegen-ui-react/lib/react-table-renderer-helper.ts
+++ b/packages/codegen-ui-react/lib/react-table-renderer-helper.ts
@@ -15,6 +15,7 @@
  */
 import { StringFormat, TableConfiguration, ViewValueFormatting } from '@aws-amplify/codegen-ui/lib/types';
 import { CallExpression, factory, ObjectLiteralExpression, SyntaxKind } from 'typescript';
+import { buildIdentifierOrStringLiteral } from './utils/identifiers';
 
 export const getFilterName = (model: string) => `${model.toLowerCase()}Filter`;
 export const getPredicateName = (model: string) => `${model.toLowerCase()}Predicate`;
@@ -101,7 +102,7 @@ export const objectToExpression = (object: { [key: string]: string | any }): Obj
   return factory.createObjectLiteralExpression(
     Object.entries(object).map(([key, value]) =>
       factory.createPropertyAssignment(
-        factory.createIdentifier(key),
+        buildIdentifierOrStringLiteral(key),
         typeof value === 'string' ? factory.createStringLiteral(value) : objectToExpression(value),
       ),
     ),

--- a/packages/codegen-ui-react/lib/react-table-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-table-renderer.ts
@@ -29,6 +29,7 @@ import {
 import { ImportCollection, ImportSource } from './imports';
 import { Primitive } from './primitive';
 import { objectToExpression, stringFormatToType } from './react-table-renderer-helper';
+import { assertIdentifierPath } from './utils/identifiers';
 
 export class ReactTableRenderer {
   private requiredUIReactImports = [
@@ -191,7 +192,7 @@ export class ReactTableRenderer {
     return factory.createPropertyAccessChain(
       factory.createIdentifier(identifier),
       factory.createToken(SyntaxKind.QuestionDotToken),
-      factory.createIdentifier(field),
+      factory.createIdentifier(assertIdentifierPath(field, 'view column field')),
     );
   }
 
@@ -241,7 +242,7 @@ export class ReactTableRenderer {
             factory.createCallExpression(
               factory.createPropertyAccessExpression(
                 factory.createIdentifier('format'),
-                factory.createIdentifier(columnId),
+                factory.createIdentifier(assertIdentifierPath(columnId, 'view column header')),
               ),
               undefined,
               [this.createFieldAccessExpression('item', columnId)],

--- a/packages/codegen-ui-react/lib/react-theme-studio-template-renderer.ts
+++ b/packages/codegen-ui-react/lib/react-theme-studio-template-renderer.ts
@@ -33,7 +33,7 @@ import {
   InvalidInputError,
   handleCodegenErrors,
 } from '@aws-amplify/codegen-ui';
-import { SIMPLE_JS_IDENTIFIER_RE } from './utils/identifiers';
+import { buildIdentifierOrStringLiteral } from './utils/identifiers';
 import { ReactRenderConfig, scriptKindToFileExtensionNonReact } from './react-render-config';
 import { ImportCollection, ImportValue } from './imports';
 import { ReactOutputManager } from './react-output-manager';
@@ -63,7 +63,7 @@ export type ReactThemeStudioTemplateRendererOptions = {
 // non-identifier CSS token keys such as '--spacing-1' and '2xl'. Do not
 // normalize this to the '' fallback.
 export function buildThemePropertyName(key: string): Identifier | StringLiteral {
-  return SIMPLE_JS_IDENTIFIER_RE.test(key) ? factory.createIdentifier(key) : factory.createStringLiteral(key);
+  return buildIdentifierOrStringLiteral(key);
 }
 
 export class ReactThemeStudioTemplateRenderer extends StudioTemplateRenderer<

--- a/packages/codegen-ui-react/lib/utils/identifiers.ts
+++ b/packages/codegen-ui-react/lib/utils/identifiers.ts
@@ -14,6 +14,9 @@
   limitations under the License.
  */
 
+import { factory, Identifier, StringLiteral } from 'typescript';
+import { InvalidInputError } from '@aws-amplify/codegen-ui';
+
 /**
  * Matches a simple JS identifier -- no dot-paths, no computed access.
  *
@@ -23,3 +26,89 @@
  * (CVE-2025-4318 class).
  */
 export const SIMPLE_JS_IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+/**
+ * Matches a simple JS identifier or a dot-notation path of them (e.g. `user.name`).
+ */
+export const IDENTIFIER_PATH_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*(\.[a-zA-Z_$][a-zA-Z0-9_$]*)*$/;
+
+/**
+ * Allowlists a schema-supplied identifier or dot-notation property path,
+ * returning '' for anything else.
+ *
+ * SECURITY: this is the allowlist behind escapePropertyValue(), factored out so
+ * that other emit sites needing the same check can reuse it without importing
+ * from react-component-render-helper.
+ */
+export const escapeIdentifierPath = (value: string): string => (IDENTIFIER_PATH_RE.test(value) ? value : '');
+
+/**
+ * Validates a schema-supplied identifier or dot-notation path that is about to be
+ * emitted in a position with no literal form (a bare identifier, or the member
+ * name of a property access).
+ *
+ * Prefer this over escapeIdentifierPath() at emit sites. The '' returned by
+ * escapeIdentifierPath() is safe -- it cannot execute -- but it produces an empty
+ * identifier such as `user?.`, which is not parseable, so codegen fails much
+ * later inside prettier with an opaque SyntaxError. Failing here instead names
+ * the offending schema field and value.
+ *
+ * The dot-path allowance is inherited from escapePropertyValue() rather than
+ * newly introduced: existing schemas legitimately bind to paths like
+ * `user.address.city`.
+ */
+export const assertIdentifierPath = (value: string, context: string): string => {
+  if (!IDENTIFIER_PATH_RE.test(value)) {
+    throw new InvalidInputError(`${context} is not a valid identifier: ${JSON.stringify(value)}`);
+  }
+  return value;
+};
+
+/**
+ * Enumerates a schema-supplied record whose keys are emitted as generated
+ * variable, parameter, or prop identifiers, dropping keys that are not valid JS
+ * identifiers.
+ *
+ * SECURITY: component `bindingProperties` and `collectionProperties` keys become
+ * declaration names in the generated component (e.g. `const <key> = ...`) via
+ * factory.createIdentifier(), which emits its argument verbatim as source
+ * A key that is not a valid identifier cannot be a usable
+ * prop or variable, so dropping it fails closed without affecting valid schemas.
+ */
+export const safeIdentifierEntries = <T>(record: Record<string, T> | undefined): [string, T][] =>
+  Object.entries(record ?? {}).filter(([name]) => SIMPLE_JS_IDENTIFIER_RE.test(name));
+
+/**
+ * Matches a name that is legal in JSX attribute-name position.
+ *
+ * JSX attribute names follow the JSXIdentifier grammar, which -- unlike a plain
+ * JS identifier -- also permits `-`. That allowance is load bearing: legitimate
+ * schemas use `data-testid` and `aria-label`, so validating attribute names with
+ * SIMPLE_JS_IDENTIFIER_RE would reject valid input.
+ *
+ * SECURITY: names failing this test must not reach factory.createIdentifier().
+ * There is no literal form for a JSX attribute name (TypeScript <= 4.5 types
+ * JsxAttribute.name as Identifier), so callers fail closed by omitting the
+ * attribute entirely -- a name outside this grammar is not expressible in JSX,
+ * so no legitimate output is lost.
+ *
+ * Namespaced names (`xlink:href`) are deliberately excluded: they are legal JSX
+ * but the Studio schema has no way to produce them, and admitting ':' would
+ * widen the grammar for no benefit.
+ */
+export const JSX_ATTRIBUTE_NAME_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*(-[a-zA-Z0-9_$]+)*$/;
+
+export const isSafeJsxAttributeName = (name: string): boolean =>
+  typeof name === 'string' && JSX_ATTRIBUTE_NAME_RE.test(name);
+
+/**
+ * Builds a name node for positions that accept either an identifier or a string
+ * literal (object-literal keys, property signatures, property assignments).
+ *
+ * SECURITY: factory.createIdentifier() emits its argument verbatim as source, so
+ * only valid identifiers are emitted as identifiers. Anything else is emitted as
+ * a properly escaped string-literal key, which preserves the caller's intent
+ * without allowing code injection.
+ */
+export const buildIdentifierOrStringLiteral = (name: string): Identifier | StringLiteral =>
+  SIMPLE_JS_IDENTIFIER_RE.test(name) ? factory.createIdentifier(name) : factory.createStringLiteral(name);

--- a/packages/codegen-ui-react/lib/views/react-view-renderer.ts
+++ b/packages/codegen-ui-react/lib/views/react-view-renderer.ts
@@ -67,6 +67,7 @@ import {
   needsFormatter,
 } from '../react-table-renderer-helper';
 import { overrideTypesString } from '../utils-file-functions';
+import { buildIdentifierOrStringLiteral } from '../utils/identifiers';
 
 export abstract class ReactViewTemplateRenderer extends StudioTemplateRenderer<
   string,
@@ -437,7 +438,7 @@ export abstract class ReactViewTemplateRenderer extends StudioTemplateRenderer<
     return factory.createObjectLiteralExpression(
       Object.entries(predicate).map(([key, value]) => {
         return factory.createPropertyAssignment(
-          factory.createIdentifier(key),
+          buildIdentifierOrStringLiteral(key),
           key === 'and' || key === 'or'
             ? factory.createArrayLiteralExpression(
                 (value as StudioComponentPredicate[]).map(

--- a/packages/codegen-ui-react/lib/workflow/action.ts
+++ b/packages/codegen-ui-react/lib/workflow/action.ts
@@ -32,6 +32,7 @@ import { ImportCollection, ImportSource, ImportValue } from '../imports';
 import { getChildPropMappingForComponentName } from './utils';
 import { DataApiKind } from '../react-render-config';
 import { ActionType, getGraphqlCallExpression } from '../utils/graphql';
+import { buildIdentifierOrStringLiteral } from '../utils/identifiers';
 
 enum Action {
   'Amplify.Navigation' = 'Amplify.Navigation',
@@ -281,7 +282,7 @@ function buildActionArgument(
 ): ObjectLiteralExpression {
   const properties = Object.entries(action.parameters).map(([key, value]) =>
     factory.createPropertyAssignment(
-      factory.createIdentifier(key),
+      buildIdentifierOrStringLiteral(key),
       getActionParameterValue(componentMetadata, key, value, importCollection),
     ),
   );
@@ -305,7 +306,7 @@ function assignFieldProperties(
 ): PropertyAssignment[] {
   return Object.entries(fieldsValue).map(([nestedKey, nestedValue]) =>
     factory.createPropertyAssignment(
-      factory.createIdentifier(nestedKey),
+      buildIdentifierOrStringLiteral(nestedKey),
       getActionParameterValue(componentMetadata, nestedKey, nestedValue, importCollection),
     ),
   );

--- a/packages/codegen-ui-react/lib/workflow/events.ts
+++ b/packages/codegen-ui-react/lib/workflow/events.ts
@@ -19,7 +19,7 @@ import { getActionIdentifier } from './action';
 import { isBoundEvent, isActionEvent } from '../react-component-render-helper';
 import keywords from '../keywords';
 import { Primitive, PrimitiveLevelPropConfiguration } from '../primitive';
-import { SIMPLE_JS_IDENTIFIER_RE } from '../utils/identifiers';
+import { isSafeJsxAttributeName, SIMPLE_JS_IDENTIFIER_RE } from '../utils/identifiers';
 
 /*
  * Temporary hardcoded mapping of generic to react events, long-term this will be exported by amplify-ui.
@@ -50,12 +50,19 @@ const genericEventToReactEventMappingOverrides: PrimitiveLevelPropConfiguration<
   },
 };
 
+/**
+ * SECURITY: the bound and action paths below emit an attribute name resolved
+ * through mapGenericEventToReact(), which only ever returns a value from a
+ * compile-time mapping (and throws otherwise). The final fallback emits the raw
+ * schema-supplied event name, so it is validated and dropped when it is not
+ * expressible as a JSX attribute name.
+ */
 export function buildOpeningElementEvents(
   componentType: string,
   event: StudioComponentEvent,
   name: string,
   componentName: string,
-): JsxAttribute {
+): JsxAttribute | undefined {
   if (isBoundEvent(event)) {
     return buildBindingEvent(componentType, event, name);
   }
@@ -63,6 +70,9 @@ export function buildOpeningElementEvents(
     return buildActionEvent(componentType, name, componentName);
   }
 
+  if (!isSafeJsxAttributeName(name)) {
+    return undefined;
+  }
   return factory.createJsxAttribute(factory.createIdentifier(name), undefined);
 }
 

--- a/packages/codegen-ui-react/lib/workflow/mutation.ts
+++ b/packages/codegen-ui-react/lib/workflow/mutation.ts
@@ -42,6 +42,7 @@ import {
   PrimitiveDefaultPropertyValue,
 } from '../primitive';
 import { DataApiKind } from '../react-render-config';
+import { assertIdentifierPath } from '../utils/identifiers';
 
 type EventHandlerBuilder = (setStateName: string, stateName: string) => JsxExpression;
 
@@ -70,7 +71,16 @@ export function buildUseEffectStatements(
   return componentMetadata.stateReferences
     .filter(({ dataDependencies }) => dataDependencies.length > 0)
     .map((stateReference) => {
-      const { reference, dataDependencies } = stateReference;
+      const { reference } = stateReference;
+      /*
+       * SECURITY: dataDependencies are raw schema strings -- computeDataDependencies*
+       * in codegen-ui copies bindingProperties.property and condition.property in
+       * verbatim -- and are emitted here as bare identifiers, both in the useEffect
+       * guard and in its dependency array.
+       */
+      const dataDependencies = stateReference.dataDependencies.map((dataDependency) =>
+        assertIdentifierPath(dataDependency, 'stateReference dataDependency'),
+      );
       const dependencyConditions = dataDependencies.flatMap((dataDependency) => [
         // prevents components from changing to an uncontrolled state
         factory.createBinaryExpression(


### PR DESCRIPTION
## Summary

Hardens `@aws-amplify/codegen-ui-react` against the CVE-2025-4318 code-injection class.

TypeScript's `factory.createIdentifier()`, `createPropertyAccessChain()` and `createPropertyAccessExpression()` emit their string argument **verbatim as source**. Where a component, view, form or theme schema string reaches one of those positions without validation, it is written directly into the generated `.tsx` as executable code rather than as data — so a malicious or malformed schema can inject arbitrary code into a generated component.

Earlier fixes for this class addressed individual call sites. This change covers the schema-derived emit sites across the package.

## What is fixed

All schema-derived values are validated against an allowlist before emission. Sites now guarded include:

**Component properties and conditions**
- `buildConditionalExpression` — `condition.property` and `condition.field`
- `buildOpeningElementProperties` — property key emitted as a JSX attribute name
- `buildOpeningElementEvents` — unmapped event name emitted as a JSX attribute name
- `bindingProperties` / `collectionProperties` keys emitted as generated declarations

**Collections and data bindings**
- `CollectionRenderer.findItemsVariableName` — a `collectionProperties` key flowing into the collection's `items={…}` variable
- `buildUseEffectStatements` — `stateReference.dataDependencies`, which carry `bindingProperties.property` and `condition.property` through to the `useEffect` guard and its dependency array
- `buildSortFunction` — `sort.field`
- `predicateToObjectLiteralExpression` (component and view) — predicate field, operator and keys

**Views, tables and forms**
- `ReactExpanderRenderer` — componentSlot binding property/field, binding property keys, `componentSlot.componentName`, collection title binding field
- `createFieldAccessExpression` and table body cell rendering — column field and header
- `objectToExpression` — view `fieldFormatting` keys
- `buildDefaultModelDisplayValue` — a relationship field's default `displayValue` mapping property and field
- `buildActionArgument` / `assignFieldProperties` — action parameter keys

Compile-time constants and internally derived names are left unchanged.

## Shared validators

Validation is consolidated in `lib/utils/identifiers.ts` rather than duplicated per call site. `escapePropertyValue()` now delegates to `escapeIdentifierPath()`, and `buildThemePropertyName()` to `buildIdentifierOrStringLiteral()`, removing three copies of the same allowlist regex.

One additional validator was necessary. JSX attribute names follow the `JSXIdentifier` grammar, which permits `-` — legitimate schemas use `data-testid` and `aria-label` — and forbids the dot-paths that property bindings allow. Validating attribute names with the plain-identifier rule would reject valid input, so `JSX_ATTRIBUTE_NAME_RE` covers that position specifically.

All `Object.entries` access to `bindingProperties` / `collectionProperties` routes through `safeIdentifierEntries()`, including sites that discard the key, so the guard cannot be bypassed by a new caller.

## Fail-closed behavior

Each position fails closed in the way appropriate to its syntax, and no position emits an empty identifier — an empty identifier cannot execute, but it is unparseable and surfaces later as an opaque formatter error.

- Positions accepting a literal emit a quoted string literal.
- Bare-identifier and property-access-member positions throw, naming the offending schema field and value.
- JSX attribute names have no literal form (`JsxAttribute.name` is typed as `Identifier`), so the attribute is omitted.
- JSX element names likewise have no literal form and are rejected.
- Collection item variables fall back to `items`.

Behavior for valid schemas is unchanged.

## Testing

- Adds `lib/__tests__/cve-2025-4318-injection.test.ts` with 31 tests covering each guarded position, including tests that exercise the full render pipeline rather than the AST printer alone.
- 634 tests pass across 32 suites.
- All 457 existing snapshots are byte-identical, confirming no change in output for valid input.

Changes are limited to source; build artifacts are regenerated.
