### PR TITLE
chore(release): v2.20.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.20.7](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.6...v2.20.7) (2026-08-04)
+
+### Bug Fixes
+
+- **codegen-ui-react:** validate schema-supplied strings before emitting identifiers ([#1204](https://github.com/aws-amplify/amplify-codegen-ui/issues/1204)) ([0f774ee](https://github.com/aws-amplify/amplify-codegen-ui/commit/0f774eea43ec85faa9b7fe5e87788a1f0f5c650e))
+
 ## [2.20.6](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.5...v2.20.6) (2026-07-14)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "exact": true,
-  "version": "2.20.6",
+  "version": "2.20.7",
   "command": {
     "version": {
       "message": "chore(release): %s"

--- a/packages/codegen-ui-react/CHANGELOG.md
+++ b/packages/codegen-ui-react/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.20.7](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.6...v2.20.7) (2026-08-04)
+
+### Bug Fixes
+
+- **codegen-ui-react:** validate schema-supplied strings before emitting identifiers ([#1204](https://github.com/aws-amplify/amplify-codegen-ui/issues/1204)) ([0f774ee](https://github.com/aws-amplify/amplify-codegen-ui/commit/0f774eea43ec85faa9b7fe5e87788a1f0f5c650e))
+
 ## [2.20.6](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.5...v2.20.6) (2026-07-14)
 
 ### Bug Fixes

--- a/packages/codegen-ui-react/package-lock.json
+++ b/packages/codegen-ui-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws-amplify/codegen-ui-react",
-      "version": "2.20.6",
+      "version": "2.20.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/vfs": "~1.3.5",

--- a/packages/codegen-ui-react/package.json
+++ b/packages/codegen-ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-react",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "description": "Amplify UI React code generation implementation",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -34,7 +34,7 @@
     "react-test-renderer": "^17.0.2"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.20.6",
+    "@aws-amplify/codegen-ui": "2.20.7",
     "@typescript/vfs": "~1.3.5",
     "pluralize": "^8.0.0",
     "semver": "^7.5.4",

--- a/packages/codegen-ui/CHANGELOG.md
+++ b/packages/codegen-ui/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.20.7](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.6...v2.20.7) (2026-08-04)
+
+**Note:** Version bump only for package @aws-amplify/codegen-ui
+
 ## [2.20.6](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.5...v2.20.6) (2026-07-14)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui

--- a/packages/codegen-ui/package-lock.json
+++ b/packages/codegen-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws-amplify/codegen-ui",
-      "version": "2.20.6",
+      "version": "2.20.7",
       "license": "Apache-2.0",
       "dependencies": {
         "change-case": "^4.1.2",

--- a/packages/codegen-ui/package.json
+++ b/packages/codegen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "description": "generic component code generation interface definitions",
   "author": "Amazon Web Services",
   "homepage": "https://docs.amplify.aws/",

--- a/packages/test-generator/CHANGELOG.md
+++ b/packages/test-generator/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.20.7](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.6...v2.20.7) (2026-08-04)
+
+**Note:** Version bump only for package @aws-amplify/codegen-ui-test-generator
+
 ## [2.20.6](https://github.com/aws-amplify/amplify-codegen-ui/compare/v2.20.5...v2.20.6) (2026-07-14)
 
 **Note:** Version bump only for package @aws-amplify/codegen-ui-test-generator

--- a/packages/test-generator/package-lock.json
+++ b/packages/test-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws-amplify/codegen-ui-test-generator",
-      "version": "2.20.6",
+      "version": "2.20.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^15.12.1",

--- a/packages/test-generator/package.json
+++ b/packages/test-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/codegen-ui-test-generator",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "description": "Test generator with sample JSON files",
   "author": "Amazon Web Services",
   "repository": "https://github.com/aws-amplify/amplify-codegen-ui.git",
@@ -19,8 +19,8 @@
     "dist/**"
   ],
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.20.6",
-    "@aws-amplify/codegen-ui-react": "2.20.6",
+    "@aws-amplify/codegen-ui": "2.20.7",
+    "@aws-amplify/codegen-ui-react": "2.20.7",
     "@types/node": "^15.12.1",
     "loglevel": "^1.7.1",
     "typescript": "^4.2.4"


### PR DESCRIPTION
## Release v2.20.7

Publishes the fix from #1204 (validate schema-supplied strings before emitting identifiers).

### Packages
- @aws-amplify/codegen-ui: 2.20.6 → 2.20.7
- @aws-amplify/codegen-ui-react: 2.20.6 → 2.20.7

### Notes
- **Squash-merge with the exact message `chore(release): v2.20.7`** — the Release workflow and CircleCI publish job key off this pattern (`.circleci/publish.sh` matches `^chore\(release\): v.*` to run `lerna publish from-git`).
